### PR TITLE
Add CI job to build Dockerfiles

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
       architecture: 'x64'
   - template: ci/azure-linux_mac.yml
 
-- job:
+- job: Images
   dependsOn: Build
   condition: |
     or(

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -3,9 +3,12 @@ trigger:
     include:
     - master
     - release-*
+  tags:
+    include:
+      - "*"
 
 jobs:
-- job:
+- job: Build
   strategy:
     matrix:
       ubuntu_18:
@@ -26,3 +29,26 @@ jobs:
       versionSpec: '$(python.version)'
       architecture: 'x64'
   - template: ci/azure-linux_mac.yml
+
+- job:
+  dependsOn: Build
+  condition: |
+    or(
+      eq(variables['build.sourceBranch'], 'refs/heads/master'),
+      startsWith(variables['build.sourceBranch'], 'refs/tags')
+    )
+
+  strategy:
+    matrix:
+      cli:
+        dockerfile: docker/Dockerfile-cli
+        repository: aaronwolen/tiledbvcf-cli
+      python:
+        dockerfile: docker/Dockerfile-py
+        repository: aaronwolen/tiledbvcf-py
+      dask:
+        dockerfile: docker/Dockerfile-dask-py
+        repository: aaronwolen/tiledbvcf-dask
+
+  steps:
+  - template: ci/build-images.yml

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -8,7 +8,7 @@ jobs:
 - job:
   strategy:
     matrix:
-      ubuntu_16:
+      ubuntu_18:
         imageName: 'ubuntu-18.04'
         python.version: '3.x'
         CXX: g++

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -43,12 +43,15 @@ jobs:
       cli:
         dockerfile: docker/Dockerfile-cli
         repository: aaronwolen/tiledbvcf-cli
+        context: libtiledbvcf
       python:
         dockerfile: docker/Dockerfile-py
         repository: aaronwolen/tiledbvcf-py
+        context: .
       dask:
         dockerfile: docker/Dockerfile-dask-py
         repository: aaronwolen/tiledbvcf-dask
+        context: .
 
   steps:
   - template: ci/build-images.yml

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -42,15 +42,15 @@ jobs:
     matrix:
       cli:
         dockerfile: docker/Dockerfile-cli
-        repository: aaronwolen/tiledbvcf-cli
+        repository: tiledb/tiledbvcf-cli
         context: libtiledbvcf
       python:
         dockerfile: docker/Dockerfile-py
-        repository: aaronwolen/tiledbvcf-py
+        repository: tiledb/tiledbvcf-py
         context: .
       dask:
         dockerfile: docker/Dockerfile-dask-py
-        repository: aaronwolen/tiledbvcf-dask
+        repository: tiledb/tiledbvcf-dask
         context: .
 
   steps:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
       architecture: 'x64'
   - template: ci/azure-linux_mac.yml
 
-- job: Images
+- job: Docker
   dependsOn: Build
   condition: |
     or(

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -44,14 +44,14 @@ jobs:
         dockerfile: docker/Dockerfile-cli
         repository: tiledb/tiledbvcf-cli
         context: libtiledbvcf
-      python:
-        dockerfile: docker/Dockerfile-py
-        repository: tiledb/tiledbvcf-py
-        context: .
-      dask:
-        dockerfile: docker/Dockerfile-dask-py
-        repository: tiledb/tiledbvcf-dask
-        context: .
+      # python:
+      #   dockerfile: docker/Dockerfile-py
+      #   repository: tiledb/tiledbvcf-py
+      #   context: .
+      # dask:
+      #   dockerfile: docker/Dockerfile-dask-py
+      #   repository: tiledb/tiledbvcf-dask
+      #   context: .
 
   steps:
   - template: ci/build-images.yml

--- a/ci/build-images.yml
+++ b/ci/build-images.yml
@@ -1,0 +1,22 @@
+steps:
+
+  - task: Docker@2
+    displayName: Docker image (latest)
+    inputs:
+      containerRegistry: 'Docker Hub'
+      repository: $(repository)
+      command: 'buildAndPush'
+      Dockerfile: $(dockerfile)
+      buildContext: '.'
+      tags: latest
+
+  - task: Docker@2
+    displayName: Docker image (tagged release)
+    condition: startsWith(variables['build.sourceBranch'], 'refs/tags')
+    inputs:
+      containerRegistry: 'Docker Hub'
+      repository: $(repository)
+      command: 'buildAndPush'
+      Dockerfile: $(dockerfile)
+      buildContext: '.'
+      tags: $(Build.SourceBranchName)

--- a/ci/build-images.yml
+++ b/ci/build-images.yml
@@ -7,7 +7,7 @@ steps:
       repository: $(repository)
       command: 'buildAndPush'
       Dockerfile: $(dockerfile)
-      buildContext: '.'
+      buildContext: $(context)
       tags: latest
 
   - task: Docker@2
@@ -18,5 +18,5 @@ steps:
       repository: $(repository)
       command: 'buildAndPush'
       Dockerfile: $(dockerfile)
-      buildContext: '.'
+      buildContext: $(context)
       tags: $(Build.SourceBranchName)

--- a/ci/build-images.yml
+++ b/ci/build-images.yml
@@ -3,7 +3,7 @@ steps:
   - task: Docker@2
     displayName: Docker image (latest)
     inputs:
-      containerRegistry: 'Docker Hub'
+      containerRegistry: 'dockerHub'
       repository: $(repository)
       command: 'buildAndPush'
       Dockerfile: $(dockerfile)
@@ -14,7 +14,7 @@ steps:
     displayName: Docker image (tagged release)
     condition: startsWith(variables['build.sourceBranch'], 'refs/tags')
     inputs:
-      containerRegistry: 'Docker Hub'
+      containerRegistry: 'dockerHub'
       repository: $(repository)
       command: 'buildAndPush'
       Dockerfile: $(dockerfile)


### PR DESCRIPTION
This updates the CI pipeline to build and push the docker images. It's setup so that images are only built when:

* `master` is updated, which will tag the image as `latest`, or
* a new `tag` is pushed, in which case the image is tagged with the tag version

Image building is implemented as a separate job, which depends on the *Build* job completing successfully. 

All 3 Dockerfiles are built in parallel, however, the python and dask images are commented out because they need to be updated.

Before merging this we need to 
- [x]  Add Docker Hub as registry service connection 
- [x] Create the corresponding repositories on Docker hub