### PR TITLE
Fix and update Dockerfile-py

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -45,11 +45,11 @@ jobs:
       cli:
         dockerfile: docker/Dockerfile-cli
         repository: tiledb/tiledbvcf-cli
-        context: libtiledbvcf
-      # python:
-      #   dockerfile: docker/Dockerfile-py
-      #   repository: tiledb/tiledbvcf-py
-      #   context: .
+        context: .
+      python:
+        dockerfile: docker/Dockerfile-py
+        repository: tiledb/tiledbvcf-py
+        context: .
       # dask:
       #   dockerfile: docker/Dockerfile-dask-py
       #   repository: tiledb/tiledbvcf-dask

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.vscode*
+dist
+libtiledbvcf/build
+apis/python/build
+apis/python/.eggs

--- a/docker/Dockerfile-cli
+++ b/docker/Dockerfile-cli
@@ -41,19 +41,17 @@ RUN wget https://cmake.org/files/v3.12/cmake-3.12.3-Linux-x86_64.sh \
     && rm cmake-3.12.3-Linux-x86_64.sh
 
 # Copy the TileDB-VCF directory and build it.
-WORKDIR /tmp/
-COPY . libtiledbvcf
-RUN pushd libtiledbvcf \
-    && rm -rf build \
-    && mkdir build \
-    && cd build \
-    && cmake -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_INSTALL_PREFIX=/usr/local \
-        -DOVERRIDE_INSTALL_PREFIX=OFF \
-        .. \
+WORKDIR /tmp
+COPY libtiledbvcf libtiledbvcf
+
+WORKDIR /tmp/libtiledbvcf/build
+RUN cmake .. -DCMAKE_BUILD_TYPE=Release \
+             -DCMAKE_INSTALL_PREFIX=/usr/local \
+             -DOVERRIDE_INSTALL_PREFIX=OFF \
     && make -j4 \
-    && make install-libtiledbvcf \
-    && popd \
-    && rm -rf libtiledbvcf
+    && make install-libtiledbvcf
+
+WORKDIR /tmp
+RUN rm -rf /tmp/libtiledbvcf
 
 ENTRYPOINT ["/usr/local/bin/tiledbvcf"]

--- a/docker/Dockerfile-py
+++ b/docker/Dockerfile-py
@@ -27,7 +27,7 @@
 # This Dockerfile builds the TileDB-VCF Python image.
 #
 
-FROM continuumio/miniconda3:4.5.12
+FROM continuumio/miniconda3:4.8.2
 ENV CFLAGS "-march=haswell"
 ENV CPPFLAGS "-march=haswell"
 

--- a/docker/Dockerfile-py
+++ b/docker/Dockerfile-py
@@ -46,18 +46,15 @@ RUN apt-get update \
 WORKDIR /tmp
 COPY . tiledbvcf
 
-
-RUN cd tiledbvcf \
-    && rm -rf libtiledbvcf/build dist \
-    && cd apis/python \
-    && conda env update -n base -f conda-env.yml \
+WORKDIR /tmp/tiledbvcf/apis/python
+RUN conda env update -n base -f conda-env.yml \
     && conda install -y -c bioconda htslib \
     && conda install -y cmake \
     && conda clean -a -y
 
-RUN cd /tmp/tiledbvcf/apis/python \
-    && python setup.py install
+RUN python setup.py install
 
-RUN cd /tmp && rm -rf tiledbvcf
+WORKDIR /tmp
+RUN rm -rf tiledbvcf
 
 ENTRYPOINT ["/bin/bash"]

--- a/docker/Dockerfile-py
+++ b/docker/Dockerfile-py
@@ -40,7 +40,6 @@ RUN conda config --prepend channels conda-forge
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
        build-essential \
-       cmake \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy the TileDB-VCF Python directory and build it.
@@ -53,6 +52,7 @@ RUN cd tiledbvcf \
     && cd apis/python \
     && conda env update -n base -f conda-env.yml \
     && conda install -y -c bioconda htslib \
+    && conda install -y cmake \
     && conda clean -a -y
 
 RUN cd /tmp/tiledbvcf/apis/python \

--- a/docker/Dockerfile-py
+++ b/docker/Dockerfile-py
@@ -44,16 +44,20 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy the TileDB-VCF Python directory and build it.
-WORKDIR /tmp/
+WORKDIR /tmp
 COPY . tiledbvcf
+
+
 RUN cd tiledbvcf \
     && rm -rf libtiledbvcf/build dist \
     && cd apis/python \
     && conda env update -n base -f conda-env.yml \
     && conda install -y -c bioconda htslib \
-    && python setup.py install \
-    && cd /tmp \
-    && rm -rf tiledbvcf \
     && conda clean -a -y
+
+RUN cd /tmp/tiledbvcf/apis/python \
+    && python setup.py install
+
+RUN cd /tmp && rm -rf tiledbvcf
 
 ENTRYPOINT ["/bin/bash"]

--- a/docker/Dockerfile-py
+++ b/docker/Dockerfile-py
@@ -51,7 +51,6 @@ RUN cd tiledbvcf \
     && cd apis/python \
     && conda env update -n base -f conda-env.yml \
     && conda install -y -c bioconda htslib \
-    && conda install dask \
     && python setup.py install \
     && cd /tmp \
     && rm -rf tiledbvcf \

--- a/docker/Dockerfile-py
+++ b/docker/Dockerfile-py
@@ -31,15 +31,16 @@ FROM continuumio/miniconda3:4.8.2
 ENV CFLAGS "-march=haswell"
 ENV CPPFLAGS "-march=haswell"
 
+ENV TILEDBVCF_FORCE_EXTERNAL_HTSLIB=OFF
+ENV LD_LIBRARY_PATH=/usr/local/lib:/opt/conda/lib
+
 RUN conda config --prepend channels conda-forge
 
 # Install some dependencies
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
-         wget cmake git gcc g++ build-essential autoconf automake \
-         libssl-dev libbz2-dev liblz4-dev libcurl4-openssl-dev \
-         zlib1g-dev liblzma-dev \
-         python3 python3-dev python3-venv \
+       build-essential \
+       cmake \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy the TileDB-VCF Python directory and build it.
@@ -49,6 +50,7 @@ RUN cd tiledbvcf \
     && rm -rf libtiledbvcf/build dist \
     && cd apis/python \
     && conda env update -n base -f conda-env.yml \
+    && conda install -y -c bioconda htslib \
     && conda install dask \
     && python setup.py install \
     && cd /tmp \

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,7 +7,7 @@ This directory contains the Dockerfiles to build containers for various componen
 This image builds the main TileDB-VCF library and CLI tool:
 ```bash
 $ cd TileDB-VCF/
-$ docker build -f docker/Dockerfile-cli -t tiledbvcf-cli libtiledbvcf
+$ docker build -f docker/Dockerfile-cli -t tiledbvcf-cli .
 
 # To test:
 $ docker run --rm -it tiledbvcf-cli --version  # or '--help'

--- a/libtiledbvcf/cmake/Modules/FindTileDB_EP.cmake
+++ b/libtiledbvcf/cmake/Modules/FindTileDB_EP.cmake
@@ -40,8 +40,8 @@ else()
 
     ExternalProject_Add(ep_tiledb
       PREFIX "externals"
-      URL "https://github.com/TileDB-Inc/TileDB/archive/2.0.0.zip"
-      URL_HASH SHA1=eb5295efc48a9c085814d0059bb4ade782df0c94
+      URL "https://github.com/TileDB-Inc/TileDB/archive/2.0.1.zip"
+      URL_HASH SHA1=698788b6b90a72c51722561800ce44950513ab64
       DOWNLOAD_NAME "tiledb.zip"
       CMAKE_ARGS
         -DCMAKE_INSTALL_PREFIX=${EP_INSTALL_PREFIX}


### PR DESCRIPTION
- Updates TileDB to 2.0.1 for superbuild
- Updates to latest miniconda3 image (v4.8.2)
- Installs HTSlib w/ conda rather than compiling as an external project and removes its systems deps
- Uses `cmake` from conda to (avoids issues compiling against libcurl)
- Removes redundant `conda install dask` step (it's already included in `conda-env.yml`)
- `Dockerfile-cli` should now be built using the project root directory as the context (to be consistent with `Dockerfile-py`)