### PR TITLE
Use gradle-git-version for java/spark versioning

### DIFF
--- a/apis/java/build.gradle
+++ b/apis/java/build.gradle
@@ -4,10 +4,11 @@ plugins {
     id 'maven-publish'
     id 'com.github.sherter.google-java-format' version '0.7.1'
     id 'com.github.johnrengelman.shadow' version '4.0.3'
+    id 'com.palantir.git-version' version '0.12.3'
 }
 
 group 'io.tiledb'
-version '0.1.0-SNAPSHOT'
+version gitVersion()
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/apis/spark/build.gradle
+++ b/apis/spark/build.gradle
@@ -4,10 +4,11 @@ plugins {
     id 'maven-publish'
     id 'com.github.sherter.google-java-format' version '0.7.1'
     id 'com.github.johnrengelman.shadow' version '4.0.3'
+    id 'com.palantir.git-version' version '0.12.3'
 }
 
 group 'io.tiledb'
-version '0.1.0-SNAPSHOT'
+version gitVersion()
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -33,7 +34,7 @@ repositories {
 dependencies {
     compile 'org.apache.spark:spark-sql_2.12:2.4.3'
     compile 'org.apache.spark:spark-core_2.12:2.4.3'
-    compile 'io.tiledb:tiledb-vcf-java:0.1.0-SNAPSHOT'
+    compile group: 'io.tiledb', name: 'tiledb-vcf-java', version: gitVersion()
     compile 'com.amazonaws:aws-java-sdk:1.11.650'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'


### PR DESCRIPTION
This allows the for the version to be automatically detected from the latest git tag