### PR TITLE
Set TileDB config before initializing the dataset.

### DIFF
--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -34,6 +34,12 @@ class TileDBVCFDataset(object):
         self.cfg = cfg
         if self.mode == 'r':
             self.reader = libtiledbvcf.Reader()
+
+            # TileDB config needs to be set first in case TBB threads are
+            # specified.
+            if cfg is not None and cfg.tiledb_config is not None:
+                self.reader.set_tiledb_config(','.join(cfg.tiledb_config))
+
             self.reader.init(uri)
             self._set_read_cfg(cfg)
         elif self.mode == 'w':
@@ -45,6 +51,9 @@ class TileDBVCFDataset(object):
             raise Exception('Unsupported dataset mode {}'.format(mode))
 
     def _set_read_cfg(self, cfg):
+        """Sets reader options based on the given config.
+
+        Note: cfg.tiledb_config is not handled here; set that separately."""
         if cfg is None:
             return
         if cfg.limit is not None:
@@ -57,8 +66,6 @@ class TileDBVCFDataset(object):
             self.reader.set_sort_regions(cfg.sort_regions)
         if cfg.memory_budget_mb is not None:
             self.reader.set_memory_budget(cfg.memory_budget_mb)
-        if cfg.tiledb_config is not None:
-            self.reader.set_tiledb_config(','.join(cfg.tiledb_config))
 
     def read(self, attrs, samples=None, regions=None, samples_file=None,
              bed_file=None):

--- a/apis/spark/src/main/java/io/tiledb/libvcfnative/VCFReader.java
+++ b/apis/spark/src/main/java/io/tiledb/libvcfnative/VCFReader.java
@@ -65,16 +65,7 @@ public class VCFReader implements AutoCloseable {
       throw new RuntimeException("Error allocating reader object");
     }
 
-    rc = LibVCFNative.tiledb_vcf_reader_init(readerPtrArray[0], uri);
-    if (rc != 0) {
-      String msg = getLastErrorMessage();
-      LibVCFNative.tiledb_vcf_reader_free(readerPtrArray[0]);
-      if (msg == null) {
-        msg = "";
-      }
-      throw new RuntimeException("Error initializing reader object: " + msg);
-    }
-
+    // Setting TileDB config needs to come first in case the user is changing TBB thread count.
     if (config.isPresent()) {
       rc = LibVCFNative.tiledb_vcf_reader_set_tiledb_config(readerPtrArray[0], config.get());
       if (rc != 0) {
@@ -85,6 +76,16 @@ public class VCFReader implements AutoCloseable {
         }
         throw new RuntimeException("Error setting TileDB config options on reader object: " + msg);
       }
+    }
+
+    rc = LibVCFNative.tiledb_vcf_reader_init(readerPtrArray[0], uri);
+    if (rc != 0) {
+      String msg = getLastErrorMessage();
+      LibVCFNative.tiledb_vcf_reader_free(readerPtrArray[0]);
+      if (msg == null) {
+        msg = "";
+      }
+      throw new RuntimeException("Error initializing reader object: " + msg);
     }
 
     if (samples.length > 0) {

--- a/libtiledbvcf/src/c_api/tiledbvcf.h
+++ b/libtiledbvcf/src/c_api/tiledbvcf.h
@@ -529,6 +529,10 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_set_max_num_records(
  * The string should be of the format: "sm.option1=1000,sm.option2=baz,..."
  * with multiple TileDB config params separated by commas.
  *
+ * **Note**: if using this to change the number of TBB threads, you must call
+ * this function before any others (including `tiledb_vcf_reader_init()`) to
+ * avoid errors initializing TBB.
+ *
  * @param reader VCF reader object
  * @param config CSV string of TileDB config param values.
  * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.


### PR DESCRIPTION
This is only needed to allow users to override the num TBB config setting.