### PR TITLE
Determine native libtiledb library in TileDB [ch1703]

### DIFF
--- a/apis/spark/src/main/java/io/tiledb/libvcfnative/NativeLibLoader.java
+++ b/apis/spark/src/main/java/io/tiledb/libvcfnative/NativeLibLoader.java
@@ -371,7 +371,10 @@ public class NativeLibLoader {
       System.loadLibrary(mapLibraryName ? System.mapLibraryName(libraryName) : libraryName);
     }
   }
-
+  /**
+   * Extracts the versioned libtiledb library name
+   * @return The library name
+   */
   private static String getVersionedName() throws IOException {
     URL jarLocation = NativeLibLoader.class.getProtectionDomain().getCodeSource().getLocation();
     ZipInputStream zipInputStream = new ZipInputStream(jarLocation.openStream());


### PR DESCRIPTION
This PR contains the changes required for the determination of the exact versioned name of the `libtiledb.so`. Tested both on OSX and Ubuntu.

ClubHouse Link: https://app.clubhouse.io/tiledb-inc/story/1703/determine-native-libtiledb-library-in-tiledb-vcf