### PR TITLE
Fix over-allocating attribute buffers

### DIFF
--- a/libtiledbvcf/src/dataset/attribute_buffer_set.cc
+++ b/libtiledbvcf/src/dataset/attribute_buffer_set.cc
@@ -22,8 +22,10 @@ void AttributeBufferSet::allocate_fixed(
 
   // Requesting 0 MB will result in a 1 KB allocation. This is used by the
   // tests to test the path of incomplete TileDB queries.
-  nbytes = mem_budget_mb == 0 ? 1024 : (mem_budget_mb * 1024 * 1024);
-  num_offsets = nbytes / sizeof(uint64_t);
+  if (mem_budget_mb == 0) {
+    nbytes = 1024;
+    num_offsets = nbytes / sizeof(uint64_t);
+  }
 
   using attrNames = TileDBVCFDataset::AttrNames;
   using dimNames = TileDBVCFDataset::DimensionNames;


### PR DESCRIPTION
When VCF is given a memory budget of N, N/2 is given to the core while
the other N/2 are given to the VCF reader.

The VCF reader allocates M attribute buffers, where each buffer should have
a size of (N/2)/M, but it currently is allocated N/2 for _each_ buffer,
which over-allocates the VCF reader by a scale of M.

This fixes the issue.