### PR TITLE
Added getDefaultRecordByteCount method

### DIFF
--- a/apis/spark/src/main/java/io/tiledb/vcf/Util.java
+++ b/apis/spark/src/main/java/io/tiledb/vcf/Util.java
@@ -1,6 +1,13 @@
 package io.tiledb.vcf;
 
+import org.apache.arrow.vector.BaseValueVector;
+import org.apache.arrow.vector.BaseVariableWidthVector;
+import org.apache.arrow.vector.ValueVector;
+import org.apache.log4j.Logger;
+
 public class Util {
+  private static Logger logger = Logger.getLogger(Util.class);
+
   public static int longToInt(long num) throws ArithmeticException {
 
     if (num > Integer.MAX_VALUE)
@@ -8,5 +15,24 @@ public class Util {
           String.format("Value %d exceeds the maximum integer value.", num));
 
     return (int) num;
+  }
+
+  /**
+   * Returns the record size in bytes. Current implementation always returns 8, but it is intended
+   * for future use.
+   *
+   * @param clazz The input ValueVector class
+   * @return The size in bytes
+   */
+  public static long getDefaultRecordByteCount(Class<? extends ValueVector> clazz) {
+    if (BaseVariableWidthVector.class.isAssignableFrom(clazz)) return 8;
+    else if (BaseValueVector.class.isAssignableFrom(clazz)) return 8;
+
+    logger.warn(
+        "Did not found size of the class with name: "
+            + clazz.getCanonicalName()
+            + " returning 8 as the record size");
+
+    return 8;
   }
 }

--- a/apis/spark/src/test/java/io/tiledb/vcf/UtilTest.java
+++ b/apis/spark/src/test/java/io/tiledb/vcf/UtilTest.java
@@ -1,5 +1,8 @@
 package io.tiledb.vcf;
 
+import org.apache.arrow.vector.BaseValueVector;
+import org.apache.arrow.vector.BaseVariableWidthVector;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class UtilTest {
@@ -7,5 +10,12 @@ public class UtilTest {
   @Test(expected = ArithmeticException.class)
   public void testLongToInt() {
     Util.longToInt(Integer.MAX_VALUE + 1L);
+  }
+
+  @Test
+  public void getDefaultRecordByteCountTest() throws Exception {
+
+    Assert.assertEquals(8, Util.getDefaultRecordByteCount(BaseValueVector.class));
+    Assert.assertEquals(8, Util.getDefaultRecordByteCount(BaseVariableWidthVector.class));
   }
 }


### PR DESCRIPTION
Added `getDefaultRecordByteCount` method that gets the record size in bytes, given a specific Arrow Vector class.