### PR TITLE
Support reads from cloud register datasets

### DIFF
--- a/libtiledbvcf/src/c_api/arrow.h
+++ b/libtiledbvcf/src/c_api/arrow.h
@@ -289,8 +289,8 @@ class Arrow {
 
     std::shared_ptr<arrow::Buffer> arrow_nulls;
     if (buffer_info.nullable)
-      arrow_nulls = arrow::Buffer::Wrap(
-          buffer_info.bitmap_buff, ceil(num_records, 8));
+      arrow_nulls =
+          arrow::Buffer::Wrap(buffer_info.bitmap_buff, ceil(num_records, 8));
 
     if (buffer_info.list) {
       // List of var-len char attribute.
@@ -329,8 +329,8 @@ class Arrow {
 
     std::shared_ptr<arrow::Buffer> arrow_nulls;
     if (buffer_info.nullable)
-      arrow_nulls = arrow::Buffer::Wrap(
-          buffer_info.bitmap_buff, ceil(num_records, 8));
+      arrow_nulls =
+          arrow::Buffer::Wrap(buffer_info.bitmap_buff, ceil(num_records, 8));
 
     std::shared_ptr<arrow::Array> values_array(
         new ArrayT(num_data_elements, arrow_values));

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -323,10 +323,15 @@ class TileDBVCFDataset {
       std::map<uint32_t, std::string>* sample_headers);
 
   /** Returns the URI of the sample data array for the dataset. */
-  static std::string data_array_uri(const std::string& root_uri);
+  static std::string data_array_uri(
+      const std::string& root_uri, bool check_for_cloud = true);
 
   /** Returns the URI of the VCF header data array for the dataset. */
-  static std::string vcf_headers_uri(const std::string& root_uri);
+  static std::string vcf_headers_uri(
+      const std::string& root_uri, bool check_for_cloud = true);
+
+  /** Returns true if the array starts with the tiledb:// URI **/
+  static bool cloud_dataset(std::string root_uri);
 
   /* ********************************* */
   /*          PRIVATE METHODS          */

--- a/libtiledbvcf/src/utils/utils.cc
+++ b/libtiledbvcf/src/utils/utils.cc
@@ -111,10 +111,11 @@ std::string uri_filename(const std::string& uri) {
   return path_parts.back();
 }
 
-std::string uri_join(const std::string& dir, const std::string& filename) {
+std::string uri_join(
+    const std::string& dir, const std::string& filename, const char delimiter) {
   std::string result = dir;
-  if (!ends_with(result, "/") && !result.empty())
-    result += "/";
+  if (!ends_with(result, std::string(1, delimiter)) && !result.empty())
+    result += delimiter;
   result += filename;
   return result;
 }

--- a/libtiledbvcf/src/utils/utils.h
+++ b/libtiledbvcf/src/utils/utils.h
@@ -239,7 +239,10 @@ std::string uri_filename(const std::string& uri);
 /**
  * Joins a filename to a directory URI (adds a '/' between them).
  */
-std::string uri_join(const std::string& dir, const std::string& filename);
+std::string uri_join(
+    const std::string& dir,
+    const std::string& filename,
+    const char delimiter = '/');
 
 /**
  * Downloads a file to local storage.


### PR DESCRIPTION
This PR is not ideal but is required for better cloud array support until TileDB Cloud supports proper groups.

The two arrays that make up a TileDBVCF dataset must be register with the same base path and then their sub-directories using "-" in place of "/".

That is a dataset with a base URI of
`s3://mybucket/vcf-samples-20`

and the arrays are actually located at:
`s3://mybucket/vcf-samples-20/data`
`s3://mybucket/vcf-samples-20/metadata/vcf_headers`

yields the following two registration names in the cloud service:

`tiledb://namespace/vcf-samples-20-data`
`tiledb://namespace/vcf-samples-20-metadata-vcf_headers`