### PR TITLE
Fix selective sample exports

### DIFF
--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -384,9 +384,6 @@ bool Reader::next_read_batch() {
 
   // Sample handles
   read_state_.current_samples.clear();
-  // The samples should be of size to cover the entire range of the sample ids
-  read_state_.current_samples.resize(
-      read_state_.sample_max - read_state_.sample_min + 1);
   for (const auto& s : samples) {
     read_state_.current_samples[s.sample_id - read_state_.sample_min] = s;
   }
@@ -719,6 +716,12 @@ bool Reader::report_cell(
   const auto& results = read_state_.query_results;
   uint32_t samp_idx = results.buffers()->sample().value<uint32_t>(cell_idx) -
                       read_state_.sample_min;
+
+  // Skip this cell if we are not reporting its sample.
+  if (read_state_.current_samples.count(samp_idx) == 0) {
+    return true;
+  }
+
   const auto& sample = read_state_.current_samples[samp_idx];
   const auto& hdr = read_state_.current_hdrs[samp_idx];
 

--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -288,7 +288,7 @@ class Reader {
     uint32_t sample_max = 0;
 
     /** Map of current relative sample ID -> sample name. */
-    std::vector<SampleAndId> current_samples;
+    std::unordered_map<uint32_t, SampleAndId> current_samples;
 
     /** Map of current relative sample ID -> VCF header instance. */
     std::vector<SafeBCFHdr> current_hdrs;


### PR DESCRIPTION
The CLI supports a flag to report a whitelist of sample names:
`-s, --sample-names   CSV list of sample names to export`

Currently, it reports all samples but reports the names of the filtered samples
as an empty string. For instance, `--sample-names v2-tJjMfKyL,v2-ZVudhauk`
exports the following TSV:
```
SAMPLE  CHR     POS
v2-ZVudhauk     chr1    1
        chr1    1
        chr1    1
        chr1    1
        chr1    1
        chr1    1
v2-tJjMfKyL     chr1    1
<snip>
```

The `v2-ZVudhauk` sample has an id of 10 and `v2-tJjMfKyL` has an id of 16,
the missing sample names correspond to samples 11-15, inclusively.

The expected output is:
```
SAMPLE  CHR POS
v2-ZVudhauk chr1  1
v2-tJjMfKyL chr1  1
<snip>
```

There are two parts to this bug:

1. Within `Reader::next_read_batch()`, the `read_state_.current_samples` "map"
   (really a vector) is only populated with the samples that match the
   names passed through the `--sample-names` flag:

```
// Sample handles
read_state_.current_samples.clear();
// The samples should be of size to cover the entire range of the sample ids
read_state_.current_samples.resize(
    read_state_.sample_max - read_state_.sample_min + 1);
for (const auto& s : samples) {
  read_state_.current_samples[s.sample_id - read_state_.sample_min] = s;
}
```

In the above example, only `read_state_.current_samples[0]` (for sample 10) and
`read_state_.current_samples[6]` (for sample 16) are populated. The indexes
1-5 (for samples 11-15) are default: the empty string.

2. Within `Reader::report_cell`, the default-state read_state_.current_samples
elements are reported as an empty string.

---

So the fix is for `Reader::report_cell` to only report the samples that have
been requested. I chose to change `read_state_.current_samples` from a vector
to an unordered_map so that we could check for existence of a sample and then
skip it. Alternatively, we could leave it as a vector and allow the elements
to be flagged as reportable, e.g. vector<Nullable<SampleAndId>>.