### PR TITLE
Fix build errors w/ -Wall

### DIFF
--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -438,7 +438,11 @@ std::vector<SafeBCFHdr> TileDBVCFDataset::fetch_vcf_headers(
           "Error fetching VCF header data; error allocating VCF header.");
     bcf_hdr_parse(hdr, const_cast<char*>(header_str.c_str()));
     bcf_hdr_add_sample(hdr, metadata_.sample_names.at(i).c_str());
-    bcf_hdr_sync(hdr);
+
+    if (bcf_hdr_sync(hdr) < 0)
+      throw std::runtime_error(
+          "Error in bcftools: failed to update VCF header.");
+
     result.emplace_back(hdr, bcf_hdr_destroy);
   }
 

--- a/libtiledbvcf/src/vcf/vcf.cc
+++ b/libtiledbvcf/src/vcf/vcf.cc
@@ -367,7 +367,20 @@ std::string VCF::hdr_to_string(bcf_hdr_t* hdr) {
         "Cannot convert header to string; bad VCF header.");
   kstring_t t = {0, 0, 0};
   auto tmp = bcf_hdr_dup(hdr);
-  bcf_hdr_set_samples(tmp, 0, 0);
+
+  int res = 0;
+  res = bcf_hdr_set_samples(tmp, 0, 0);
+  if (res != 0) {
+    if (res == -1) {
+      throw std::invalid_argument(
+        "Cannot set VCF samples; possibly bad VCF header.");
+    } else if (res > 0) {
+      throw std::runtime_error(
+        std::string("Cannot set VCF samples: list contains samples not present in VCF header, sample #:") +
+        std::to_string(res)
+      );
+    }
+  }
   bcf_hdr_format(tmp, 0, &t);
   std::string ret(t.s, t.l);
   bcf_hdr_destroy(tmp);


### PR DESCRIPTION
Check return values for several more functions. HTSLIB sets '__attribute__((warn_unused_result))' on these functions, which leads to a build error for the existing code under conda's GCC.