### PR TITLE
Update Native Loader for TileDB 1.7 usage

### DIFF
--- a/apis/spark/src/main/java/io/tiledb/libvcfnative/NativeLibLoader.java
+++ b/apis/spark/src/main/java/io/tiledb/libvcfnative/NativeLibLoader.java
@@ -41,7 +41,7 @@ public class NativeLibLoader {
   /** Finds and loads native TileDB. */
   static void loadNativeTileDB() {
     String os = getOSClassifier();
-    String versionedLibName = os.startsWith("osx") ? "libtiledb.dylib" : "libtiledb.so.1.6.2";
+    String versionedLibName = os.startsWith("osx") ? "libtiledb.dylib" : "libtiledb.so.1.7";
     try {
       // Don't use name mapping to get the versioned tiledb
       loadNativeLib(versionedLibName, false);


### PR DESCRIPTION
Update Native Loader for TileDB 1.7 usage. I'm still checking on #44 , but this is needed at a minimum now that this is building with 1.7, as `libtiledb.so.1.7` is what is included in the jar.

```
unzip -l build/libs/TileDB-VCF-Spark-0.1.0-SNAPSHOT.jar 
Archive:  build/libs/TileDB-VCF-Spark-0.1.0-SNAPSHOT.jar
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  2019-12-10 17:05   META-INF/
       25  2019-12-10 17:05   META-INF/MANIFEST.MF
        0  2019-12-10 17:05   io/
        0  2019-12-10 17:05   io/tiledb/
        0  2019-12-10 17:05   io/tiledb/vcf/
     1457  2019-12-10 17:05   io/tiledb/vcf/VCFInfoFmtUDF.class
      601  2019-12-10 17:05   io/tiledb/vcf/VCFPartitionInfo.class
     5242  2019-12-10 17:05   io/tiledb/vcf/VCFSparkSchema.class
    15025  2019-12-10 17:05   io/tiledb/vcf/VCFInputPartitionReader.class
     2444  2019-12-10 17:05   io/tiledb/vcf/VCFDataSource.class
     6565  2019-12-10 17:05   io/tiledb/vcf/VCFDataSourceReader.class
     2562  2019-12-10 17:05   io/tiledb/vcf/VCFInfoFmtDecoder.class
      303  2019-12-10 17:05   io/tiledb/vcf/DefaultSource.class
      975  2019-12-10 17:05   io/tiledb/vcf/VCFInputPartitionReader$1.class
     2324  2019-12-10 17:05   io/tiledb/vcf/VCFInputPartition.class
     4860  2019-12-10 17:05   io/tiledb/vcf/VCFDataSourceOptions.class
        0  2019-12-10 17:05   io/tiledb/libvcfnative/
     7917  2019-12-10 17:05   io/tiledb/libvcfnative/NativeLibLoader.class
    11714  2019-12-10 17:05   io/tiledb/libvcfnative/VCFReader.class
      938  2019-12-10 17:05   io/tiledb/libvcfnative/VCFReader$AttributeTypeInfo.class
     2218  2019-12-10 17:05   io/tiledb/libvcfnative/LibVCFNative.class
     1251  2019-12-10 17:05   io/tiledb/libvcfnative/VCFReader$Status.class
     1311  2019-12-10 17:05   io/tiledb/libvcfnative/VCFReader$AttributeDatatype.class
      815  2019-12-10 17:05   io/tiledb/libvcfnative/VCFReader$BufferInfo.class
        0  2019-12-10 17:05   lib/
 17204400  2019-12-10 17:05   lib/libtiledb.so.1.7
  3072016  2019-12-10 17:05   lib/libhts.so.1.8
    24448  2019-12-10 17:05   lib/libtiledbvcfjni.so
   929816  2019-12-10 17:05   lib/libtiledbvcf.so
```