### PR TITLE
Config option

### DIFF
--- a/python-api/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/python-api/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -22,6 +22,7 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("set_samples_file", &Reader::set_samples_file)
       .def("set_regions", &Reader::set_regions)
       .def("set_bed_file", &Reader::set_bed_file)
+      .def("set_sort_regions", &Reader::set_sort_regions)
       .def("set_region_partition", &Reader::set_region_partition)
       .def("set_sample_partition", &Reader::set_sample_partition)
       .def("set_memory_budget", &Reader::set_memory_budget)

--- a/python-api/src/tiledbvcf/binding/reader.cc
+++ b/python-api/src/tiledbvcf/binding/reader.cc
@@ -121,6 +121,12 @@ void Reader::set_memory_budget(int32_t memory_mb) {
   check_error(reader, tiledb_vcf_reader_set_memory_budget(reader, memory_mb));
 }
 
+void Reader::set_sort_regions(bool sort_regions) {
+  auto reader = ptr.get();
+  check_error(
+      reader, tiledb_vcf_reader_set_sort_regions(reader, sort_regions ? 1 : 0));
+}
+
 void Reader::set_max_num_records(int64_t max_num_records) {
   auto reader = ptr.get();
   check_error(

--- a/python-api/src/tiledbvcf/binding/reader.h
+++ b/python-api/src/tiledbvcf/binding/reader.h
@@ -76,6 +76,9 @@ class Reader {
   /** Sets the sample partition of this reader. */
   void set_sample_partition(int32_t partition, int32_t num_partitions);
 
+  /** Sets the sort regions parameter of this reader. */
+  void set_sort_regions(bool sort_regions);
+
   /** Sets the internal memory budget for the TileDB-VCF library. */
   void set_memory_budget(int32_t memory_mb);
 

--- a/python-api/src/tiledbvcf/dataset.py
+++ b/python-api/src/tiledbvcf/dataset.py
@@ -10,13 +10,15 @@ ReadConfig = namedtuple('ReadConfig', [
     'region_partition',
     # Samples partition tuple (idx, num_partitions)
     'sample_partition',
+    # Whether or not to sort the regions to be read (default True)
+    'sort_regions',
     # Allocation size of Python attribute buffers (default 100MB/attribute)
     'attribute_buffer_mb',
     # Allocation size of TileDB-VCF internal attribute buffers (default 200MB/attribute)
     'internal_memory_budget',
     # List of strings of format 'option=value'
     'tiledb_config'
-], defaults=[None] * 6)
+], defaults=[None] * 7)
 
 
 class TileDBVCFDataset(object):
@@ -51,6 +53,8 @@ class TileDBVCFDataset(object):
             self.reader.set_region_partition(*cfg.region_partition)
         if cfg.sample_partition is not None:
             self.reader.set_sample_partition(*cfg.sample_partition)
+        if cfg.sort_regions is not None:
+            self.reader.set_sort_regions(cfg.sort_regions)
         if cfg.attribute_buffer_mb is not None:
             self.reader.set_buffer_alloc_size(cfg.attribute_buffer_mb)
         if cfg.internal_memory_budget is not None:

--- a/src/c_api/tiledbvcf.cc
+++ b/src/c_api/tiledbvcf.cc
@@ -230,6 +230,18 @@ int32_t tiledb_vcf_reader_set_regions(
   return TILEDB_VCF_OK;
 }
 
+int32_t tiledb_vcf_reader_set_sort_regions(
+    tiledb_vcf_reader_t* reader, int32_t sort_regions) {
+  if (sanity_check(reader) == TILEDB_VCF_ERR)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          reader, reader->reader_->set_sort_regions(sort_regions == 1)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
 int32_t tiledb_vcf_reader_set_region_partition(
     tiledb_vcf_reader_t* reader, int32_t partition, int32_t num_partitions) {
   if (sanity_check(reader) == TILEDB_VCF_ERR)

--- a/src/c_api/tiledbvcf.h
+++ b/src/c_api/tiledbvcf.h
@@ -167,6 +167,18 @@ TILEDBVCF_EXPORT int32_t
 tiledb_vcf_reader_set_regions(tiledb_vcf_reader_t* reader, const char* regions);
 
 /**
+ * Sets whether or not to sort the regions to be read. You can disable region
+ * sorting if you are certain that the BED file being used is already sorted.
+ *
+ * @param reader VCF reader object
+ * @param sort_regions If `1`, regions will be sorted (the default). If `0`,
+ *      region sorting is disabled.
+ * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
+ */
+TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_set_sort_regions(
+    tiledb_vcf_reader_t* reader, int32_t sort_regions);
+
+/**
  * Sets the region partitioning info for the reader. The partitioning divides
  * the reader genomic regions (e.g. the BED ranges) according to a simple block
  * distribution.

--- a/src/read/reader.cc
+++ b/src/read/reader.cc
@@ -64,6 +64,10 @@ void Reader::set_regions(const std::string& regions) {
   params_.regions = utils::split(regions, ',');
 }
 
+void Reader::set_sort_regions(bool sort_regions) {
+  params_.sort_regions = sort_regions;
+}
+
 void Reader::set_samples_file(const std::string& uri) {
   if (!vfs_->is_file(uri))
     throw std::runtime_error(
@@ -751,7 +755,8 @@ void Reader::prepare_regions(
     *regions = dataset_->all_contigs();
 
   // Sort all by global column coord.
-  Region::sort(dataset_->metadata().contig_offsets, regions);
+  if (params_.sort_regions)
+    Region::sort(dataset_->metadata().contig_offsets, regions);
 
   // Apply region partitioning before expanding.
   utils::partition_vector(

--- a/src/read/reader.h
+++ b/src/read/reader.h
@@ -75,6 +75,7 @@ struct ExportParams {
   bool verbose = false;
   bool export_to_disk = false;
   bool cli_count_only = false;
+  bool sort_regions = true;
   uint64_t max_num_records = std::numeric_limits<uint64_t>::max();
   std::vector<std::string> tiledb_config;
 
@@ -120,6 +121,9 @@ class Reader {
 
   /** Sets the regions list parameter. */
   void set_regions(const std::string& regions);
+
+  /** Sets the sort regionsparameter. */
+  void set_sort_regions(bool sort_regions);
 
   /** Sets the samples file URI parameter. */
   void set_samples_file(const std::string& uri);


### PR DESCRIPTION
Sorting BED files can be expensive so we need an option to skip it if we know the BED file is already sorted.