### PR TITLE
Add export test with non-contiguous samples

### DIFF
--- a/libtiledbvcf/test/run-cli-tests.sh
+++ b/libtiledbvcf/test/run-cli-tests.sh
@@ -17,7 +17,7 @@ upload_dir=/tmp/tilevcf-upload-dir-$$
 # Clean up test outputs
 function clean_up {
     rm -rf ingested_1 ingested_2 ingested_3 ingested_3_attrs \
-           ingested_1_2 ingested_1_2_vcf ingested_comb ingested_append \
+           ingested_1_2 ingested_1_2_vcf ingested_3_samples ingested_comb ingested_append \
            ingested_from_file ingested_diff_order ingested_buffered \
            ingested_sep_indexes \
            ingested_capacity HG01762.vcf HG00280.vcf tmp.bed tmp1.vcf tmp2.vcf \
@@ -45,6 +45,8 @@ create_register_ingest ingested_2 ${input_dir}/small2.bcf
 create_register_ingest ingested_3 ${input_dir}/small3.bcf
 create_register_ingest ingested_1_2 ${input_dir}/small2.bcf ${input_dir}/small.bcf
 create_register_ingest ingested_1_2_vcf ${input_dir}/small2.bcf ${input_dir}/small.vcf.gz
+create_register_ingest ingested_3_samples ${input_dir}/random_synthetic/G{1,2,3}.bcf
+
 $tilevcf create -u ingested_3_attrs -a fmt_DP,info_MLEAC,info_MLEAF,info_MQ,fmt_AD,info_GQ || exit 1
 $tilevcf register -u ingested_3_attrs ${input_dir}/small3.bcf || exit 1
 $tilevcf store -u ingested_3_attrs ${input_dir}/small3.bcf || exit 1
@@ -279,6 +281,10 @@ EOF
 ) || exit 1
 rm -f /tmp/pfx.tsv
 rm -f HG00280.vcf HG01762.vcf region-map.txt $upload_dir/*
+
+echo "Export non-contiguous samples (#79)"
+$tilevcf export -u ingested_3_samples -Ob -v -s G1,G3 || exit 1
+rm -f G{1,3}.bcf
 
 # Check count only
 region="1\t12141\t15000\n1\t17484\t18000"


### PR DESCRIPTION
This adds a test for the segfault fixed in #79.