### PR TITLE
Add AD field back to spark schema

### DIFF
--- a/apis/spark/src/main/java/io/tiledb/vcf/VCFSparkSchema.java
+++ b/apis/spark/src/main/java/io/tiledb/vcf/VCFSparkSchema.java
@@ -134,15 +134,15 @@ public class VCFSparkSchema implements Serializable {
                 true,
                 metadata.build()));
     //    // AD field in FORMAT block of BCF
-    //    metadata = new MetadataBuilder();
-    //    metadata.putString("comment", "AD field in FORMAT block of BCF");
-    //    schema =
-    //        schema.add(
-    //            new StructField(
-    //                "fmt_AD",
-    //                DataTypes.createArrayType(DataTypes.IntegerType, false),
-    //                true,
-    //                metadata.build()));
+    metadata = new MetadataBuilder();
+    metadata.putString("comment", "AD field in FORMAT block of BCF");
+    schema =
+        schema.add(
+            new StructField(
+                "fmt_AD",
+                DataTypes.createArrayType(DataTypes.IntegerType, false),
+                true,
+                metadata.build()));
     // DP field in FORMAT block of BCF
     metadata = new MetadataBuilder();
     metadata.putString("comment", "DP field in FORMAT block of BCF");

--- a/apis/spark/src/test/java/io/tiledb/vcf/VCFDatasourceTest.java
+++ b/apis/spark/src/test/java/io/tiledb/vcf/VCFDatasourceTest.java
@@ -58,7 +58,7 @@ public class VCFDatasourceTest extends SharedJavaSparkSession {
     dfRead.createOrReplaceTempView("vcf");
 
     long numColumns = spark.sql("SHOW COLUMNS FROM vcf").count();
-    Assert.assertEquals(numColumns, 14l);
+    Assert.assertEquals(numColumns, 15l);
 
     List<Row> colNameList = spark.sql("SHOW COLUMNS FROM vcf").collectAsList();
     List<String> colNames =
@@ -73,6 +73,7 @@ public class VCFDatasourceTest extends SharedJavaSparkSession {
             "alleles",
             "filter",
             "genotype",
+            "fmt_AD",
             "fmt_DP",
             "fmt_GQ",
             "fmt_MIN_DP",
@@ -387,17 +388,16 @@ public class VCFDatasourceTest extends SharedJavaSparkSession {
     Assert.assertArrayEquals(expectedEnd, resultEnd);
   }
 
-  // TODO(ttd) commenting out because AD is not in the default schema
-  //  @Test
-  //  public void testADNull() {
-  //    Dataset<Row> dfRead = testSampleDataset();
-  //    List<Row> rows = dfRead.select("fmt_AD").collectAsList();
-  //    Assert.assertEquals(10, rows.size());
-  //    // assert all are null
-  //    for (int i = 0; i < rows.size(); i++) {
-  //      Assert.assertTrue(rows.get(i).isNullAt(0));
-  //    }
-  //  }
+  @Test
+  public void testADNull() {
+    Dataset<Row> dfRead = testSampleDataset();
+    List<Row> rows = dfRead.select("fmt_AD").collectAsList();
+    Assert.assertEquals(10, rows.size());
+    // assert all are null
+    for (int i = 0; i < rows.size(); i++) {
+      Assert.assertTrue(rows.get(i).isNullAt(0));
+    }
+  }
 
   @Test
   public void testFmtInfoUdf() {


### PR DESCRIPTION
Even through this field is not default materialized, it is still a helpful field to show in spark for users to access.