### PR TITLE
Large change to fix our offsets representation.

### DIFF
--- a/python-api/src/tiledbvcf/binding/reader.cc
+++ b/python-api/src/tiledbvcf/binding/reader.cc
@@ -179,19 +179,21 @@ void Reader::prepare_result_buffers() {
     py::buffer_info data_info = buff.data.request(true);
     py::buffer_info bitmap_info = buff.bitmap.request(true);
 
-    int64_t offset_size = 0, data_size = 0;
+    int64_t num_offsets = 0, num_data_elements = 0, num_data_bytes = 0;
     check_error(
         reader,
         tiledb_vcf_reader_get_result_size(
-            reader, attr.c_str(), &offset_size, &data_size));
+            reader,
+            attr.c_str(),
+            &num_offsets,
+            &num_data_elements,
+            &num_data_bytes));
 
-    int64_t num_offsets = offset_size / sizeof(int32_t);
     if (buff.offsets.size() > 0) {
       buff.offsets.resize({num_offsets});
     }
 
-    int64_t num_data_elts = data_size / buff.data.itemsize();
-    buff.data.resize({num_data_elts});
+    buff.data.resize({num_data_elements});
 
     if (bitmap_info.shape[0] > 0) {
       buff.bitmap.resize({num_offsets - 1});

--- a/src/c_api/tiledbvcf.cc
+++ b/src/c_api/tiledbvcf.cc
@@ -365,19 +365,17 @@ int32_t tiledb_vcf_reader_get_result_num_records(
 int32_t tiledb_vcf_reader_get_result_size(
     tiledb_vcf_reader_t* reader,
     const char* attribute,
-    int64_t* offset_buff_size,
-    int64_t* buff_size) {
+    int64_t* num_offsets,
+    int64_t* num_data_elements,
+    int64_t* num_data_bytes) {
   if (sanity_check(reader) == TILEDB_VCF_ERR)
     return TILEDB_VCF_ERR;
 
-  int64_t num_offsets = 0, nbytes = 0;
   if (SAVE_ERROR_CATCH(
           reader,
-          reader->reader_->result_size(attribute, &num_offsets, &nbytes)))
+          reader->reader_->result_size(
+              attribute, num_offsets, num_data_elements, num_data_bytes)))
     return TILEDB_VCF_ERR;
-
-  *offset_buff_size = num_offsets * sizeof(int32_t);
-  *buff_size = nbytes;
 
   return TILEDB_VCF_OK;
 }

--- a/src/c_api/tiledbvcf.h
+++ b/src/c_api/tiledbvcf.h
@@ -390,20 +390,26 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_result_num_records(
     tiledb_vcf_reader_t* reader, int64_t* num_records);
 
 /**
- * After reading some data, gets the size (in bytes) of a buffer holding reader
- * results.
+ * After reading some data, gets the sizes of reader results for an attribute.
  *
  * @param reader VCF reader object
  * @param attribute Name of attribute
- * @param offset_buff_size Set to the size (bytes) of the result offset buffer
- * @param buff_size Set to the size (bytes) of the result data buffer
+ * @param num_offsets Set to the number of offsets in the result offsets buffer
+ *      (var-len attributes only). This will be one more than the number of
+ *      "cells" of data read.
+ * @param num_data_elements Set to the number of elements in the result data
+ *      buffer. This will be the number of data elements across all cells,
+ *      variable-length included.
+ * @param num_data_bytes Set to the number of bytes in the result data buffer
+ *      across all cells.
  * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
  */
 TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_result_size(
     tiledb_vcf_reader_t* reader,
     const char* attribute,
-    int64_t* offset_buff_size,
-    int64_t* buff_size);
+    int64_t* num_offsets,
+    int64_t* num_data_elements,
+    int64_t* num_data_bytes);
 
 /**
  * Gets the number of buffers that have been previously set on the reader.

--- a/src/read/in_memory_exporter.h
+++ b/src/read/in_memory_exporter.h
@@ -116,15 +116,12 @@ class InMemoryExporter : public Exporter {
 
   /**
    * Returns the size of the result copied for the given attribute.
-   *
-   * @param attribute Name of attribute
-   * @param num_offsets For var-length attrs, number of offsets copied.
-   * @param nbytes Number of data bytes copid,
    */
   void result_size(
       const std::string& attribute,
       int64_t* num_offsets,
-      int64_t* nbytes) const;
+      int64_t* num_data_elements,
+      int64_t* num_data_bytes) const;
 
   /** Returns the number of in-memory user buffers that have been set. */
   void num_buffers(int32_t* num_buffers) const;
@@ -193,6 +190,7 @@ class InMemoryExporter : public Exporter {
         , data(nullptr)
         , max_data_bytes(0)
         , curr_data_bytes(0)
+        , curr_data_nelts(0)
         , offsets(nullptr)
         , max_num_offsets(0)
         , curr_num_offsets(0)
@@ -214,6 +212,8 @@ class InMemoryExporter : public Exporter {
     int64_t max_data_bytes;
     /** Currently used number of bytes in user's buffer. */
     int64_t curr_data_bytes;
+    /** Current number of elements in user's buffer. */
+    int64_t curr_data_nelts;
 
     /** Pointer to user's offset buffer (null for fixed-len) */
     int32_t* offsets;
@@ -278,7 +278,10 @@ class InMemoryExporter : public Exporter {
 
   /** Copies the given data to a user buffer. */
   bool copy_to_user_buff(
-      UserBuffer* dest, const void* data, uint64_t nbytes) const;
+      UserBuffer* dest,
+      const void* data,
+      uint64_t nbytes,
+      uint64_t nelts) const;
 
   /** Helper method to export an info_/fmt_ attribute. */
   bool copy_info_fmt_value(uint64_t cell_idx, UserBuffer* dest) const;
@@ -303,7 +306,8 @@ class InMemoryExporter : public Exporter {
       const std::string& field_name,
       uint64_t cell_idx,
       const void** data,
-      uint64_t* nbytes) const;
+      uint64_t* nbytes,
+      uint64_t* nelts) const;
 
   /**
    * Constructs a string CSV list of filter names from the given filter data.

--- a/src/read/reader.cc
+++ b/src/read/reader.cc
@@ -153,12 +153,16 @@ void Reader::dataset_version(int32_t* version) const {
 }
 
 void Reader::result_size(
-    const std::string& attribute, int64_t* num_offsets, int64_t* nbytes) const {
+    const std::string& attribute,
+    int64_t* num_offsets,
+    int64_t* num_data_elements,
+    int64_t* num_data_bytes) const {
   auto exp = dynamic_cast<InMemoryExporter*>(exporter_.get());
   if (exp == nullptr)
     throw std::runtime_error(
         "Error getting result size; improper or null exporter instance");
-  return exp->result_size(attribute, num_offsets, nbytes);
+  return exp->result_size(
+      attribute, num_offsets, num_data_elements, num_data_bytes);
 }
 
 void Reader::attribute_datatype(

--- a/src/read/reader.h
+++ b/src/read/reader.h
@@ -172,13 +172,14 @@ class Reader {
   void dataset_version(int32_t* version) const;
 
   /**
-   * Returns the size of data and offsets last exported for the given
+   * Returns the size of the result last exported for the given
    * attribute.
    */
   void result_size(
       const std::string& attribute,
       int64_t* num_offsets,
-      int64_t* nbytes) const;
+      int64_t* num_data_elements,
+      int64_t* num_data_bytes) const;
 
   /**
    * Returns the datatype, var-length, and nullable setting of the given

--- a/test/src/unit-c-api-reader.cc
+++ b/test/src/unit-c-api-reader.cc
@@ -319,22 +319,34 @@ TEST_CASE("C API: Reader submit (default attributes)", "[capi][reader]") {
   REQUIRE(num_records == expected_num_records);
 
   // Check a few buffer sizes
-  int64_t buff_size, off_size;
+  int64_t num_offsets, num_data_elements, num_data_bytes;
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "pos_start", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(buff_size == expected_num_records * sizeof(uint32_t));
-  REQUIRE(off_size == 0);
+          reader,
+          "pos_start",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_data_bytes == expected_num_records * sizeof(uint32_t));
+  REQUIRE(num_offsets == 0);
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "sample_name", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(buff_size == 70);
-  REQUIRE(off_size == (expected_num_records + 1) * sizeof(int32_t));
+          reader,
+          "sample_name",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_data_bytes == 70);
+  REQUIRE(num_offsets == (expected_num_records + 1));
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "alleles", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(buff_size == 120);
-  REQUIRE(off_size == (expected_num_records + 1) * sizeof(int32_t));
+          reader,
+          "alleles",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_data_bytes == 120);
+  REQUIRE(num_offsets == (expected_num_records + 1));
 
   // Check results
   REQUIRE(start_pos[0] == 12141);
@@ -346,8 +358,8 @@ TEST_CASE("C API: Reader submit (default attributes)", "[capi][reader]") {
   REQUIRE((filter_bitmap[0] & ((uint8_t)1 << 0)) == 0);
   REQUIRE(filter_offsets[0] == 0);
   REQUIRE(genotype_offsets[0] == 0);
-  REQUIRE(genotype[genotype_offsets[0] / sizeof(int32_t)] == 0);
-  REQUIRE(genotype[genotype_offsets[0] / sizeof(int32_t) + 1] == 0);
+  REQUIRE(genotype[genotype_offsets[0]] == 0);
+  REQUIRE(genotype[genotype_offsets[0] + 1] == 0);
   REQUIRE(info_offsets[0] == 0);
   REQUIRE(format_offsets[0] == 0);
   REQUIRE(qrange_start[0] == 12099);
@@ -361,9 +373,9 @@ TEST_CASE("C API: Reader submit (default attributes)", "[capi][reader]") {
   REQUIRE(strncmp("C,<NON_REF>", &alleles[alleles_offsets[1]], 11) == 0);
   REQUIRE((filter_bitmap[0] & ((uint8_t)1 << 1)) == 0);
   REQUIRE(filter_offsets[1] == 0);
-  REQUIRE(genotype_offsets[1] == 8);
-  REQUIRE(genotype[genotype_offsets[1] / sizeof(int32_t)] == 0);
-  REQUIRE(genotype[genotype_offsets[1] / sizeof(int32_t) + 1] == 0);
+  REQUIRE(genotype_offsets[1] == 2);
+  REQUIRE(genotype[genotype_offsets[1]] == 0);
+  REQUIRE(genotype[genotype_offsets[1] + 1] == 0);
   REQUIRE(info_offsets[1] == 4);
   REQUIRE(format_offsets[1] == 95);
   REQUIRE(qrange_start[1] == 12099);
@@ -377,9 +389,9 @@ TEST_CASE("C API: Reader submit (default attributes)", "[capi][reader]") {
   REQUIRE(strncmp("G,<NON_REF>", &alleles[alleles_offsets[2]], 11) == 0);
   REQUIRE((filter_bitmap[0] & ((uint8_t)1 << 2)) == 0);
   REQUIRE(filter_offsets[2] == 0);
-  REQUIRE(genotype_offsets[2] == 16);
-  REQUIRE(genotype[genotype_offsets[2] / sizeof(int32_t)] == 0);
-  REQUIRE(genotype[genotype_offsets[2] / sizeof(int32_t) + 1] == 0);
+  REQUIRE(genotype_offsets[2] == 4);
+  REQUIRE(genotype[genotype_offsets[2]] == 0);
+  REQUIRE(genotype[genotype_offsets[2] + 1] == 0);
   REQUIRE(info_offsets[2] == 8);
   REQUIRE(format_offsets[2] == 190);
   REQUIRE(qrange_start[2] == 12099);
@@ -393,9 +405,9 @@ TEST_CASE("C API: Reader submit (default attributes)", "[capi][reader]") {
   REQUIRE(strncmp("G,<NON_REF>", &alleles[alleles_offsets[3]], 11) == 0);
   REQUIRE((filter_bitmap[0] & ((uint8_t)1 << 3)) == 0);
   REQUIRE(filter_offsets[3] == 0);
-  REQUIRE(genotype_offsets[3] == 24);
-  REQUIRE(genotype[genotype_offsets[3] / sizeof(int32_t)] == 0);
-  REQUIRE(genotype[genotype_offsets[3] / sizeof(int32_t) + 1] == 0);
+  REQUIRE(genotype_offsets[3] == 6);
+  REQUIRE(genotype[genotype_offsets[3]] == 0);
+  REQUIRE(genotype[genotype_offsets[3] + 1] == 0);
   REQUIRE(info_offsets[3] == 12);
   REQUIRE(format_offsets[3] == 285);
   REQUIRE(qrange_start[3] == 12099);
@@ -410,9 +422,9 @@ TEST_CASE("C API: Reader submit (default attributes)", "[capi][reader]") {
   REQUIRE((filter_bitmap[0] & ((uint8_t)1 << 4)) != 0);
   REQUIRE(filter_offsets[4] == 0);
   REQUIRE(strncmp("LowQual", &filter[filter_offsets[4]], 7) == 0);
-  REQUIRE(genotype_offsets[4] == 32);
-  REQUIRE(genotype[genotype_offsets[4] / sizeof(int32_t)] == 0);
-  REQUIRE(genotype[genotype_offsets[4] / sizeof(int32_t) + 1] == 0);
+  REQUIRE(genotype_offsets[4] == 8);
+  REQUIRE(genotype[genotype_offsets[4]] == 0);
+  REQUIRE(genotype[genotype_offsets[4] + 1] == 0);
   REQUIRE(info_offsets[4] == 16);
   REQUIRE(format_offsets[4] == 380);
   REQUIRE(qrange_start[4] == 12099);
@@ -426,9 +438,9 @@ TEST_CASE("C API: Reader submit (default attributes)", "[capi][reader]") {
   REQUIRE(strncmp("T,<NON_REF>", &alleles[alleles_offsets[5]], 11) == 0);
   REQUIRE((filter_bitmap[0] & ((uint8_t)1 << 5)) == 0);
   REQUIRE(filter_offsets[5] == 7);
-  REQUIRE(genotype_offsets[5] == 40);
-  REQUIRE(genotype[genotype_offsets[5] / sizeof(int32_t)] == 0);
-  REQUIRE(genotype[genotype_offsets[5] / sizeof(int32_t) + 1] == 0);
+  REQUIRE(genotype_offsets[5] == 10);
+  REQUIRE(genotype[genotype_offsets[5]] == 0);
+  REQUIRE(genotype[genotype_offsets[5] + 1] == 0);
   REQUIRE(info_offsets[5] == 20);
   REQUIRE(format_offsets[5] == 475);
   REQUIRE(qrange_start[5] == 12099);
@@ -442,9 +454,9 @@ TEST_CASE("C API: Reader submit (default attributes)", "[capi][reader]") {
   REQUIRE(strncmp("G,<NON_REF>", &alleles[alleles_offsets[6]], 11) == 0);
   REQUIRE((filter_bitmap[0] & ((uint8_t)1 << 6)) == 0);
   REQUIRE(filter_offsets[6] == 7);
-  REQUIRE(genotype_offsets[6] == 48);
-  REQUIRE(genotype[genotype_offsets[6] / sizeof(int32_t)] == 0);
-  REQUIRE(genotype[genotype_offsets[6] / sizeof(int32_t) + 1] == 0);
+  REQUIRE(genotype_offsets[6] == 12);
+  REQUIRE(genotype[genotype_offsets[6]] == 0);
+  REQUIRE(genotype[genotype_offsets[6] + 1] == 0);
   REQUIRE(info_offsets[6] == 24);
   REQUIRE(format_offsets[6] == 570);
   REQUIRE(qrange_start[6] == 13499);
@@ -458,9 +470,9 @@ TEST_CASE("C API: Reader submit (default attributes)", "[capi][reader]") {
   REQUIRE(strncmp("G,<NON_REF>", &alleles[alleles_offsets[7]], 11) == 0);
   REQUIRE((filter_bitmap[0] & ((uint8_t)1 << 7)) == 0);
   REQUIRE(filter_offsets[7] == 7);
-  REQUIRE(genotype_offsets[7] == 56);
-  REQUIRE(genotype[genotype_offsets[7] / sizeof(int32_t)] == 0);
-  REQUIRE(genotype[genotype_offsets[7] / sizeof(int32_t) + 1] == 0);
+  REQUIRE(genotype_offsets[7] == 14);
+  REQUIRE(genotype[genotype_offsets[7]] == 0);
+  REQUIRE(genotype[genotype_offsets[7] + 1] == 0);
   REQUIRE(info_offsets[7] == 28);
   REQUIRE(format_offsets[7] == 665);
   REQUIRE(qrange_start[7] == 13499);
@@ -474,9 +486,9 @@ TEST_CASE("C API: Reader submit (default attributes)", "[capi][reader]") {
   REQUIRE(strncmp("G,<NON_REF>", &alleles[alleles_offsets[8]], 11) == 0);
   REQUIRE((filter_bitmap[1] & ((uint8_t)1 << 0)) == 0);
   REQUIRE(filter_offsets[8] == 7);
-  REQUIRE(genotype_offsets[8] == 64);
-  REQUIRE(genotype[genotype_offsets[8] / sizeof(int32_t)] == 0);
-  REQUIRE(genotype[genotype_offsets[8] / sizeof(int32_t) + 1] == 0);
+  REQUIRE(genotype_offsets[8] == 16);
+  REQUIRE(genotype[genotype_offsets[8]] == 0);
+  REQUIRE(genotype[genotype_offsets[8] + 1] == 0);
   REQUIRE(info_offsets[8] == 32);
   REQUIRE(format_offsets[8] == 760);
   REQUIRE(qrange_start[8] == 13499);
@@ -490,9 +502,9 @@ TEST_CASE("C API: Reader submit (default attributes)", "[capi][reader]") {
   REQUIRE(strncmp("T,<NON_REF>", &alleles[alleles_offsets[9]], 11) == 0);
   REQUIRE((filter_bitmap[1] & ((uint8_t)1 << 1)) == 0);
   REQUIRE(filter_offsets[9] == 7);
-  REQUIRE(genotype_offsets[9] == 72);
-  REQUIRE(genotype[genotype_offsets[9] / sizeof(int32_t)] == 0);
-  REQUIRE(genotype[genotype_offsets[9] / sizeof(int32_t) + 1] == 0);
+  REQUIRE(genotype_offsets[9] == 18);
+  REQUIRE(genotype[genotype_offsets[9]] == 0);
+  REQUIRE(genotype[genotype_offsets[9] + 1] == 0);
   REQUIRE(info_offsets[9] == 36);
   REQUIRE(format_offsets[9] == 855);
   REQUIRE(qrange_start[9] == 13499);
@@ -501,7 +513,7 @@ TEST_CASE("C API: Reader submit (default attributes)", "[capi][reader]") {
   // Check final offsets are equal to data size
   REQUIRE(sample_name_offsets[10] == 70);
   REQUIRE(filter_offsets[10] == 7);
-  REQUIRE(genotype_offsets[10] == 80);
+  REQUIRE(genotype_offsets[10] == 20);
   REQUIRE(info_offsets[10] == 40);
   REQUIRE(format_offsets[10] == 950);
 
@@ -671,16 +683,16 @@ TEST_CASE("C API: Reader submit (optional attributes)", "[capi][reader]") {
   REQUIRE((filter_bitmap[0] & ((uint8_t)1 << 0)) == 0);
   REQUIRE(filter_offsets[0] == 0);
   REQUIRE(genotype_offsets[0] == 0);
-  REQUIRE(genotype[genotype_offsets[0] / sizeof(int32_t)] == 0);
-  REQUIRE(genotype[genotype_offsets[0] / sizeof(int32_t) + 1] == 0);
+  REQUIRE(genotype[genotype_offsets[0]] == 0);
+  REQUIRE(genotype[genotype_offsets[0] + 1] == 0);
   REQUIRE(info_offsets[0] == 0);
   REQUIRE(format_offsets[0] == 0);
   REQUIRE(qrange_start[0] == 12099);
   REQUIRE(qrange_end[0] == 13360);
-  REQUIRE(dp[dp_offsets[0] / sizeof(int32_t)] == 0);
-  REQUIRE(pl[pl_offsets[0] / sizeof(int32_t)] == 0);
-  REQUIRE(pl[pl_offsets[0] / sizeof(int32_t) + 1] == 0);
-  REQUIRE(pl[pl_offsets[0] / sizeof(int32_t) + 2] == 0);
+  REQUIRE(dp[dp_offsets[0]] == 0);
+  REQUIRE(pl[pl_offsets[0]] == 0);
+  REQUIRE(pl[pl_offsets[0] + 1] == 0);
+  REQUIRE(pl[pl_offsets[0] + 2] == 0);
 
   REQUIRE(start_pos[1] == 12141);
   REQUIRE(end_pos[1] == 12277);
@@ -690,17 +702,17 @@ TEST_CASE("C API: Reader submit (optional attributes)", "[capi][reader]") {
   REQUIRE(strncmp("C,<NON_REF>", &alleles[alleles_offsets[1]], 11) == 0);
   REQUIRE((filter_bitmap[0] & ((uint8_t)1 << 1)) == 0);
   REQUIRE(filter_offsets[1] == 0);
-  REQUIRE(genotype_offsets[1] == 8);
-  REQUIRE(genotype[genotype_offsets[1] / sizeof(int32_t)] == 0);
-  REQUIRE(genotype[genotype_offsets[1] / sizeof(int32_t) + 1] == 0);
+  REQUIRE(genotype_offsets[1] == 2);
+  REQUIRE(genotype[genotype_offsets[1]] == 0);
+  REQUIRE(genotype[genotype_offsets[1] + 1] == 0);
   REQUIRE(info_offsets[1] == 4);
   REQUIRE(format_offsets[1] == 38);
   REQUIRE(qrange_start[1] == 12099);
   REQUIRE(qrange_end[1] == 13360);
-  REQUIRE(dp[dp_offsets[1] / sizeof(int32_t)] == 0);
-  REQUIRE(pl[pl_offsets[1] / sizeof(int32_t)] == 0);
-  REQUIRE(pl[pl_offsets[1] / sizeof(int32_t) + 1] == 0);
-  REQUIRE(pl[pl_offsets[1] / sizeof(int32_t) + 2] == 0);
+  REQUIRE(dp[dp_offsets[1]] == 0);
+  REQUIRE(pl[pl_offsets[1]] == 0);
+  REQUIRE(pl[pl_offsets[1] + 1] == 0);
+  REQUIRE(pl[pl_offsets[1] + 2] == 0);
 
   REQUIRE(start_pos[2] == 12546);
   REQUIRE(end_pos[2] == 12771);
@@ -710,17 +722,17 @@ TEST_CASE("C API: Reader submit (optional attributes)", "[capi][reader]") {
   REQUIRE(strncmp("G,<NON_REF>", &alleles[alleles_offsets[2]], 11) == 0);
   REQUIRE((filter_bitmap[0] & ((uint8_t)1 << 2)) == 0);
   REQUIRE(filter_offsets[2] == 0);
-  REQUIRE(genotype_offsets[2] == 16);
-  REQUIRE(genotype[genotype_offsets[2] / sizeof(int32_t)] == 0);
-  REQUIRE(genotype[genotype_offsets[2] / sizeof(int32_t) + 1] == 0);
+  REQUIRE(genotype_offsets[2] == 4);
+  REQUIRE(genotype[genotype_offsets[2]] == 0);
+  REQUIRE(genotype[genotype_offsets[2] + 1] == 0);
   REQUIRE(info_offsets[2] == 8);
   REQUIRE(format_offsets[2] == 76);
   REQUIRE(qrange_start[2] == 12099);
   REQUIRE(qrange_end[2] == 13360);
-  REQUIRE(dp[dp_offsets[2] / sizeof(int32_t)] == 0);
-  REQUIRE(pl[pl_offsets[2] / sizeof(int32_t)] == 0);
-  REQUIRE(pl[pl_offsets[2] / sizeof(int32_t) + 1] == 0);
-  REQUIRE(pl[pl_offsets[2] / sizeof(int32_t) + 2] == 0);
+  REQUIRE(dp[dp_offsets[2]] == 0);
+  REQUIRE(pl[pl_offsets[2]] == 0);
+  REQUIRE(pl[pl_offsets[2] + 1] == 0);
+  REQUIRE(pl[pl_offsets[2] + 2] == 0);
 
   REQUIRE(start_pos[3] == 12546);
   REQUIRE(end_pos[3] == 12771);
@@ -730,17 +742,17 @@ TEST_CASE("C API: Reader submit (optional attributes)", "[capi][reader]") {
   REQUIRE(strncmp("G,<NON_REF>", &alleles[alleles_offsets[3]], 11) == 0);
   REQUIRE((filter_bitmap[0] & ((uint8_t)1 << 3)) == 0);
   REQUIRE(filter_offsets[3] == 0);
-  REQUIRE(genotype_offsets[3] == 24);
-  REQUIRE(genotype[genotype_offsets[3] / sizeof(int32_t)] == 0);
-  REQUIRE(genotype[genotype_offsets[3] / sizeof(int32_t) + 1] == 0);
+  REQUIRE(genotype_offsets[3] == 6);
+  REQUIRE(genotype[genotype_offsets[3]] == 0);
+  REQUIRE(genotype[genotype_offsets[3] + 1] == 0);
   REQUIRE(info_offsets[3] == 12);
   REQUIRE(format_offsets[3] == 114);
   REQUIRE(qrange_start[3] == 12099);
   REQUIRE(qrange_end[3] == 13360);
-  REQUIRE(dp[dp_offsets[3] / sizeof(int32_t)] == 0);
-  REQUIRE(pl[pl_offsets[3] / sizeof(int32_t)] == 0);
-  REQUIRE(pl[pl_offsets[3] / sizeof(int32_t) + 1] == 0);
-  REQUIRE(pl[pl_offsets[3] / sizeof(int32_t) + 2] == 0);
+  REQUIRE(dp[dp_offsets[3]] == 0);
+  REQUIRE(pl[pl_offsets[3]] == 0);
+  REQUIRE(pl[pl_offsets[3] + 1] == 0);
+  REQUIRE(pl[pl_offsets[3] + 2] == 0);
 
   REQUIRE(start_pos[4] == 13354);
   REQUIRE(end_pos[4] == 13374);
@@ -751,17 +763,17 @@ TEST_CASE("C API: Reader submit (optional attributes)", "[capi][reader]") {
   REQUIRE((filter_bitmap[0] & ((uint8_t)1 << 4)) != 0);
   REQUIRE(filter_offsets[4] == 0);
   REQUIRE(strncmp("LowQual", &filter[filter_offsets[4]], 7) == 0);
-  REQUIRE(genotype_offsets[4] == 32);
-  REQUIRE(genotype[genotype_offsets[4] / sizeof(int32_t)] == 0);
-  REQUIRE(genotype[genotype_offsets[4] / sizeof(int32_t) + 1] == 0);
+  REQUIRE(genotype_offsets[4] == 8);
+  REQUIRE(genotype[genotype_offsets[4]] == 0);
+  REQUIRE(genotype[genotype_offsets[4] + 1] == 0);
   REQUIRE(info_offsets[4] == 16);
   REQUIRE(format_offsets[4] == 152);
   REQUIRE(qrange_start[4] == 12099);
   REQUIRE(qrange_end[4] == 13360);
-  REQUIRE(dp[dp_offsets[4] / sizeof(int32_t)] == 15);
-  REQUIRE(pl[pl_offsets[4] / sizeof(int32_t)] == 0);
-  REQUIRE(pl[pl_offsets[4] / sizeof(int32_t) + 1] == 24);
-  REQUIRE(pl[pl_offsets[4] / sizeof(int32_t) + 2] == 360);
+  REQUIRE(dp[dp_offsets[4]] == 15);
+  REQUIRE(pl[pl_offsets[4]] == 0);
+  REQUIRE(pl[pl_offsets[4] + 1] == 24);
+  REQUIRE(pl[pl_offsets[4] + 2] == 360);
 
   REQUIRE(start_pos[5] == 13354);
   REQUIRE(end_pos[5] == 13389);
@@ -771,17 +783,17 @@ TEST_CASE("C API: Reader submit (optional attributes)", "[capi][reader]") {
   REQUIRE(strncmp("T,<NON_REF>", &alleles[alleles_offsets[5]], 11) == 0);
   REQUIRE((filter_bitmap[0] & ((uint8_t)1 << 5)) == 0);
   REQUIRE(filter_offsets[5] == 7);
-  REQUIRE(genotype_offsets[5] == 40);
-  REQUIRE(genotype[genotype_offsets[5] / sizeof(int32_t)] == 0);
-  REQUIRE(genotype[genotype_offsets[5] / sizeof(int32_t) + 1] == 0);
+  REQUIRE(genotype_offsets[5] == 10);
+  REQUIRE(genotype[genotype_offsets[5]] == 0);
+  REQUIRE(genotype[genotype_offsets[5] + 1] == 0);
   REQUIRE(info_offsets[5] == 20);
   REQUIRE(format_offsets[5] == 190);
   REQUIRE(qrange_start[5] == 12099);
   REQUIRE(qrange_end[5] == 13360);
-  REQUIRE(dp[dp_offsets[5] / sizeof(int32_t)] == 64);
-  REQUIRE(pl[pl_offsets[5] / sizeof(int32_t)] == 0);
-  REQUIRE(pl[pl_offsets[5] / sizeof(int32_t) + 1] == 66);
-  REQUIRE(pl[pl_offsets[5] / sizeof(int32_t) + 2] == 990);
+  REQUIRE(dp[dp_offsets[5]] == 64);
+  REQUIRE(pl[pl_offsets[5]] == 0);
+  REQUIRE(pl[pl_offsets[5] + 1] == 66);
+  REQUIRE(pl[pl_offsets[5] + 2] == 990);
 
   REQUIRE(start_pos[6] == 13452);
   REQUIRE(end_pos[6] == 13519);
@@ -791,17 +803,17 @@ TEST_CASE("C API: Reader submit (optional attributes)", "[capi][reader]") {
   REQUIRE(strncmp("G,<NON_REF>", &alleles[alleles_offsets[6]], 11) == 0);
   REQUIRE((filter_bitmap[0] & ((uint8_t)1 << 6)) == 0);
   REQUIRE(filter_offsets[6] == 7);
-  REQUIRE(genotype_offsets[6] == 48);
-  REQUIRE(genotype[genotype_offsets[6] / sizeof(int32_t)] == 0);
-  REQUIRE(genotype[genotype_offsets[6] / sizeof(int32_t) + 1] == 0);
+  REQUIRE(genotype_offsets[6] == 12);
+  REQUIRE(genotype[genotype_offsets[6]] == 0);
+  REQUIRE(genotype[genotype_offsets[6] + 1] == 0);
   REQUIRE(info_offsets[6] == 24);
   REQUIRE(format_offsets[6] == 228);
   REQUIRE(qrange_start[6] == 13499);
   REQUIRE(qrange_end[6] == 17350);
-  REQUIRE(dp[dp_offsets[6] / sizeof(int32_t)] == 10);
-  REQUIRE(pl[pl_offsets[6] / sizeof(int32_t)] == 0);
-  REQUIRE(pl[pl_offsets[6] / sizeof(int32_t) + 1] == 21);
-  REQUIRE(pl[pl_offsets[6] / sizeof(int32_t) + 2] == 210);
+  REQUIRE(dp[dp_offsets[6]] == 10);
+  REQUIRE(pl[pl_offsets[6]] == 0);
+  REQUIRE(pl[pl_offsets[6] + 1] == 21);
+  REQUIRE(pl[pl_offsets[6] + 2] == 210);
 
   REQUIRE(start_pos[7] == 13520);
   REQUIRE(end_pos[7] == 13544);
@@ -811,17 +823,17 @@ TEST_CASE("C API: Reader submit (optional attributes)", "[capi][reader]") {
   REQUIRE(strncmp("G,<NON_REF>", &alleles[alleles_offsets[7]], 11) == 0);
   REQUIRE((filter_bitmap[0] & ((uint8_t)1 << 7)) == 0);
   REQUIRE(filter_offsets[7] == 7);
-  REQUIRE(genotype_offsets[7] == 56);
-  REQUIRE(genotype[genotype_offsets[7] / sizeof(int32_t)] == 0);
-  REQUIRE(genotype[genotype_offsets[7] / sizeof(int32_t) + 1] == 0);
+  REQUIRE(genotype_offsets[7] == 14);
+  REQUIRE(genotype[genotype_offsets[7]] == 0);
+  REQUIRE(genotype[genotype_offsets[7] + 1] == 0);
   REQUIRE(info_offsets[7] == 28);
   REQUIRE(format_offsets[7] == 266);
   REQUIRE(qrange_start[7] == 13499);
   REQUIRE(qrange_end[7] == 17350);
-  REQUIRE(dp[dp_offsets[7] / sizeof(int32_t)] == 6);
-  REQUIRE(pl[pl_offsets[7] / sizeof(int32_t)] == 0);
-  REQUIRE(pl[pl_offsets[7] / sizeof(int32_t) + 1] == 6);
-  REQUIRE(pl[pl_offsets[7] / sizeof(int32_t) + 2] == 90);
+  REQUIRE(dp[dp_offsets[7]] == 6);
+  REQUIRE(pl[pl_offsets[7]] == 0);
+  REQUIRE(pl[pl_offsets[7] + 1] == 6);
+  REQUIRE(pl[pl_offsets[7] + 2] == 90);
 
   REQUIRE(start_pos[8] == 13545);
   REQUIRE(end_pos[8] == 13689);
@@ -831,17 +843,17 @@ TEST_CASE("C API: Reader submit (optional attributes)", "[capi][reader]") {
   REQUIRE(strncmp("G,<NON_REF>", &alleles[alleles_offsets[8]], 11) == 0);
   REQUIRE((filter_bitmap[1] & ((uint8_t)1 << 0)) == 0);
   REQUIRE(filter_offsets[8] == 7);
-  REQUIRE(genotype_offsets[8] == 64);
-  REQUIRE(genotype[genotype_offsets[8] / sizeof(int32_t)] == 0);
-  REQUIRE(genotype[genotype_offsets[8] / sizeof(int32_t) + 1] == 0);
+  REQUIRE(genotype_offsets[8] == 16);
+  REQUIRE(genotype[genotype_offsets[8]] == 0);
+  REQUIRE(genotype[genotype_offsets[8] + 1] == 0);
   REQUIRE(info_offsets[8] == 32);
   REQUIRE(format_offsets[8] == 304);
   REQUIRE(qrange_start[8] == 13499);
   REQUIRE(qrange_end[8] == 17350);
-  REQUIRE(dp[dp_offsets[8] / sizeof(int32_t)] == 0);
-  REQUIRE(pl[pl_offsets[8] / sizeof(int32_t)] == 0);
-  REQUIRE(pl[pl_offsets[8] / sizeof(int32_t) + 1] == 0);
-  REQUIRE(pl[pl_offsets[8] / sizeof(int32_t) + 2] == 0);
+  REQUIRE(dp[dp_offsets[8]] == 0);
+  REQUIRE(pl[pl_offsets[8]] == 0);
+  REQUIRE(pl[pl_offsets[8] + 1] == 0);
+  REQUIRE(pl[pl_offsets[8] + 2] == 0);
 
   REQUIRE(start_pos[9] == 17319);
   REQUIRE(end_pos[9] == 17479);
@@ -851,17 +863,17 @@ TEST_CASE("C API: Reader submit (optional attributes)", "[capi][reader]") {
   REQUIRE(strncmp("T,<NON_REF>", &alleles[alleles_offsets[9]], 11) == 0);
   REQUIRE((filter_bitmap[1] & ((uint8_t)1 << 1)) == 0);
   REQUIRE(filter_offsets[9] == 7);
-  REQUIRE(genotype_offsets[9] == 72);
-  REQUIRE(genotype[genotype_offsets[9] / sizeof(int32_t)] == 0);
-  REQUIRE(genotype[genotype_offsets[9] / sizeof(int32_t) + 1] == 0);
+  REQUIRE(genotype_offsets[9] == 18);
+  REQUIRE(genotype[genotype_offsets[9]] == 0);
+  REQUIRE(genotype[genotype_offsets[9] + 1] == 0);
   REQUIRE(info_offsets[9] == 36);
   REQUIRE(format_offsets[9] == 342);
   REQUIRE(qrange_start[9] == 13499);
   REQUIRE(qrange_end[9] == 17350);
-  REQUIRE(dp[dp_offsets[9] / sizeof(int32_t)] == 0);
-  REQUIRE(pl[pl_offsets[9] / sizeof(int32_t)] == 0);
-  REQUIRE(pl[pl_offsets[9] / sizeof(int32_t) + 1] == 0);
-  REQUIRE(pl[pl_offsets[9] / sizeof(int32_t) + 2] == 0);
+  REQUIRE(dp[dp_offsets[9]] == 0);
+  REQUIRE(pl[pl_offsets[9]] == 0);
+  REQUIRE(pl[pl_offsets[9] + 1] == 0);
+  REQUIRE(pl[pl_offsets[9] + 2] == 0);
 
   tiledb_vcf_reader_free(&reader);
 }
@@ -939,52 +951,52 @@ TEST_CASE("C API: Reader submit (subselect attributes)", "[capi][reader]") {
   REQUIRE(end_pos[0] == 12277);
   REQUIRE(strncmp("HG00280", &sample_name[sample_name_offsets[0]], 7) == 0);
   REQUIRE(strncmp("C,<NON_REF>", &alleles[alleles_offsets[0]], 11) == 0);
-  REQUIRE(dp[dp_offsets[0] / sizeof(int32_t)] == 0);
+  REQUIRE(dp[dp_offsets[0]] == 0);
 
   REQUIRE(end_pos[1] == 12277);
   REQUIRE(strncmp("HG01762", &sample_name[sample_name_offsets[1]], 7) == 0);
   REQUIRE(strncmp("C,<NON_REF>", &alleles[alleles_offsets[1]], 11) == 0);
-  REQUIRE(dp[dp_offsets[1] / sizeof(int32_t)] == 0);
+  REQUIRE(dp[dp_offsets[1]] == 0);
 
   REQUIRE(end_pos[2] == 12771);
   REQUIRE(strncmp("HG00280", &sample_name[sample_name_offsets[2]], 7) == 0);
   REQUIRE(strncmp("G,<NON_REF>", &alleles[alleles_offsets[2]], 11) == 0);
-  REQUIRE(dp[dp_offsets[2] / sizeof(int32_t)] == 0);
+  REQUIRE(dp[dp_offsets[2]] == 0);
 
   REQUIRE(end_pos[3] == 12771);
   REQUIRE(strncmp("HG01762", &sample_name[sample_name_offsets[3]], 7) == 0);
   REQUIRE(strncmp("G,<NON_REF>", &alleles[alleles_offsets[3]], 11) == 0);
-  REQUIRE(dp[dp_offsets[3] / sizeof(int32_t)] == 0);
+  REQUIRE(dp[dp_offsets[3]] == 0);
 
   REQUIRE(end_pos[4] == 13374);
   REQUIRE(strncmp("HG00280", &sample_name[sample_name_offsets[4]], 7) == 0);
   REQUIRE(strncmp("T,<NON_REF>", &alleles[alleles_offsets[4]], 11) == 0);
-  REQUIRE(dp[dp_offsets[4] / sizeof(int32_t)] == 15);
+  REQUIRE(dp[dp_offsets[4]] == 15);
 
   REQUIRE(end_pos[5] == 13389);
   REQUIRE(strncmp("HG01762", &sample_name[sample_name_offsets[5]], 7) == 0);
   REQUIRE(strncmp("T,<NON_REF>", &alleles[alleles_offsets[5]], 11) == 0);
-  REQUIRE(dp[dp_offsets[5] / sizeof(int32_t)] == 64);
+  REQUIRE(dp[dp_offsets[5]] == 64);
 
   REQUIRE(end_pos[6] == 13519);
   REQUIRE(strncmp("HG00280", &sample_name[sample_name_offsets[6]], 7) == 0);
   REQUIRE(strncmp("G,<NON_REF>", &alleles[alleles_offsets[6]], 11) == 0);
-  REQUIRE(dp[dp_offsets[6] / sizeof(int32_t)] == 10);
+  REQUIRE(dp[dp_offsets[6]] == 10);
 
   REQUIRE(end_pos[7] == 13544);
   REQUIRE(strncmp("HG00280", &sample_name[sample_name_offsets[7]], 7) == 0);
   REQUIRE(strncmp("G,<NON_REF>", &alleles[alleles_offsets[7]], 11) == 0);
-  REQUIRE(dp[dp_offsets[7] / sizeof(int32_t)] == 6);
+  REQUIRE(dp[dp_offsets[7]] == 6);
 
   REQUIRE(end_pos[8] == 13689);
   REQUIRE(strncmp("HG00280", &sample_name[sample_name_offsets[8]], 7) == 0);
   REQUIRE(strncmp("G,<NON_REF>", &alleles[alleles_offsets[8]], 11) == 0);
-  REQUIRE(dp[dp_offsets[8] / sizeof(int32_t)] == 0);
+  REQUIRE(dp[dp_offsets[8]] == 0);
 
   REQUIRE(end_pos[9] == 17479);
   REQUIRE(strncmp("HG00280", &sample_name[sample_name_offsets[9]], 7) == 0);
   REQUIRE(strncmp("T,<NON_REF>", &alleles[alleles_offsets[9]], 11) == 0);
-  REQUIRE(dp[dp_offsets[9] / sizeof(int32_t)] == 0);
+  REQUIRE(dp[dp_offsets[9]] == 0);
 
   tiledb_vcf_reader_free(&reader);
 }
@@ -1060,22 +1072,22 @@ TEST_CASE("C API: Reader submit (all samples)", "[capi][reader]") {
   REQUIRE(end_pos[0] == 12277);
   REQUIRE(strncmp("HG00280", &sample_name[sample_name_offsets[0]], 7) == 0);
   REQUIRE(strncmp("C,<NON_REF>", &alleles[alleles_offsets[0]], 11) == 0);
-  REQUIRE(dp[dp_offsets[0] / sizeof(int32_t)] == 0);
+  REQUIRE(dp[dp_offsets[0]] == 0);
 
   REQUIRE(end_pos[1] == 12277);
   REQUIRE(strncmp("HG01762", &sample_name[sample_name_offsets[1]], 7) == 0);
   REQUIRE(strncmp("C,<NON_REF>", &alleles[alleles_offsets[1]], 11) == 0);
-  REQUIRE(dp[dp_offsets[1] / sizeof(int32_t)] == 0);
+  REQUIRE(dp[dp_offsets[1]] == 0);
 
   REQUIRE(end_pos[2] == 12771);
   REQUIRE(strncmp("HG00280", &sample_name[sample_name_offsets[2]], 7) == 0);
   REQUIRE(strncmp("G,<NON_REF>", &alleles[alleles_offsets[2]], 11) == 0);
-  REQUIRE(dp[dp_offsets[2] / sizeof(int32_t)] == 0);
+  REQUIRE(dp[dp_offsets[2]] == 0);
 
   REQUIRE(end_pos[3] == 12771);
   REQUIRE(strncmp("HG01762", &sample_name[sample_name_offsets[3]], 7) == 0);
   REQUIRE(strncmp("G,<NON_REF>", &alleles[alleles_offsets[3]], 11) == 0);
-  REQUIRE(dp[dp_offsets[3] / sizeof(int32_t)] == 0);
+  REQUIRE(dp[dp_offsets[3]] == 0);
 
   tiledb_vcf_reader_free(&reader);
 }
@@ -1152,52 +1164,52 @@ TEST_CASE("C API: Reader submit (BED file)", "[capi][reader]") {
   REQUIRE(end_pos[0] == 12277);
   REQUIRE(strncmp("HG00280", &sample_name[sample_name_offsets[0]], 7) == 0);
   REQUIRE(strncmp("C,<NON_REF>", &alleles[alleles_offsets[0]], 11) == 0);
-  REQUIRE(dp[dp_offsets[0] / sizeof(int32_t)] == 0);
+  REQUIRE(dp[dp_offsets[0]] == 0);
 
   REQUIRE(end_pos[1] == 12277);
   REQUIRE(strncmp("HG01762", &sample_name[sample_name_offsets[1]], 7) == 0);
   REQUIRE(strncmp("C,<NON_REF>", &alleles[alleles_offsets[1]], 11) == 0);
-  REQUIRE(dp[dp_offsets[1] / sizeof(int32_t)] == 0);
+  REQUIRE(dp[dp_offsets[1]] == 0);
 
   REQUIRE(end_pos[2] == 12771);
   REQUIRE(strncmp("HG00280", &sample_name[sample_name_offsets[2]], 7) == 0);
   REQUIRE(strncmp("G,<NON_REF>", &alleles[alleles_offsets[2]], 11) == 0);
-  REQUIRE(dp[dp_offsets[2] / sizeof(int32_t)] == 0);
+  REQUIRE(dp[dp_offsets[2]] == 0);
 
   REQUIRE(end_pos[3] == 12771);
   REQUIRE(strncmp("HG01762", &sample_name[sample_name_offsets[3]], 7) == 0);
   REQUIRE(strncmp("G,<NON_REF>", &alleles[alleles_offsets[3]], 11) == 0);
-  REQUIRE(dp[dp_offsets[3] / sizeof(int32_t)] == 0);
+  REQUIRE(dp[dp_offsets[3]] == 0);
 
   REQUIRE(end_pos[4] == 13374);
   REQUIRE(strncmp("HG00280", &sample_name[sample_name_offsets[4]], 7) == 0);
   REQUIRE(strncmp("T,<NON_REF>", &alleles[alleles_offsets[4]], 11) == 0);
-  REQUIRE(dp[dp_offsets[4] / sizeof(int32_t)] == 15);
+  REQUIRE(dp[dp_offsets[4]] == 15);
 
   REQUIRE(end_pos[5] == 13389);
   REQUIRE(strncmp("HG01762", &sample_name[sample_name_offsets[5]], 7) == 0);
   REQUIRE(strncmp("T,<NON_REF>", &alleles[alleles_offsets[5]], 11) == 0);
-  REQUIRE(dp[dp_offsets[5] / sizeof(int32_t)] == 64);
+  REQUIRE(dp[dp_offsets[5]] == 64);
 
   REQUIRE(end_pos[6] == 13519);
   REQUIRE(strncmp("HG00280", &sample_name[sample_name_offsets[6]], 7) == 0);
   REQUIRE(strncmp("G,<NON_REF>", &alleles[alleles_offsets[6]], 11) == 0);
-  REQUIRE(dp[dp_offsets[6] / sizeof(int32_t)] == 10);
+  REQUIRE(dp[dp_offsets[6]] == 10);
 
   REQUIRE(end_pos[7] == 13544);
   REQUIRE(strncmp("HG00280", &sample_name[sample_name_offsets[7]], 7) == 0);
   REQUIRE(strncmp("G,<NON_REF>", &alleles[alleles_offsets[7]], 11) == 0);
-  REQUIRE(dp[dp_offsets[7] / sizeof(int32_t)] == 6);
+  REQUIRE(dp[dp_offsets[7]] == 6);
 
   REQUIRE(end_pos[8] == 13689);
   REQUIRE(strncmp("HG00280", &sample_name[sample_name_offsets[8]], 7) == 0);
   REQUIRE(strncmp("G,<NON_REF>", &alleles[alleles_offsets[8]], 11) == 0);
-  REQUIRE(dp[dp_offsets[8] / sizeof(int32_t)] == 0);
+  REQUIRE(dp[dp_offsets[8]] == 0);
 
   REQUIRE(end_pos[9] == 17479);
   REQUIRE(strncmp("HG00280", &sample_name[sample_name_offsets[9]], 7) == 0);
   REQUIRE(strncmp("T,<NON_REF>", &alleles[alleles_offsets[9]], 11) == 0);
-  REQUIRE(dp[dp_offsets[9] / sizeof(int32_t)] == 0);
+  REQUIRE(dp[dp_offsets[9]] == 0);
 
   tiledb_vcf_reader_free(&reader);
 }
@@ -1279,52 +1291,52 @@ TEST_CASE("C API: Reader submit (samples file)", "[capi][reader]") {
   REQUIRE(end_pos[0] == 12277);
   REQUIRE(strncmp("HG00280", &sample_name[sample_name_offsets[0]], 7) == 0);
   REQUIRE(strncmp("C,<NON_REF>", &alleles[alleles_offsets[0]], 11) == 0);
-  REQUIRE(dp[dp_offsets[0] / sizeof(int32_t)] == 0);
+  REQUIRE(dp[dp_offsets[0]] == 0);
 
   REQUIRE(end_pos[1] == 12277);
   REQUIRE(strncmp("HG01762", &sample_name[sample_name_offsets[1]], 7) == 0);
   REQUIRE(strncmp("C,<NON_REF>", &alleles[alleles_offsets[1]], 11) == 0);
-  REQUIRE(dp[dp_offsets[1] / sizeof(int32_t)] == 0);
+  REQUIRE(dp[dp_offsets[1]] == 0);
 
   REQUIRE(end_pos[2] == 12771);
   REQUIRE(strncmp("HG00280", &sample_name[sample_name_offsets[2]], 7) == 0);
   REQUIRE(strncmp("G,<NON_REF>", &alleles[alleles_offsets[2]], 11) == 0);
-  REQUIRE(dp[dp_offsets[2] / sizeof(int32_t)] == 0);
+  REQUIRE(dp[dp_offsets[2]] == 0);
 
   REQUIRE(end_pos[3] == 12771);
   REQUIRE(strncmp("HG01762", &sample_name[sample_name_offsets[3]], 7) == 0);
   REQUIRE(strncmp("G,<NON_REF>", &alleles[alleles_offsets[3]], 11) == 0);
-  REQUIRE(dp[dp_offsets[3] / sizeof(int32_t)] == 0);
+  REQUIRE(dp[dp_offsets[3]] == 0);
 
   REQUIRE(end_pos[4] == 13374);
   REQUIRE(strncmp("HG00280", &sample_name[sample_name_offsets[4]], 7) == 0);
   REQUIRE(strncmp("T,<NON_REF>", &alleles[alleles_offsets[4]], 11) == 0);
-  REQUIRE(dp[dp_offsets[4] / sizeof(int32_t)] == 15);
+  REQUIRE(dp[dp_offsets[4]] == 15);
 
   REQUIRE(end_pos[5] == 13389);
   REQUIRE(strncmp("HG01762", &sample_name[sample_name_offsets[5]], 7) == 0);
   REQUIRE(strncmp("T,<NON_REF>", &alleles[alleles_offsets[5]], 11) == 0);
-  REQUIRE(dp[dp_offsets[5] / sizeof(int32_t)] == 64);
+  REQUIRE(dp[dp_offsets[5]] == 64);
 
   REQUIRE(end_pos[6] == 13519);
   REQUIRE(strncmp("HG00280", &sample_name[sample_name_offsets[6]], 7) == 0);
   REQUIRE(strncmp("G,<NON_REF>", &alleles[alleles_offsets[6]], 11) == 0);
-  REQUIRE(dp[dp_offsets[6] / sizeof(int32_t)] == 10);
+  REQUIRE(dp[dp_offsets[6]] == 10);
 
   REQUIRE(end_pos[7] == 13544);
   REQUIRE(strncmp("HG00280", &sample_name[sample_name_offsets[7]], 7) == 0);
   REQUIRE(strncmp("G,<NON_REF>", &alleles[alleles_offsets[7]], 11) == 0);
-  REQUIRE(dp[dp_offsets[7] / sizeof(int32_t)] == 6);
+  REQUIRE(dp[dp_offsets[7]] == 6);
 
   REQUIRE(end_pos[8] == 13689);
   REQUIRE(strncmp("HG00280", &sample_name[sample_name_offsets[8]], 7) == 0);
   REQUIRE(strncmp("G,<NON_REF>", &alleles[alleles_offsets[8]], 11) == 0);
-  REQUIRE(dp[dp_offsets[8] / sizeof(int32_t)] == 0);
+  REQUIRE(dp[dp_offsets[8]] == 0);
 
   REQUIRE(end_pos[9] == 17479);
   REQUIRE(strncmp("HG00280", &sample_name[sample_name_offsets[9]], 7) == 0);
   REQUIRE(strncmp("T,<NON_REF>", &alleles[alleles_offsets[9]], 11) == 0);
-  REQUIRE(dp[dp_offsets[9] / sizeof(int32_t)] == 0);
+  REQUIRE(dp[dp_offsets[9]] == 0);
 
   tiledb_vcf_reader_free(&reader);
 }
@@ -1444,17 +1456,25 @@ TEST_CASE(
   tot_num_records += num_records;
 
   // Check a few buffer sizes
-  int64_t buff_size, off_size;
+  int64_t num_offsets, num_data_elements, num_data_bytes;
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "pos_start", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(buff_size == alloced_num_records * sizeof(uint32_t));
-  REQUIRE(off_size == 0);
+          reader,
+          "pos_start",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_data_bytes == alloced_num_records * sizeof(uint32_t));
+  REQUIRE(num_offsets == 0);
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "sample_name", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(buff_size == 14);
-  REQUIRE(off_size == (alloced_num_records + 1) * sizeof(int32_t));
+          reader,
+          "sample_name",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_data_bytes == 14);
+  REQUIRE(num_offsets == (alloced_num_records + 1));
 
   // Check first results
   REQUIRE(start_pos[0] == 12141);
@@ -1513,14 +1533,22 @@ TEST_CASE(
   // Check buffer sizes again
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "pos_start", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(buff_size == alloced_num_records * sizeof(uint32_t));
-  REQUIRE(off_size == 0);
+          reader,
+          "pos_start",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_data_bytes == alloced_num_records * sizeof(uint32_t));
+  REQUIRE(num_offsets == 0);
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "sample_name", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(buff_size == 14);
-  REQUIRE(off_size == (alloced_num_records + 1) * sizeof(int32_t));
+          reader,
+          "sample_name",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_data_bytes == 14);
+  REQUIRE(num_offsets == (alloced_num_records + 1));
 
   // Check next results
   REQUIRE(start_pos[0] == 13354);
@@ -1589,14 +1617,22 @@ TEST_CASE(
   // Check last buffer sizes
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "pos_start", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(buff_size == 1 * sizeof(uint32_t));
-  REQUIRE(off_size == 0);
+          reader,
+          "pos_start",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_data_bytes == 1 * sizeof(uint32_t));
+  REQUIRE(num_offsets == 0);
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "sample_name", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(buff_size == 7);
-  REQUIRE(off_size == 2 * sizeof(int32_t));
+          reader,
+          "sample_name",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_data_bytes == 7);
+  REQUIRE(num_offsets == 2);
 
   // Check resubmit completed query is ok
   REQUIRE(tiledb_vcf_reader_read(reader) == TILEDB_VCF_OK);
@@ -1689,17 +1725,25 @@ TEST_CASE(
   tot_num_records += num_records;
 
   // Check a few buffer sizes
-  int64_t buff_size, off_size;
+  int64_t num_offsets, num_data_elements, num_data_bytes;
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "pos_start", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(buff_size == alloced_num_records * sizeof(uint32_t));
-  REQUIRE(off_size == 0);
+          reader,
+          "pos_start",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_data_bytes == alloced_num_records * sizeof(uint32_t));
+  REQUIRE(num_offsets == 0);
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "sample_name", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(buff_size == 14);
-  REQUIRE(off_size == (alloced_num_records + 1) * sizeof(int32_t));
+          reader,
+          "sample_name",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_data_bytes == 14);
+  REQUIRE(num_offsets == (alloced_num_records + 1));
 
   // Check first results
   REQUIRE(start_pos[0] == 12141);
@@ -1758,14 +1802,22 @@ TEST_CASE(
   // Check buffer sizes again
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "pos_start", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(buff_size == alloced_num_records * sizeof(uint32_t));
-  REQUIRE(off_size == 0);
+          reader,
+          "pos_start",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_data_bytes == alloced_num_records * sizeof(uint32_t));
+  REQUIRE(num_offsets == 0);
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "sample_name", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(buff_size == 14);
-  REQUIRE(off_size == (alloced_num_records + 1) * sizeof(int32_t));
+          reader,
+          "sample_name",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_data_bytes == 14);
+  REQUIRE(num_offsets == (alloced_num_records + 1));
 
   // Check next results
   REQUIRE(start_pos[0] == 13354);
@@ -1840,14 +1892,22 @@ TEST_CASE(
   // Check last buffer sizes
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "pos_start", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(buff_size == 2 * sizeof(uint32_t));
-  REQUIRE(off_size == 0);
+          reader,
+          "pos_start",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_data_bytes == 2 * sizeof(uint32_t));
+  REQUIRE(num_offsets == 0);
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "sample_name", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(buff_size == 14);
-  REQUIRE(off_size == 3 * sizeof(int32_t));
+          reader,
+          "sample_name",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_data_bytes == 14);
+  REQUIRE(num_offsets == 3);
 
   // Check resubmit completed query is ok
   REQUIRE(tiledb_vcf_reader_read(reader) == TILEDB_VCF_OK);
@@ -1975,17 +2035,25 @@ TEST_CASE("C API: Reader submit (max num records)", "[capi][reader]") {
   tot_num_records += num_records;
 
   // Check a few buffer sizes
-  int64_t buff_size, off_size;
+  int64_t num_offsets, num_data_elements, num_data_bytes;
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "pos_start", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(buff_size == alloced_num_records * sizeof(uint32_t));
-  REQUIRE(off_size == 0);
+          reader,
+          "pos_start",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_data_bytes == alloced_num_records * sizeof(uint32_t));
+  REQUIRE(num_offsets == 0);
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "sample_name", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(buff_size == 14);
-  REQUIRE(off_size == (alloced_num_records + 1) * sizeof(int32_t));
+          reader,
+          "sample_name",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_data_bytes == 14);
+  REQUIRE(num_offsets == (alloced_num_records + 1));
 
   // Check first results
   REQUIRE(start_pos[0] == 12141);
@@ -2027,14 +2095,22 @@ TEST_CASE("C API: Reader submit (max num records)", "[capi][reader]") {
   // Check last buffer sizes
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "pos_start", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(buff_size == 1 * sizeof(uint32_t));
-  REQUIRE(off_size == 0);
+          reader,
+          "pos_start",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_data_bytes == 1 * sizeof(uint32_t));
+  REQUIRE(num_offsets == 0);
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "sample_name", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(buff_size == 7);
-  REQUIRE(off_size == 2 * sizeof(int32_t));
+          reader,
+          "sample_name",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_data_bytes == 7);
+  REQUIRE(num_offsets == 2);
 
   // Check resubmit completed query is ok
   REQUIRE(tiledb_vcf_reader_read(reader) == TILEDB_VCF_OK);
@@ -2360,27 +2436,27 @@ TEST_CASE("C API: Reader submit (ranges will overlap)", "[capi][reader]") {
   REQUIRE(end_pos[0] == 13374);
   REQUIRE(strncmp("HG00280", &sample_name[sample_name_offsets[0]], 7) == 0);
   REQUIRE(strncmp("T,<NON_REF>", &alleles[alleles_offsets[0]], 11) == 0);
-  REQUIRE(dp[dp_offsets[0] / sizeof(int32_t)] == 15);
+  REQUIRE(dp[dp_offsets[0]] == 15);
 
   REQUIRE(end_pos[1] == 13389);
   REQUIRE(strncmp("HG01762", &sample_name[sample_name_offsets[1]], 7) == 0);
   REQUIRE(strncmp("T,<NON_REF>", &alleles[alleles_offsets[1]], 11) == 0);
-  REQUIRE(dp[dp_offsets[1] / sizeof(int32_t)] == 64);
+  REQUIRE(dp[dp_offsets[1]] == 64);
 
   REQUIRE(end_pos[2] == 13519);
   REQUIRE(strncmp("HG00280", &sample_name[sample_name_offsets[2]], 7) == 0);
   REQUIRE(strncmp("G,<NON_REF>", &alleles[alleles_offsets[2]], 11) == 0);
-  REQUIRE(dp[dp_offsets[2] / sizeof(int32_t)] == 10);
+  REQUIRE(dp[dp_offsets[2]] == 10);
 
   REQUIRE(end_pos[3] == 13544);
   REQUIRE(strncmp("HG00280", &sample_name[sample_name_offsets[3]], 7) == 0);
   REQUIRE(strncmp("G,<NON_REF>", &alleles[alleles_offsets[3]], 11) == 0);
-  REQUIRE(dp[dp_offsets[3] / sizeof(int32_t)] == 6);
+  REQUIRE(dp[dp_offsets[3]] == 6);
 
   REQUIRE(end_pos[4] == 13689);
   REQUIRE(strncmp("HG00280", &sample_name[sample_name_offsets[4]], 7) == 0);
   REQUIRE(strncmp("G,<NON_REF>", &alleles[alleles_offsets[4]], 11) == 0);
-  REQUIRE(dp[dp_offsets[4] / sizeof(int32_t)] == 0);
+  REQUIRE(dp[dp_offsets[4]] == 0);
 
   tiledb_vcf_reader_free(&reader);
 }
@@ -2449,21 +2525,29 @@ TEST_CASE(
   REQUIRE(status == TILEDB_VCF_INCOMPLETE);
 
   // Check result size
-  int64_t off_size = 0, buff_size = 0;
+  int64_t num_offsets, num_data_elements, num_data_bytes;
   REQUIRE(
       tiledb_vcf_reader_get_result_num_records(reader, &num_records) ==
       TILEDB_VCF_OK);
   REQUIRE(num_records == 1);
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "sample_name", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(off_size == 2 * sizeof(int32_t));
-  REQUIRE(buff_size == 7);
+          reader,
+          "sample_name",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_offsets == 2);
+  REQUIRE(num_data_bytes == 7);
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "contig", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(off_size == 2 * sizeof(int32_t));
-  REQUIRE(buff_size == 1);
+          reader,
+          "contig",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_offsets == 2);
+  REQUIRE(num_data_bytes == 1);
 
   // Resubmit query
   REQUIRE(tiledb_vcf_reader_read(reader) == TILEDB_VCF_OK);
@@ -2475,14 +2559,22 @@ TEST_CASE(
   REQUIRE(num_records == 1);
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "sample_name", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(off_size == 2 * sizeof(int32_t));
-  REQUIRE(buff_size == 7);
+          reader,
+          "sample_name",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_offsets == 2);
+  REQUIRE(num_data_bytes == 7);
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "contig", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(off_size == 2 * sizeof(int32_t));
-  REQUIRE(buff_size == 1);
+          reader,
+          "contig",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_offsets == 2);
+  REQUIRE(num_data_bytes == 1);
 
   // Resubmit query
   REQUIRE(tiledb_vcf_reader_read(reader) == TILEDB_VCF_OK);
@@ -2494,14 +2586,22 @@ TEST_CASE(
   REQUIRE(num_records == 1);
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "sample_name", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(off_size == 2 * sizeof(int32_t));
-  REQUIRE(buff_size == 7);
+          reader,
+          "sample_name",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_offsets == 2);
+  REQUIRE(num_data_bytes == 7);
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "contig", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(off_size == 2 * sizeof(int32_t));
-  REQUIRE(buff_size == 1);
+          reader,
+          "contig",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_offsets == 2);
+  REQUIRE(num_data_bytes == 1);
 
   // Resubmit query
   REQUIRE(tiledb_vcf_reader_read(reader) == TILEDB_VCF_OK);
@@ -2513,14 +2613,22 @@ TEST_CASE(
   REQUIRE(num_records == 1);
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "sample_name", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(off_size == 2 * sizeof(int32_t));
-  REQUIRE(buff_size == 7);
+          reader,
+          "sample_name",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_offsets == 2);
+  REQUIRE(num_data_bytes == 7);
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "contig", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(off_size == 2 * sizeof(int32_t));
-  REQUIRE(buff_size == 1);
+          reader,
+          "contig",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_offsets == 2);
+  REQUIRE(num_data_bytes == 1);
 
   // Resubmit query
   REQUIRE(tiledb_vcf_reader_read(reader) == TILEDB_VCF_OK);
@@ -2532,14 +2640,22 @@ TEST_CASE(
   REQUIRE(num_records == 1);
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "sample_name", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(off_size == 2 * sizeof(int32_t));
-  REQUIRE(buff_size == 7);
+          reader,
+          "sample_name",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_offsets == 2);
+  REQUIRE(num_data_bytes == 7);
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "contig", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(off_size == 2 * sizeof(int32_t));
-  REQUIRE(buff_size == 1);
+          reader,
+          "contig",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_offsets == 2);
+  REQUIRE(num_data_bytes == 1);
 
   // Resubmit query
   REQUIRE(tiledb_vcf_reader_read(reader) == TILEDB_VCF_OK);
@@ -2551,14 +2667,22 @@ TEST_CASE(
   REQUIRE(num_records == 1);
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "sample_name", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(off_size == 2 * sizeof(int32_t));
-  REQUIRE(buff_size == 7);
+          reader,
+          "sample_name",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_offsets == 2);
+  REQUIRE(num_data_bytes == 7);
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "contig", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(off_size == 2 * sizeof(int32_t));
-  REQUIRE(buff_size == 1);
+          reader,
+          "contig",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_offsets == 2);
+  REQUIRE(num_data_bytes == 1);
 
   // Resubmit query
   REQUIRE(tiledb_vcf_reader_read(reader) == TILEDB_VCF_OK);
@@ -2570,14 +2694,22 @@ TEST_CASE(
   REQUIRE(num_records == 1);
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "sample_name", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(off_size == 2 * sizeof(int32_t));
-  REQUIRE(buff_size == 7);
+          reader,
+          "sample_name",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_offsets == 2);
+  REQUIRE(num_data_bytes == 7);
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "contig", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(off_size == 2 * sizeof(int32_t));
-  REQUIRE(buff_size == 1);
+          reader,
+          "contig",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_offsets == 2);
+  REQUIRE(num_data_bytes == 1);
 
   // Resubmit query
   REQUIRE(tiledb_vcf_reader_read(reader) == TILEDB_VCF_OK);
@@ -2589,14 +2721,22 @@ TEST_CASE(
   REQUIRE(num_records == 1);
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "sample_name", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(off_size == 2 * sizeof(int32_t));
-  REQUIRE(buff_size == 7);
+          reader,
+          "sample_name",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_offsets == 2);
+  REQUIRE(num_data_bytes == 7);
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "contig", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(off_size == 2 * sizeof(int32_t));
-  REQUIRE(buff_size == 1);
+          reader,
+          "contig",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_offsets == 2);
+  REQUIRE(num_data_bytes == 1);
 
   // Resubmit query
   REQUIRE(tiledb_vcf_reader_read(reader) == TILEDB_VCF_OK);
@@ -2608,14 +2748,22 @@ TEST_CASE(
   REQUIRE(num_records == 1);
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "sample_name", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(off_size == 2 * sizeof(int32_t));
-  REQUIRE(buff_size == 7);
+          reader,
+          "sample_name",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_offsets == 2);
+  REQUIRE(num_data_bytes == 7);
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "contig", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(off_size == 2 * sizeof(int32_t));
-  REQUIRE(buff_size == 1);
+          reader,
+          "contig",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_offsets == 2);
+  REQUIRE(num_data_bytes == 1);
 
   // Resubmit query
   REQUIRE(tiledb_vcf_reader_read(reader) == TILEDB_VCF_OK);
@@ -2627,14 +2775,22 @@ TEST_CASE(
   REQUIRE(num_records == 1);
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "sample_name", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(off_size == 2 * sizeof(int32_t));
-  REQUIRE(buff_size == 7);
+          reader,
+          "sample_name",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_offsets == 2);
+  REQUIRE(num_data_bytes == 7);
   REQUIRE(
       tiledb_vcf_reader_get_result_size(
-          reader, "contig", &off_size, &buff_size) == TILEDB_VCF_OK);
-  REQUIRE(off_size == 2 * sizeof(int32_t));
-  REQUIRE(buff_size == 1);
+          reader,
+          "contig",
+          &num_offsets,
+          &num_data_elements,
+          &num_data_bytes) == TILEDB_VCF_OK);
+  REQUIRE(num_offsets == 2);
+  REQUIRE(num_data_bytes == 1);
 
   tiledb_vcf_reader_free(&reader);
 }


### PR DESCRIPTION
Arrow's offset representation is the number of *elements*, not bytes. This change incorporates that, and adds a Python test that used to expose the bug when reading var-len attributes.