### PR TITLE
Build the shadowJar without a classifier

### DIFF
--- a/apis/spark/build.gradle
+++ b/apis/spark/build.gradle
@@ -49,6 +49,14 @@ shadowJar {
     zip64 true
 }
 
+tasks.jar.configure {
+    classifier = 'default'
+}
+
+tasks.shadowJar.configure {
+    classifier = null
+}
+
 import com.github.sherter.googlejavaformatgradleplugin.GoogleJavaFormat
 import com.github.sherter.googlejavaformatgradleplugin.VerifyGoogleJavaFormat
 


### PR DESCRIPTION
The default assemble jar will have `-default` added.