### PR TITLE
Update to split coordinates for TileDB 2.0.0

### DIFF
--- a/libtiledbvcf/CMakeLists.txt
+++ b/libtiledbvcf/CMakeLists.txt
@@ -47,7 +47,7 @@ set(CMAKE_CXX_EXTENSIONS OFF) # Don't use GNU extensions
 
 # Release builds by default.
 if (NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
+  set(CMAKE_BUILD_TYPE RELEASE)
 endif()
 
 # Root directory default installation prefix
@@ -69,11 +69,13 @@ if (APPLE)
 endif()
 
 # Add some global compiler flags
-if (CMAKE_BUILD_TYPE MATCHES "Debug")
+string( TOUPPER "${CMAKE_BUILD_TYPE}" BUILD_TYPE)
+if (BUILD_TYPE STREQUAL "DEBUG")
   add_compile_options(-DDEBUG -O0 -g3 -ggdb3 -gdwarf-3 -Wall)
-elseif (CMAKE_BUILD_TYPE MATCHES "Release")
+elseif (BUILD_TYPE STREQUAL "RELEASE")
   add_compile_options(-DNDEBUG -O3 -Wall -Werror)
 endif()
+add_compile_options(-Wno-error=deprecated-declarations)
 add_definitions(-D_FILE_OFFSET_BITS=64)
 
 ############################################################

--- a/libtiledbvcf/cmake/Modules/FindTileDB_EP.cmake
+++ b/libtiledbvcf/cmake/Modules/FindTileDB_EP.cmake
@@ -40,8 +40,8 @@ else()
 
     ExternalProject_Add(ep_tiledb
       PREFIX "externals"
-      URL "https://github.com/TileDB-Inc/TileDB/archive/1.7.6.zip"
-      URL_HASH SHA1=f6b63111d0eff8633ecebf2ca3a64fc9d22c362f
+      URL "https://github.com/TileDB-Inc/TileDB/archive/2.0.0.zip"
+      URL_HASH SHA1=eb5295efc48a9c085814d0059bb4ade782df0c94
       DOWNLOAD_NAME "tiledb.zip"
       CMAKE_ARGS
         -DCMAKE_INSTALL_PREFIX=${EP_INSTALL_PREFIX}

--- a/libtiledbvcf/src/dataset/attribute_buffer_set.h
+++ b/libtiledbvcf/src/dataset/attribute_buffer_set.h
@@ -68,11 +68,17 @@ class AttributeBufferSet {
   /** Clears all buffers. */
   void clear();
 
-  /** Coords buffer. */
-  const Buffer& coords() const;
+  /** sample buffer. */
+  const Buffer& sample() const;
 
-  /** Coords buffer. */
-  Buffer& coords();
+  /** sample buffer. */
+  Buffer& sample();
+
+  /** end_pos buffer. */
+  const Buffer& end_pos() const;
+
+  /** end_pos buffer. */
+  Buffer& end_pos();
 
   /** pos buffer. */
   const Buffer& pos() const;
@@ -141,8 +147,11 @@ class AttributeBufferSet {
   bool extra_attr(const std::string& name, Buffer** buffer);
 
  private:
-  /** coords (uint32_t) */
-  Buffer coords_;
+  /** sample (uint32_t) */
+  Buffer sample_;
+
+  /** end_pos (uint32_t) */
+  Buffer end_pos_;
 
   /** pos attribute (uint32_t) */
   Buffer pos_;

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -129,6 +129,14 @@ class TileDBVCFDataset {
   /**
    * String names for built-in attribute names in the data array.
    */
+  struct DimensionNames {
+    static const std::string sample;
+    static const std::string end_pos;
+  };
+
+  /**
+   * String names for built-in attribute names in the data array.
+   */
   struct AttrNames {
     static const std::string pos;
     static const std::string real_end;

--- a/libtiledbvcf/src/read/in_memory_exporter.cc
+++ b/libtiledbvcf/src/read/in_memory_exporter.cc
@@ -124,8 +124,10 @@ std::set<std::string> InMemoryExporter::array_attributes_required() const {
   for (const auto& it : user_buffers_) {
     switch (it.second.attr) {
       case ExportableAttribute::SampleName:
+        result.insert(TileDBVCFDataset::DimensionNames::sample);
+        break;
       case ExportableAttribute::PosEnd:
-        result.insert(TILEDB_COORDS);
+        result.insert(TileDBVCFDataset::DimensionNames::end_pos);
         break;
       case ExportableAttribute::PosStart:
         result.insert(TileDBVCFDataset::AttrNames::pos);
@@ -281,8 +283,7 @@ bool InMemoryExporter::export_record(
     UserBuffer& user_buff = it.second;
     switch (user_buff.attr) {
       case ExportableAttribute::SampleName: {
-        const uint32_t sample_id =
-            buffers->coords().value<uint32_t>(2 * cell_idx + 0);
+        const uint32_t sample_id = buffers->sample().value<uint32_t>(cell_idx);
         const std::string& sample_name =
             dataset_->metadata().sample_names[sample_id];
         overflow = !copy_cell(

--- a/libtiledbvcf/src/read/read_query_results.cc
+++ b/libtiledbvcf/src/read/read_query_results.cc
@@ -42,7 +42,7 @@ void ReadQueryResults::set_results(
   query_status_ = query.query_status();
 
   auto result_el = query.result_buffer_elements();
-  num_cells_ = result_el[TILEDB_COORDS].second / 2;
+  num_cells_ = result_el["sample"].second;
   alleles_size_ = result_el["alleles"];
   id_size_ = result_el["id"];
   filter_ids_size_ = result_el["filter_ids"];

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -519,15 +519,14 @@ bool Reader::process_query_results() {
 
   // Get the contig offset and length of the first cell in the results.
   uint32_t first_col =
-      results.buffers()->coords().value<uint32_t>(2 * read_state_.cell_idx + 1);
+      results.buffers()->end_pos().value<uint32_t>(read_state_.cell_idx);
   auto contig_info = dataset_->contig_from_column(first_col);
 
   for (; read_state_.cell_idx < num_cells; read_state_.cell_idx++) {
     // For easy reference
     const uint64_t i = read_state_.cell_idx;
-    const uint32_t sample_id =
-        results.buffers()->coords().value<uint32_t>(2 * i + 0);
-    const uint32_t end = results.buffers()->coords().value<uint32_t>(2 * i + 1);
+    const uint32_t sample_id = results.buffers()->sample().value<uint32_t>(i);
+    const uint32_t end = results.buffers()->end_pos().value<uint32_t>(i);
     const uint32_t start = results.buffers()->pos().value<uint32_t>(i);
     const uint32_t real_end = results.buffers()->real_end().value<uint32_t>(i);
 
@@ -676,9 +675,8 @@ bool Reader::report_cell(
   }
 
   const auto& results = read_state_.query_results;
-  uint32_t samp_idx =
-      results.buffers()->coords().value<uint32_t>(2 * cell_idx + 0) -
-      read_state_.sample_min;
+  uint32_t samp_idx = results.buffers()->sample().value<uint32_t>(cell_idx) -
+                      read_state_.sample_min;
   const auto& sample = read_state_.current_samples[samp_idx];
   const auto& hdr = read_state_.current_hdrs[samp_idx];
 
@@ -898,7 +896,8 @@ void Reader::prepare_regions(
 
 void Reader::prepare_attribute_buffers() {
   // This base set of attributes is required for the read algorithm to run.
-  std::set<std::string> attrs = {TILEDB_COORDS,
+  std::set<std::string> attrs = {TileDBVCFDataset::DimensionNames::sample,
+                                 TileDBVCFDataset::DimensionNames::end_pos,
                                  TileDBVCFDataset::AttrNames::pos,
                                  TileDBVCFDataset::AttrNames::real_end};
 

--- a/libtiledbvcf/src/write/writer_worker.cc
+++ b/libtiledbvcf/src/write/writer_worker.cc
@@ -175,8 +175,8 @@ bool WriterWorker::buffer_record(
   const uint32_t pos = contig_offset + r->pos;
   const uint32_t real_end = contig_offset + VCF::get_end_pos(hdr, r, &val_);
 
-  buffers_.coords().append(&row, sizeof(uint32_t));
-  buffers_.coords().append(&col, sizeof(uint32_t));
+  buffers_.sample().append(&row, sizeof(uint32_t));
+  buffers_.end_pos().append(&col, sizeof(uint32_t));
   buffers_.qual().append(&r->qual, sizeof(float));
   buffers_.pos().append(&pos, sizeof(uint32_t));
   buffers_.real_end().append(&real_end, sizeof(uint32_t));

--- a/libtiledbvcf/test/src/unit-c-api-reader.cc
+++ b/libtiledbvcf/test/src/unit-c-api-reader.cc
@@ -2041,10 +2041,9 @@ TEST_CASE("C API: Reader get error message", "[capi][reader]") {
   const char* msg = nullptr;
   std::string expected_msg =
       "TileDB-VCF exception: Cannot open TileDB-VCF dataset; dataset 'abc' "
-      "or its metadata does not exist. TileDB error message: "
-      "[TileDB::StorageManager] Error: Cannot open array; Array does not exist";
+      "or its metadata does not exist.";
   REQUIRE(tiledb_vcf_error_get_message(error, &msg) == TILEDB_VCF_OK);
-  REQUIRE(std::string(msg) == expected_msg);
+  REQUIRE(std::string(msg).find(expected_msg) != std::string::npos);
   tiledb_vcf_error_free(&error);
 
   // Check OK operation clears error message


### PR DESCRIPTION
Instead of using the TILEDB_COORDS buffer now sample and end_pos are queried as independent buffers. This if a feature allowed in TileDB 2.0.0 which will improve performance and memory usage.

~We will wait to merge this until an official TileDB 2.0.0 release (which should be in a few days) and the TileDB superbuild verison will be updated then.~ TileDB 2.0.0 is released and this PR has been updated.