### PR TITLE
Filter contigs for read to nonEmptyDomain

### DIFF
--- a/apis/python/tests/test_tiledbvcf.py
+++ b/apis/python/tests/test_tiledbvcf.py
@@ -358,12 +358,12 @@ def test_region_partitioned_read():
                  regions=['1:12000-13000', '1:17000-18000'])
     assert len(df) == 2
 
-    # Error: too many partitions
+    # Too many partitions still produces results
     cfg = tiledbvcf.ReadConfig(region_partition=(1, 3))
     ds = tiledbvcf.TileDBVCFDataset(uri, mode='r', cfg=cfg)
-    with pytest.raises(RuntimeError):
-        df = ds.read(attrs=['sample_name', 'pos_start', 'pos_end'],
-                     regions=['1:12000-13000', '1:17000-18000'])
+    df = ds.read(attrs=['sample_name', 'pos_start', 'pos_end'],
+                 regions=['1:12000-13000', '1:17000-18000'])
+    assert len(df) == 2
 
     # Error: index >= num partitions
     cfg = tiledbvcf.ReadConfig(region_partition=(2, 2))


### PR DESCRIPTION
This is an optimization for more efficient partitioning to limit the regions to those that are within or contain the nonEmptyDomain. This allows for more balanced partitioning by discarding regions which are known to have no results.