### PR TITLE
Add checksum filter support

### DIFF
--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -40,6 +40,7 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("init", &Writer::init)
       .def("set_samples", &Writer::set_samples)
       .def("set_extra_attributes", &Writer::set_extra_attributes)
+      .def("set_checksum", &Writer::set_checksum)
       .def("create_dataset", &Writer::create_dataset)
       .def("register_samples", &Writer::register_samples)
       .def("ingest_samples", &Writer::ingest_samples);

--- a/apis/python/src/tiledbvcf/binding/writer.cc
+++ b/apis/python/src/tiledbvcf/binding/writer.cc
@@ -82,6 +82,20 @@ void Writer::set_extra_attributes(const std::string& attributes) {
       tiledb_vcf_writer_set_extra_attributes(writer, attributes.c_str()));
 }
 
+void Writer::set_checksum(const std::string& checksum) {
+  auto writer = ptr.get();
+  tiledb_vcf_checksum_type_t checksum_type = TILEDB_VCF_CHECKSUM_SHA256;
+
+  if (checksum == "md5")
+    checksum_type = TILEDB_VCF_CHECKSUM_MD5;
+  else if (checksum == "sha256")
+    checksum_type = TILEDB_VCF_CHECKSUM_SHA256;
+  else if (checksum == "none")
+    checksum_type = TILEDB_VCF_CHECKSUM_NONE;
+
+  check_error(writer, tiledb_vcf_writer_set_checksum_type(writer, checksum_type));
+}
+
 void Writer::create_dataset() {
   auto writer = ptr.get();
   check_error(writer, tiledb_vcf_writer_create_dataset(writer));

--- a/apis/python/src/tiledbvcf/binding/writer.h
+++ b/apis/python/src/tiledbvcf/binding/writer.h
@@ -58,6 +58,11 @@ class Writer {
    */
   void set_extra_attributes(const std::string& attributes);
 
+  /**
+    [Creation only] Sets the checksum type to be used of the arrays
+  */
+  void set_checksum(const std::string& checksum);
+
   void create_dataset();
 
   void register_samples();

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -167,12 +167,25 @@ class TileDBVCFDataset(object):
 
         return self.reader.result_num_records()
 
-    def ingest_samples(self, sample_uris=None, extra_attrs=None):
+    def ingest_samples(self, sample_uris=None, extra_attrs=None, checksum_type=None):
+        """Ingest samples
+
+        :param list of str samples: CSV list of sample names to include in
+            the count.
+        :param list of str extra_attrs: CSV list of extra attributes to
+            materialize from fmt field
+        :param str checksum_type: Optional override checksum type for creating new dataset
+            valid values are sha256, md5 or none.
+        """
         if self.mode != 'w':
             raise Exception('Dataset not open in write mode')
 
         if sample_uris is None:
             return
+
+        if checksum_type is not None:
+            checksum_type = checksum_type.lower()
+            self.writer.set_checksum(checksum_type)
 
         self.writer.set_samples(','.join(sample_uris))
 

--- a/libtiledbvcf/cmake/Modules/FindTileDB_EP.cmake
+++ b/libtiledbvcf/cmake/Modules/FindTileDB_EP.cmake
@@ -40,8 +40,8 @@ else()
 
     ExternalProject_Add(ep_tiledb
       PREFIX "externals"
-      URL "https://github.com/TileDB-Inc/TileDB/archive/1.7.5.zip"
-      URL_HASH SHA1=129c6e046df074fac8af9d449dd5f8ae7221fbbe
+      URL "https://github.com/TileDB-Inc/TileDB/archive/1.7.6.zip"
+      URL_HASH SHA1=f6b63111d0eff8633ecebf2ca3a64fc9d22c362f
       DOWNLOAD_NAME "tiledb.zip"
       CMAKE_ARGS
         -DCMAKE_INSTALL_PREFIX=${EP_INSTALL_PREFIX}

--- a/libtiledbvcf/src/c_api/tiledbvcf.cc
+++ b/libtiledbvcf/src/c_api/tiledbvcf.cc
@@ -624,6 +624,18 @@ int32_t tiledb_vcf_writer_set_extra_attributes(
   return TILEDB_VCF_OK;
 }
 
+int32_t tiledb_vcf_writer_set_checksum_type(
+    tiledb_vcf_writer_t* writer, tiledb_vcf_checksum_type_t checksum_type) {
+  if (sanity_check(writer) == TILEDB_VCF_ERR)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          writer, writer->writer_->set_checksum_type((int)checksum_type)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
 int32_t tiledb_vcf_writer_create_dataset(tiledb_vcf_writer_t* writer) {
   if (sanity_check(writer) == TILEDB_VCF_ERR)
     return TILEDB_VCF_ERR;

--- a/libtiledbvcf/src/c_api/tiledbvcf.h
+++ b/libtiledbvcf/src/c_api/tiledbvcf.h
@@ -71,6 +71,14 @@ typedef enum {
 #undef TILEDB_VCF_ATTR_DATATYPE_ENUM
 } tiledb_vcf_attr_datatype_t;
 
+/** Checksum filter types. */
+typedef enum {
+/** Helper macro for defining subset of tiledb filter type enums. */
+#define TILEDB_VCF_CHECKSUM_TYPE_ENUM(id) TILEDB_VCF_##id
+#include "tiledbvcf_enum.h"
+#undef TILEDB_VCF_CHECKSUM_TYPE_ENUM
+} tiledb_vcf_checksum_type_t;
+
 /* ********************************* */
 /*           STRUCT TYPES            */
 /* ********************************* */
@@ -762,6 +770,21 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_set_samples(
  */
 TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_set_extra_attributes(
     tiledb_vcf_writer_t* writer, const char* attributes);
+
+/**
+ * [Creation only] Sets the checksum type to be used for the underlying arrays
+ *
+ * The checksum type can be set to TILEDB_VCF_CHECKSUM_MD5,
+ * TILEDB_VCF_CHECKSUM_SHA256 or TILEDB_VCF_CHECKSUM_NONE to disable.
+ *
+ * TILEDB_VCF_CHECKSUM_SHA256 is the default
+ *
+ * @param writer VCF writer object
+ * @param checksum_type tiledb checksum filter type to be use
+ * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
+ */
+TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_set_checksum_type(
+    tiledb_vcf_writer_t* writer, tiledb_vcf_checksum_type_t checksum);
 
 /**
  * Creates a new TileDB-VCF dataset, using previously set parameters.

--- a/libtiledbvcf/src/c_api/tiledbvcf_enum.h
+++ b/libtiledbvcf/src/c_api/tiledbvcf_enum.h
@@ -43,3 +43,12 @@ TILEDB_VCF_READ_STATUS_ENUM(FAILED) = 0,
     /** 32-bit floating-point  */
     TILEDB_VCF_ATTR_DATATYPE_ENUM(FLOAT32) = 3,
 #endif
+
+#ifdef TILEDB_VCF_CHECKSUM_TYPE_ENUM
+    /** No-op filter */
+    TILEDB_VCF_CHECKSUM_TYPE_ENUM(CHECKSUM_NONE) = 0,
+    /** MD5 checksum filter. */
+    TILEDB_VCF_CHECKSUM_TYPE_ENUM(CHECKSUM_MD5) = 12,
+    /** SHA256 checksum filter. */
+    TILEDB_VCF_CHECKSUM_TYPE_ENUM(CHECKSUM_SHA256) = 13,
+#endif

--- a/libtiledbvcf/src/cli/tiledbvcf.cc
+++ b/libtiledbvcf/src/cli/tiledbvcf.cc
@@ -236,6 +236,17 @@ int main(int argc, char** argv) {
                "specifying optional TileDB configuration parameter settings." &
            value("params").call([&create_args](const std::string& s) {
              create_args.tiledb_config = utils::split(s, ',');
+           }),
+       option("--checksum") %
+               "Checksum to use for dataset validation on read and writes, "
+               "defauls to 'sha256'" &
+           value("checksum").call([&create_args](const std::string& s) {
+             if (s == "sha256")
+               create_args.checksum = TILEDB_FILTER_CHECKSUM_SHA256;
+             else if (s == "md5")
+               create_args.checksum = TILEDB_FILTER_CHECKSUM_MD5;
+             else if (s == "none")
+               create_args.checksum = TILEDB_FILTER_NONE;
            }));
 
   RegistrationParams register_args;

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -53,6 +53,7 @@ struct CreationParams {
   uint32_t row_tile_extent = 10;
   uint32_t anchor_gap = 1000;
   std::vector<std::string> tiledb_config;
+  tiledb_filter_type_t checksum = TILEDB_FILTER_CHECKSUM_SHA256;
 };
 
 /** Arguments/params for dataset registration. */
@@ -241,11 +242,13 @@ class TileDBVCFDataset {
    * @param ctx TileDB context
    * @param root_uri Root URI of the dataset
    * @param metadata General dataset metadata to write
+   * @param checksum optional checksum filter
    */
   static void create_empty_metadata(
       const Context& ctx,
       const std::string& root_uri,
-      const Metadata& metadata);
+      const Metadata& metadata,
+      const tiledb_filter_type_t& checksum);
 
   /**
    * Creates the empty sample data array for a new dataset.
@@ -253,11 +256,13 @@ class TileDBVCFDataset {
    * @param ctx TileDB context
    * @param root_uri Root URI of the dataset
    * @param metadata Dataset metadata containing tile capacity etc. to use
+   * @param checksum optional checksum filter
    */
   static void create_empty_data_array(
       const Context& ctx,
       const std::string& root_uri,
-      const Metadata& metadata);
+      const Metadata& metadata,
+      const tiledb_filter_type_t& checksum);
 
   /**
    * Creates the empty sample header array for a new dataset.
@@ -268,9 +273,12 @@ class TileDBVCFDataset {
    *
    * @param ctx TileDB context
    * @param root_uri Root URI of the dataset
+   * @param checksum optional checksum filter
    */
   static void create_sample_header_array(
-      const Context& ctx, const std::string& root_uri);
+      const Context& ctx,
+      const std::string& root_uri,
+      const tiledb_filter_type_t& checksum);
 
   /**
    * Write the given Metadata instance into the dataset.

--- a/libtiledbvcf/src/vcf/vcf.cc
+++ b/libtiledbvcf/src/vcf/vcf.cc
@@ -373,12 +373,12 @@ std::string VCF::hdr_to_string(bcf_hdr_t* hdr) {
   if (res != 0) {
     if (res == -1) {
       throw std::invalid_argument(
-        "Cannot set VCF samples; possibly bad VCF header.");
+          "Cannot set VCF samples; possibly bad VCF header.");
     } else if (res > 0) {
       throw std::runtime_error(
-        std::string("Cannot set VCF samples: list contains samples not present in VCF header, sample #:") +
-        std::to_string(res)
-      );
+          std::string("Cannot set VCF samples: list contains samples not "
+                      "present in VCF header, sample #:") +
+          std::to_string(res));
     }
   }
   bcf_hdr_format(tmp, 0, &t);

--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -56,6 +56,8 @@ void Writer::init(
   array_.reset(new Array(*ctx_, dataset.data_uri(), TILEDB_WRITE));
   query_.reset(new Query(*ctx_, *array_));
   query_->set_layout(TILEDB_GLOBAL_ORDER);
+
+  creation_params_.checksum = TILEDB_FILTER_CHECKSUM_SHA256;
 }
 
 void Writer::set_all_params(const IngestionParams& params) {
@@ -77,6 +79,14 @@ void Writer::set_sample_uris(const std::string& sample_uris) {
 void Writer::set_extra_attributes(const std::string& attributes) {
   auto attrs = utils::split(attributes, ",");
   creation_params_.extra_attributes = attrs;
+}
+
+void Writer::set_checksum_type(const int& checksum) {
+  set_checksum_type((tiledb_filter_type_t)checksum);
+}
+
+void Writer::set_checksum_type(const tiledb_filter_type_t& checksum) {
+  creation_params_.checksum = checksum;
 }
 
 void Writer::create_dataset() {

--- a/libtiledbvcf/src/write/writer.h
+++ b/libtiledbvcf/src/write/writer.h
@@ -122,6 +122,14 @@ class Writer {
    */
   void set_extra_attributes(const std::string& attributes);
 
+  /**
+   * Sets the checksum type for filter on new dataset arrays
+   *
+   * @param checksum
+   */
+  void set_checksum_type(const int& checksum);
+  void set_checksum_type(const tiledb_filter_type_t& checksum);
+
   /** Creates an empty dataset based on parameters that have been set. */
   void create_dataset();
 

--- a/libtiledbvcf/test/src/unit-c-api-writer.cc
+++ b/libtiledbvcf/test/src/unit-c-api-writer.cc
@@ -33,7 +33,6 @@
 
 #include <cstring>
 #include <iostream>
-#include <tiledb/tiledb>
 
 static const std::string INPUT_DIR =
     TILEDB_VCF_TEST_INPUT_DIR + std::string("/");
@@ -57,6 +56,56 @@ TEST_CASE("C API: Writer create default", "[capi][writer]") {
   tiledb_vcf_writer_t* writer = nullptr;
   REQUIRE(tiledb_vcf_writer_alloc(&writer) == TILEDB_VCF_OK);
   REQUIRE(tiledb_vcf_writer_init(writer, dataset_uri.c_str()) == TILEDB_VCF_OK);
+
+  REQUIRE(tiledb_vcf_writer_create_dataset(writer) == TILEDB_VCF_OK);
+
+  tiledb::vcf::TileDBVCFDataset ds;
+  REQUIRE_NOTHROW(ds.open(dataset_uri));
+
+  tiledb_vcf_writer_free(&writer);
+  if (vfs.is_dir(dataset_uri))
+    vfs.remove_dir(dataset_uri);
+}
+
+TEST_CASE("C API: Writer create md5 checksum", "[capi][writer]") {
+  tiledb::Context ctx;
+  tiledb::VFS vfs(ctx);
+
+  std::string dataset_uri = "test_dataset";
+  if (vfs.is_dir(dataset_uri))
+    vfs.remove_dir(dataset_uri);
+
+  tiledb_vcf_writer_t* writer = nullptr;
+  REQUIRE(tiledb_vcf_writer_alloc(&writer) == TILEDB_VCF_OK);
+  REQUIRE(tiledb_vcf_writer_init(writer, dataset_uri.c_str()) == TILEDB_VCF_OK);
+  REQUIRE(
+      tiledb_vcf_writer_set_checksum_type(writer, TILEDB_VCF_CHECKSUM_MD5) ==
+      TILEDB_VCF_OK);
+
+  REQUIRE(tiledb_vcf_writer_create_dataset(writer) == TILEDB_VCF_OK);
+
+  tiledb::vcf::TileDBVCFDataset ds;
+  REQUIRE_NOTHROW(ds.open(dataset_uri));
+
+  tiledb_vcf_writer_free(&writer);
+  if (vfs.is_dir(dataset_uri))
+    vfs.remove_dir(dataset_uri);
+}
+
+TEST_CASE("C API: Writer create no checksum", "[capi][writer]") {
+  tiledb::Context ctx;
+  tiledb::VFS vfs(ctx);
+
+  std::string dataset_uri = "test_dataset";
+  if (vfs.is_dir(dataset_uri))
+    vfs.remove_dir(dataset_uri);
+
+  tiledb_vcf_writer_t* writer = nullptr;
+  REQUIRE(tiledb_vcf_writer_alloc(&writer) == TILEDB_VCF_OK);
+  REQUIRE(tiledb_vcf_writer_init(writer, dataset_uri.c_str()) == TILEDB_VCF_OK);
+  REQUIRE(
+      tiledb_vcf_writer_set_checksum_type(writer, TILEDB_VCF_CHECKSUM_NONE) ==
+      TILEDB_VCF_OK);
 
   REQUIRE(tiledb_vcf_writer_create_dataset(writer) == TILEDB_VCF_OK);
 


### PR DESCRIPTION
The underlying TileDB arrays will have a sha256 checksum filter enabled by default on all fields, coordinates and offsets with an new CLI option `--checksum` to allow the user to set the checksum to md5/sha256 or none.