### PR TITLE
Don't set full version of libtiledb soname

### DIFF
--- a/apis/spark/src/main/java/io/tiledb/libvcfnative/NativeLibLoader.java
+++ b/apis/spark/src/main/java/io/tiledb/libvcfnative/NativeLibLoader.java
@@ -41,7 +41,7 @@ public class NativeLibLoader {
   /** Finds and loads native TileDB. */
   static void loadNativeTileDB() {
     String os = getOSClassifier();
-    String versionedLibName = os.startsWith("osx") ? "libtiledb.dylib" : "libtiledb.so.1.6.2";
+    String versionedLibName = os.startsWith("osx") ? "libtiledb.dylib" : "libtiledb.so";
     try {
       // Don't use name mapping to get the versioned tiledb
       loadNativeLib(versionedLibName, false);


### PR DESCRIPTION
We should not be hard coding the full soname version for libtiledb in native loader.