### PR TITLE
Mark spark libraries as compileOnly for spark api 

### DIFF
--- a/apis/spark/build.gradle
+++ b/apis/spark/build.gradle
@@ -49,6 +49,14 @@ shadowJar {
     zip64 true
 }
 
+tasks.jar.configure {
+    classifier = 'default'
+}
+
+tasks.shadowJar.configure {
+    classifier = null
+}
+
 import com.github.sherter.googlejavaformatgradleplugin.GoogleJavaFormat
 import com.github.sherter.googlejavaformatgradleplugin.VerifyGoogleJavaFormat
 

--- a/apis/spark/build.gradle
+++ b/apis/spark/build.gradle
@@ -31,12 +31,17 @@ repositories {
 }
 
 dependencies {
-    compile 'org.apache.spark:spark-sql_2.12:2.4.3'
-    compile 'org.apache.spark:spark-core_2.12:2.4.3'
+    compileOnly 'org.apache.spark:spark-sql_2.12:2.4.3'
+    compileOnly 'org.apache.spark:spark-core_2.12:2.4.3'
     compile 'io.tiledb:tiledb-vcf-java:0.1.0-SNAPSHOT'
     compile 'com.amazonaws:aws-java-sdk:1.11.650'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
+}
+
+// Make sure all the compileOnly packagse (spark) are included for testing
+configurations {
+    testCompile.extendsFrom compileOnly
 }
 
 test {


### PR DESCRIPTION
Mark spark libraries as compileOnly for spark api 