### PR TITLE
Reset current buffer sizes only in read

### DIFF
--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -268,6 +268,13 @@ void Reader::read() {
       break;
   }
 
+  // If we are using the InMemoryExporter we need to reset the user buffer
+  // sizes at the start of each query
+  if (!params_.export_to_disk && exporter_ != nullptr) {
+    auto exp = dynamic_cast<InMemoryExporter*>(exporter_.get());
+    exp->reset_current_sizes();
+  }
+
   while (pending_work) {
     bool complete = read_current_batch();
     if (!complete) {
@@ -416,7 +423,6 @@ bool Reader::read_current_batch() {
 
     // If the read status was incomplete, pick up processing the previous TileDB
     // query results.
-    exp->reset_current_sizes();
     if (!process_query_results())
       return false;  // Still incomplete.
 


### PR DESCRIPTION
Resetting these in read_current_batch causes results to be overridden if we hit a case where the TileDB query is completed but the vcf read is not AND the user's buffers are not filled. In that cases we previously would (correctly) start a new TileDB query but incorrectly reset the buffers, thus overriding the last bit of results from the previously completed TileDB query.