### PR TITLE
Add support for github tar archives in building

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,1 @@
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst

--- a/apis/python/conda-env.yml
+++ b/apis/python/conda-env.yml
@@ -7,7 +7,9 @@ dependencies:
   - pyarrow>=0.16.0
   - dask>=0.19.0
   - pip
+  - setuptools
+  - setuptools_scm
+  - setuptools_scm_git_archive
   - pip:
-    - setuptools==39.0.1
     - pytest-runner==5.1
     - pytest==5.1.2

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -253,7 +253,8 @@ setup(
         'setuptools>=18.0',
         'setuptools_scm>=1.5.4',
         'wheel>=0.30',
-        'pybind11>=2.3.0'
+        'pybind11>=2.3.0',
+        'setuptools_scm_git_archive'
     ],
     install_requires=[],
     tests_require=[],


### PR DESCRIPTION
This is needed for conda package building.