### PR TITLE
Add destructor for reader

### DIFF
--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -39,6 +39,16 @@ namespace vcf {
 Reader::Reader() {
 }
 
+Reader::~Reader() {
+  if (read_state_.async_query.valid()) {
+    // We must wait for the inflight query to finish before we destroy
+    // everything. If we don't its possible to delete the buffers in the middle
+    // of an active query
+    ctx_->cancel_tasks();
+    read_state_.async_query.wait();
+  }
+}
+
 void Reader::open_dataset(const std::string& dataset_uri) {
   init_tiledb();
 

--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -105,6 +105,9 @@ class Reader {
   /** Constructor. */
   Reader();
 
+  /** Destructor. */
+  ~Reader();
+
   /** Unimplemented rule-of-5. */
   Reader(Reader&&) = delete;
   Reader(const Reader&) = delete;


### PR DESCRIPTION
In the destructor we only make sure any async queries that are active finish before allow everything to be cleaned up. This prevent deleting the attribute/coords buffers from an active tiledb query.