### PR TITLE
Batches need to not cross tile boundaries

### DIFF
--- a/libtiledbvcf/src/utils/sample_utils.cc
+++ b/libtiledbvcf/src/utils/sample_utils.cc
@@ -147,5 +147,29 @@ std::vector<SampleAndIndex> SampleUtils::build_samples_uri_list(
   return result;
 }
 
+std::vector<std::vector<SampleAndIndex>> batch_elements_by_tile(
+    const std::vector<SampleAndIndex>& vec, uint64_t tile_size) {
+  std::vector<std::vector<SampleAndIndex>> result;
+  std::vector<SampleAndIndex> batch;
+  // Set last seen tile extent to max, as an initialized value
+  uint32_t last_seen_tile_extent = std::numeric_limits<uint32_t>::max();
+  for (unsigned vec_idx = 0; vec_idx < vec.size(); vec_idx++) {
+    auto sample = vec[vec_idx];
+    // When batching we must include samples only in the same tile extent
+    if (last_seen_tile_extent != sample.sample_id / tile_size) {
+      // reset last_seen_tile_extent
+      last_seen_tile_extent = sample.sample_id / tile_size;
+      result.emplace_back(batch);
+      batch = std::vector<SampleAndIndex>();
+    }
+    batch.push_back(vec[vec_idx]);
+  }
+  // Add last batch if it exists
+  if (!batch.empty())
+    result.push_back(batch);
+
+  return result;
+}
+
 }  // namespace vcf
 }  // namespace tiledb

--- a/libtiledbvcf/src/utils/sample_utils.h
+++ b/libtiledbvcf/src/utils/sample_utils.h
@@ -66,6 +66,7 @@ struct ScratchSpaceInfo {
 struct SampleAndIndex {
   std::string sample_uri;
   std::string index_uri;
+  uint32_t sample_id;
 };
 
 /** Pair of sample name and ID (row coord). */
@@ -226,6 +227,23 @@ class SampleUtils {
     return result;
   }
 };
+
+/**
+ * Batches the given vector into a vector of vectors based on the tile_size .
+ * Ideally the vectors will be fixed (even) sized. However if the sample ids
+ * cross tile extents we must stop the batch as we can not load across tile
+ * extents.
+ *
+ * In the worst case, if a user tried to load multiple samples but all from
+ * unique tile extents this will devolve into single sample batches
+ *
+ *
+ * @param vec Vector to batch
+ * @param batch_size Number of elements per tile extent
+ * @return Batched result
+ */
+std::vector<std::vector<SampleAndIndex>> batch_elements_by_tile(
+    const std::vector<SampleAndIndex>& vec, uint64_t tile_size);
 
 }  // namespace vcf
 }  // namespace tiledb

--- a/libtiledbvcf/src/utils/utils.h
+++ b/libtiledbvcf/src/utils/utils.h
@@ -38,6 +38,7 @@
 
 namespace tiledb {
 namespace vcf {
+
 namespace utils {
 
 /** Commit hash of TileDB-VCF (#defined by CMake) */

--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -105,7 +105,7 @@ void Writer::ingest_samples() {
 
   // Batch the list of samples per space tile.
   auto batches =
-      utils::batch_elements(samples, dataset.metadata().row_tile_extent);
+      batch_elements_by_tile(samples, dataset.metadata().row_tile_extent);
 
   // Set up parameters for two scratch spaces.
   const auto scratch_size_mb = ingestion_params_.scratch_space.size_mb / 2;
@@ -315,8 +315,12 @@ std::vector<SampleAndIndex> Writer::prepare_sample_list(
       });
 
   std::vector<SampleAndIndex> result;
-  for (const auto& pair : sorted)
-    result.push_back(pair.first);
+  // Set sample id for later use
+  for (const auto& pair : sorted) {
+    auto s = pair.first;
+    s.sample_id = dataset.metadata().sample_ids.at(pair.second);
+    result.push_back(s);
+  }
 
   return result;
 }


### PR DESCRIPTION
Previously we batched on tile size but did not check tile boundaries. This led to cases where we tried to load across the tile extent and caused a ordering problem with global order writes.

The new batching can lead to degraded performance if a user issues a store request in which the samples all fall onto individual tile extents. The decision was made to be robust and support loading in this case, and to instruct users ahead of time for best performance to load batches that align with complete tile extents (10 samples).