### PR TITLE
Fix duplicate cell reporting between incomplete queries

### DIFF
--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -293,6 +293,12 @@ class Reader {
     /** Map of current relative sample ID -> VCF header instance. */
     std::vector<SafeBCFHdr> current_hdrs;
 
+    /**
+     * Stores the index to a region that was unsuccessfully reported
+     * in the last read.
+     */
+    size_t last_intersecting_region_idx_;
+
     /** Map of current relative sample ID -> last real_end reported. */
     std::vector<uint32_t> last_reported_end;
 


### PR DESCRIPTION
The reader fetches one or more intersecting regions to a given gVCF range. It
iterates through each intersecting region, report its respective cell in-place.
If we overflow while reporting one of these regions, the reader aborts and
returns incomplete to the user. When the reader continues the read, the reader
will start from the same gVCF range, re-reporting all intersecting regions that
precede the region that overflowed the previous read.

To fix this, we save the index of the region that caused the overflow. On the
next read, we start at this region instead of from the first region that
intersects the gVCF range.