### PR TITLE
Overhaul Dockerfile READMEs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .vscode*
+docker
 dist
 libtiledbvcf/build
 apis/python/build

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Check out our [docs][vcf] for installation and usage instructions:
 
 The docs linked above provide more comprehensive examples but here a few quick exercises to get you started.
 
-By the way, we host a publicly accessible version of the `vcf-samples-20` array on S3. If you have TileDB-VCF installed and you'd like to follow along just swap out the `uri`'s below for `s3://tiledb-inc-demo-data/tiledb-arrays/2.0/vcf-samples-20`. And if you *don't* have TileDB-VCF installed yet, you can use our Docker images to test things out.
+By the way, we host a publicly accessible version of the `vcf-samples-20` array on S3. If you have TileDB-VCF installed and you'd like to follow along just swap out the `uri`'s below for `s3://tiledb-inc-demo-data/tiledb-arrays/2.0/vcf-samples-20`. And if you *don't* have TileDB-VCF installed yet, you can use our [Docker images](docker/README.md) to test things out.
 
 ### CLI
 

--- a/docker/Dockerfile-cli
+++ b/docker/Dockerfile-cli
@@ -29,6 +29,8 @@
 
 FROM amazonlinux:latest
 
+ENV AWS_EC2_METADATA_DISABLED true
+
 # Install some dependencies
 RUN yum -y install which wget git tar gzip unzip gcc-c++ zlib-devel \
        openssl-devel bzip2-devel tbb-devel libcurl-devel xz-devel make \

--- a/docker/Dockerfile-cli
+++ b/docker/Dockerfile-cli
@@ -1,32 +1,3 @@
-#
-# Dockerfile-cli
-#
-#
-# The MIT License
-#
-# Copyright (c) 2018 TileDB, Inc.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
-#
-# This Dockerfile builds the TileDB-VCF CLI image.
-#
-
 FROM amazonlinux:latest
 
 ENV AWS_EC2_METADATA_DISABLED true

--- a/docker/Dockerfile-cli
+++ b/docker/Dockerfile-cli
@@ -50,8 +50,7 @@ RUN cmake .. -DCMAKE_BUILD_TYPE=Release \
              -DOVERRIDE_INSTALL_PREFIX=OFF \
     && make -j4 \
     && make install-libtiledbvcf
-
-WORKDIR /tmp
 RUN rm -rf /tmp/libtiledbvcf
 
+WORKDIR /data
 ENTRYPOINT ["/usr/local/bin/tiledbvcf"]

--- a/docker/Dockerfile-dask-py
+++ b/docker/Dockerfile-dask-py
@@ -1,33 +1,3 @@
-#
-# Dockerfile-py
-#
-#
-# The MIT License
-#
-# Copyright (c) 2018 TileDB, Inc.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
-#
-# This Dockerfile builds a TileDB-VCF Python image suitable for use in a dask
-# environment.
-#
-
 FROM daskdev/dask:latest
 
 RUN conda config --prepend channels conda-forge

--- a/docker/Dockerfile-py
+++ b/docker/Dockerfile-py
@@ -56,4 +56,4 @@ RUN python setup.py install
 RUN rm -rf /tmp/tiledbvcf
 
 WORKDIR /data
-CMD ["python3"]
+ENTRYPOINT ["python3"]

--- a/docker/Dockerfile-py
+++ b/docker/Dockerfile-py
@@ -31,6 +31,7 @@ FROM continuumio/miniconda3:4.8.2
 ENV CFLAGS "-march=haswell"
 ENV CPPFLAGS "-march=haswell"
 
+ENV AWS_EC2_METADATA_DISABLED true
 ENV TILEDBVCF_FORCE_EXTERNAL_HTSLIB=OFF
 ENV LD_LIBRARY_PATH=/usr/local/lib:/opt/conda/lib
 

--- a/docker/Dockerfile-py
+++ b/docker/Dockerfile-py
@@ -1,32 +1,3 @@
-#
-# Dockerfile-py
-#
-#
-# The MIT License
-#
-# Copyright (c) 2018 TileDB, Inc.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
-#
-# This Dockerfile builds the TileDB-VCF Python image.
-#
-
 FROM continuumio/miniconda3:4.8.2
 ENV CFLAGS "-march=haswell"
 ENV CPPFLAGS "-march=haswell"

--- a/docker/Dockerfile-py
+++ b/docker/Dockerfile-py
@@ -50,7 +50,10 @@ RUN conda env update -n base -f conda-env.yml \
 
 WORKDIR /tmp
 COPY . tiledbvcf
-RUN cd tiledbvcf/apis/python && python setup.py install
 
-RUN cd /tmp && rm -rf tiledbvcf
+WORKDIR /tmp/tiledbvcf/apis/python
+RUN python setup.py install
+RUN rm -rf /tmp/tiledbvcf
+
+WORKDIR /data
 CMD ["python3"]

--- a/docker/Dockerfile-py
+++ b/docker/Dockerfile-py
@@ -53,4 +53,4 @@ COPY . tiledbvcf
 RUN cd tiledbvcf/apis/python && python setup.py install
 
 RUN cd /tmp && rm -rf tiledbvcf
-ENTRYPOINT ["/bin/bash"]
+CMD ["python3"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -23,8 +23,9 @@ Pre-built images are available on [Docker Hub][docker].
 * `dev`: development version
 * `v0.x.x` for a specific version
 
+## Parameters
 
-## Building
+* `AWS_EC2_METADATA_DISABLED` Disable the EC2 metadata service (default `true`). This avoids unnecessary API calls when querying S3-hosted arrays from non-EC2 clients. If you are on an EC2 instance this service can be enabled with `-e AWS_EC2_METADATA_DISABLED=false`.
 
 ## Building locally
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -55,14 +55,14 @@ You can use the `tiledbvcf-cli` image to run any of the CLI's [available command
 List all samples in the dataset:
 
 ```sh
-docker run --rm tiledbvcf-cli list \
+docker run --rm tiledb/tiledbvcf-cli list \
   --uri s3://tiledb-inc-demo-data/tiledb-arrays/2.0/vcf-samples-20
 ```
 
 Create a table of all variants within a region of interest for sample `v2-WpXCYApL` and save the results in `./exported-vars.tsv`.
 
 ```sh
-docker run --rm -v $PWD:/data tiledbvcf-cli export \
+docker run --rm -v $PWD:/data tiledb/tiledbvcf-cli export \
   --uri s3://tiledb-inc-demo-data/tiledb-arrays/2.0/vcf-samples-20 \
   -Ot --tsv-fields "CHR,POS,REF,S:GT" \
   --output-path exported-vars.tsv \
@@ -75,7 +75,7 @@ docker run --rm -v $PWD:/data tiledbvcf-cli export \
 You can use the `tiledbcf-py` container to execute an external script or launch an interactive Python session.
 
 ```
-docker run -it --rm tiledbvcf-py
+docker run -it --rm tiledb/tiledbvcf-py
 ```
 
 The following script performs the same query as above but returns a pandas `DataFrame`:

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,38 +1,72 @@
-# TileDB-VCF docker images
+# TileDB-VCF Docker Images
 
-This directory contains the Dockerfiles to build containers for various components of TileDB-VCF.
+TileDB-VCF is a C++ library for efficient storage and retrieval of genomic variant-call data using [TileDB][].
 
-## `Dockerfile-cli`
+Pre-built images are available on [Docker Hub](https://hub.docker.com/u/tiledb) with the following tags:
 
-This image builds the main TileDB-VCF library and CLI tool:
-```bash
-$ cd TileDB-VCF/
-$ docker build -f docker/Dockerfile-cli -t tiledbvcf-cli .
+* `latest`: latest stable release (*recommended*)
+* `dev`: development version
 
-# To test:
-$ docker run --rm -it tiledbvcf-cli --version  # or '--help'
-TileDB-VCF build
-TileDB version 1.6.2
+## Building
+
+You can also build the Dockerfiles locally by cloning the TileDB-VCF repository from GitHub and running the following commands:
+
+```sh
+git clone https://github.com/TileDB-Inc/TileDB-VCF.git
+cd TileDB-VCF
+
+# build the cli image
+docker build -f docker/Dockerfile-cli .
+
+# build the python library
+docker build -f docker/Dockerfile-py .
 ```
 
-## `Dockerfile-py`
+## Usage
 
-This image builds the main TileDB-VCF Python module and API:
-```bash
-$ cd TileDB-VCF/
-$ docker build -f docker/Dockerfile-py -t tiledbvcf-py .
+In these examples we'll use a publicly accessible TileDB-VCF dataset hosted on S3. TileDB provides native support for a number of cloud storage backends, so you can work with this data directly, without having to download it first.
 
-# To test:
-$ docker run --rm -it --entrypoint python tiledbvcf-py
->>> import tiledbvcf
->>> # If no errors occur when importing, installation succeeded.
+### CLI
+
+Create a table of all variants within one or more regions of interest for 2 samples:
+
+```sh
+docker run --rm tiledbvcf-cli:dev export \
+  --uri s3://tiledb-inc-demo-data/tiledb-arrays/2.0/vcf-samples-20 \
+  -Ot --tsv-fields CHR,POS,REF,S:GT \
+  --sample-names v2-usVwJUmo,v2-WpXCYApL \
+  --regions chr1:1-50000
 ```
 
+### Python
 
-## `Dockerfile-dask-py`
+You can use the `tiledbcf-py` image to execute an external script or launch an interactive Python session.
 
-This image builds a TileDB-VCF Python image suitable for use as the image for a dask worker:
-```bash
-$ cd TileDB-VCF/
-$ docker build -f docker/Dockerfile-dask-py -t tiledbvcf-dask-py .
 ```
+docker run -it --rm tiledbvcf-py:dev
+```
+
+Performing the same query in python returns a pandas `DataFrame`
+
+```py
+import tiledbvcf
+
+uri = "s3://tiledb-inc-demo-data/tiledb-arrays/2.0/vcf-samples-20"
+
+# open the array in 'read' mode
+ds = tiledbvcf.TileDBVCFDataset(uri, mode = "r")
+
+ds.read(
+  attrs=['sample_name', 'pos_start', 'pos_end', 'alleles'],
+  regions=['chr1:1-50000'],
+  samples=['v2-usVwJUmo', 'v2-WpXCYApL']
+)
+```
+
+## Want to learn more?
+
+Check out [TileDB-VCF's docs][vcf] for installation instructions, in-depth descriptions of the data format and algorithms, more examples and in-depth tutorials.
+
+<!-- links -->
+[tiledb]: https://tiledb.com
+[vcf]: https://docs.tiledb.com/genomics/

--- a/docker/README.md
+++ b/docker/README.md
@@ -99,6 +99,10 @@ ds.read(
 
 Check out [TileDB-VCF's docs][vcf-docs] for installation instructions, detailed descriptions of the data format and algorithms, and in-depth tutorials.
 
+## License
+
+This project is licensed under the MIT License - see the [LICENSE.md](https://github.com/TileDB-Inc/TileDB-VCF/blob/master/LICENSE) file for details.
+
 <!-- links -->
 [vcf-repo]: https://github.com/TileDB-Inc/TileDB-VCF
 [docker]: https://hub.docker.com/u/tiledb

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,14 +2,33 @@
 
 TileDB-VCF is a C++ library for efficient storage and retrieval of genomic variant-call data using [TileDB][].
 
-Pre-built images are available on [Docker Hub](https://hub.docker.com/u/tiledb) with the following tags:
+## Quick reference
+
+* :blue_book: [TileDB-VCF docs][vcf-docs]
+* :package: [TileDB-VCF repo][vcf-repo]
+* :whale: [Docker Hub][docker]
+
+## Images
+
+Pre-built images are available on [Docker Hub][docker].
+
+### Variants
+
+- [`tiledbvcf-cli`](https://hub.docker.com/r/tiledb/tiledbvcf-cli) for the command line interface (CLI)
+- [`tiledbvcf-py`](https://hub.docker.com/r/tiledb/tiledbvcf-py) for the Python module
+
+### Supported tags
 
 * `latest`: latest stable release (*recommended*)
 * `dev`: development version
+* `v0.x.x` for a specific version
+
 
 ## Building
 
-You can also build the Dockerfiles locally by cloning the TileDB-VCF repository from GitHub and running the following commands:
+## Building locally
+
+To build the Dockerfiles locally you need to clone the [TileDB-VCF][vcf-repo] repository from GitHub and run `docker build` from within the local repo's root directory.
 
 ```sh
 git clone https://github.com/TileDB-Inc/TileDB-VCF.git
@@ -24,29 +43,41 @@ docker build -f docker/Dockerfile-py .
 
 ## Usage
 
-In these examples we'll use a publicly accessible TileDB-VCF dataset hosted on S3. TileDB provides native support for a number of cloud storage backends, so you can work with this data directly, without having to download it first.
+The following examples are meant to provide a quick overview of how to use these containers. See our [docs][vcf-docs] for more comprehensive introductions to TileDB-VCF's functionality.
+
+Here, we're using a publicly accessible [TileDB-VCF dataset][vcf-samples-20] hosted on S3 that contains genome-wide variants for 20 synthetic samples. To pass in a local array or save exported files you will need to bind a local directory to the container's `/data` directory.
 
 ### CLI
 
-Create a table of all variants within one or more regions of interest for 2 samples:
+You can use the `tiledbvcf-cli` image to run any of the CLI's [available commands][cli-api].
+
+List all samples in the dataset:
 
 ```sh
-docker run --rm tiledbvcf-cli:dev export \
+docker run --rm tiledbvcf-cli list \
+  --uri s3://tiledb-inc-demo-data/tiledb-arrays/2.0/vcf-samples-20
+```
+
+Create a table of all variants within a region of interest for sample `v2-WpXCYApL` and save the results in `./exported-vars.tsv`.
+
+```sh
+docker run --rm -v $PWD:/data tiledbvcf-cli export \
   --uri s3://tiledb-inc-demo-data/tiledb-arrays/2.0/vcf-samples-20 \
-  -Ot --tsv-fields CHR,POS,REF,S:GT \
-  --sample-names v2-usVwJUmo,v2-WpXCYApL \
-  --regions chr1:1-50000
+  -Ot --tsv-fields "CHR,POS,REF,S:GT" \
+  --output-path exported-vars.tsv \
+  --regions chr7:144000320-144008793 \
+  --sample-names v2-WpXCYApL
 ```
 
 ### Python
 
-You can use the `tiledbcf-py` image to execute an external script or launch an interactive Python session.
+You can use the `tiledbcf-py` container to execute an external script or launch an interactive Python session.
 
 ```
-docker run -it --rm tiledbvcf-py:dev
+docker run -it --rm tiledbvcf-py
 ```
 
-Performing the same query in python returns a pandas `DataFrame`
+The following script performs the same query as above but returns a pandas `DataFrame`:
 
 ```py
 import tiledbvcf
@@ -58,15 +89,20 @@ ds = tiledbvcf.TileDBVCFDataset(uri, mode = "r")
 
 ds.read(
   attrs=['sample_name', 'pos_start', 'pos_end', 'alleles'],
-  regions=['chr1:1-50000'],
-  samples=['v2-usVwJUmo', 'v2-WpXCYApL']
+  regions=['chr7:144000320-144008793'],
+  samples=['v2-WpXCYApL']
 )
 ```
 
 ## Want to learn more?
 
-Check out [TileDB-VCF's docs][vcf] for installation instructions, in-depth descriptions of the data format and algorithms, more examples and in-depth tutorials.
+Check out [TileDB-VCF's docs][vcf-docs] for installation instructions, detailed descriptions of the data format and algorithms, and in-depth tutorials.
 
 <!-- links -->
+[vcf-repo]: https://github.com/TileDB-Inc/TileDB-VCF
+[docker]: https://hub.docker.com/u/tiledb
 [tiledb]: https://tiledb.com
-[vcf]: https://docs.tiledb.com/genomics/
+[vcf-docs]: https://docs.tiledb.com/genomics/
+[cli-api]: https://docs.tiledb.com/genomics/apis/cli
+[py-api]: https://docs.tiledb.com/genomics/apis/python
+[vcf-samples-20]: https://console.tiledb.com/arrays/details/TileDB-Inc/vcf-samples-20-data

--- a/docker/README.md
+++ b/docker/README.md
@@ -72,7 +72,7 @@ docker run --rm -v $PWD:/data tiledb/tiledbvcf-cli export \
 
 ### Python
 
-You can use the `tiledbcf-py` container to execute an external script or launch an interactive Python session.
+You can use the `tiledbvcf-py` container to execute an external script or launch an interactive Python session.
 
 ```
 docker run -it --rm tiledb/tiledbvcf-py
@@ -93,6 +93,21 @@ ds.read(
   regions=['chr7:144000320-144008793'],
   samples=['v2-WpXCYApL']
 )
+
+##     sample_name  pos_start    pos_end         alleles
+## 0   v2-WpXCYApL  143999628  144000483  [G, <NON_REF>]
+## 1   v2-WpXCYApL  144000484  144001253  [C, <NON_REF>]
+## 2   v2-WpXCYApL  144001254  144001494  [G, <NON_REF>]
+## 3   v2-WpXCYApL  144001495  144001735  [T, <NON_REF>]
+## 4   v2-WpXCYApL  144001736  144001900  [C, <NON_REF>]
+## ..          ...        ...        ...             ...
+## 66  v2-WpXCYApL  144008445  144008467  [C, <NON_REF>]
+## 67  v2-WpXCYApL  144008468  144008479  [T, <NON_REF>]
+## 68  v2-WpXCYApL  144008480  144008690  [A, <NON_REF>]
+## 69  v2-WpXCYApL  144008691  144008697  [A, <NON_REF>]
+## 70  v2-WpXCYApL  144008698  144008846  [C, <NON_REF>]
+##
+## [71 rows x 4 columns]
 ```
 
 ## Want to learn more?


### PR DESCRIPTION
New [README](https://github.com/TileDB-Inc/TileDB-VCF/blob/aw/ch2596/docker-quickstart/docker/README.md) for Dockerfiles that includes a quick start guide for `tiledbvcf-py` and `tiledbvcf-cli`. Mainly intended for Docker Hub. 

Other changes:

- final working directory is now `/data` rather than `/temp`
- `tiledbvcf-py` can be used to execute a script or launch an interactive session
- set `AWS_EC2_METADATA_DISABLED` env variable to avoid slow down caused by the (typically) necessary API calls
