### PR TITLE
More conda build fixes

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -9,7 +9,7 @@ jobs:
   strategy:
     matrix:
       ubuntu_16:
-        imageName: 'ubuntu-16.04'
+        imageName: 'ubuntu-18.04'
         python.version: '3.x'
         CXX: g++
         BUILD_PYTHON_API: ON

--- a/apis/python/conda-env.yml
+++ b/apis/python/conda-env.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python>=3.4
   - pybind11=2.3.0
-  - pyarrow=0.14.1
+  - pyarrow>=0.16.0
   - dask>=0.19.0
   - pip
   - pip:

--- a/ci/azure-linux_mac.yml
+++ b/ci/azure-linux_mac.yml
@@ -37,9 +37,6 @@ steps:
   displayName: 'Install dependencies'
 
 - bash: |
-    # DELETEME work-around for https://github.com/microsoft/azure-pipelines-image-generation/issues/969
-    sudo chown root.root /
-
     # azure bash does not treat intermediate failure as error
     # https://github.com/Microsoft/azure-pipelines-yaml/issues/135
     set -e pipefail
@@ -61,12 +58,12 @@ steps:
     make check
     ../test/run-cli-tests.sh . ../test/inputs
 
-    sudo make install-libtiledbvcf
+    make install-libtiledbvcf
 
   displayName: 'Build and test TileDB-VCF'
 
 - bash: |
-    set -e pipefail
+    set -ex pipefail
 
     if [[ "$BUILD_PYTHON_API" == "ON" ]]; then
       # Add conda to PATH


### PR DESCRIPTION
- Get libtiledbvcf from environment (PREFIX) if available
- Use -g and -O0 with debug option
- Don't overlink the arrow core library
- Bump the pyarrow minimum version to fix test errors