### PR TITLE
Allow spark schema to be dynamic

### DIFF
--- a/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.c
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.c
@@ -520,6 +520,123 @@ Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1get_1attribute_1ty
   return rc;
 }
 
+JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1get_1attribute_1count
+  (JNIEnv* env, jclass self, jlong readerPtr, jintArray countOut) {
+  (void)self;
+  tiledb_vcf_reader_t* reader = (tiledb_vcf_reader_t*)readerPtr;
+  if (reader == 0) {
+    return TILEDB_VCF_ERR;
+  }
+
+  int32_t count;
+  int32_t rc = tiledb_vcf_reader_get_attribute_count(reader, &count);
+  if (rc == TILEDB_VCF_OK) {
+    return set_out_param_int32(env, count, countOut);
+  }
+
+    return rc;
+}
+
+JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1get_1attribute_1name
+  (JNIEnv* env, jclass self, jlong readerPtr, jint index, jbyteArray nameOut) {
+  (void)self;
+  tiledb_vcf_reader_t* reader = (tiledb_vcf_reader_t*)readerPtr;
+  if (reader == 0) {
+    return TILEDB_VCF_ERR;
+  }
+
+  char *buf;
+  int32_t rc = tiledb_vcf_reader_get_attribute_name(reader, index, &buf);
+  if (rc == TILEDB_VCF_OK) {
+//    nameOut = (*env)->NewStringUTF(env, buf);
+    int length = strlen(buf);
+    (*env)->SetByteArrayRegion(env, nameOut, 0, length, buf);
+  }
+
+  if (buf != NULL)
+    free(buf);
+
+  return rc;
+}
+
+JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1get_1fmt_1attribute_1count
+  (JNIEnv* env, jclass self, jlong readerPtr, jintArray countOut) {
+  (void)self;
+  tiledb_vcf_reader_t* reader = (tiledb_vcf_reader_t*)readerPtr;
+  if (reader == 0) {
+    return TILEDB_VCF_ERR;
+  }
+
+  int32_t count;
+  int32_t rc = tiledb_vcf_reader_get_fmt_attribute_count(reader, &count);
+    if (rc == TILEDB_VCF_OK) {
+      return set_out_param_int32(env, count, countOut);
+    }
+
+    return rc;
+}
+
+JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1get_1fmt_1attribute_1name
+  (JNIEnv* env, jclass self, jlong readerPtr, jint index, jbyteArray nameOut) {
+  (void)self;
+  tiledb_vcf_reader_t* reader = (tiledb_vcf_reader_t*)readerPtr;
+  if (reader == 0) {
+    return TILEDB_VCF_ERR;
+  }
+
+  char *buf;
+  int32_t rc = tiledb_vcf_reader_get_fmt_attribute_name(reader, index, &buf);
+  if (rc == TILEDB_VCF_OK) {
+//    nameOut = (*env)->NewStringUTF(env, buf);
+    int length = strlen(buf);
+    (*env)->SetByteArrayRegion(env, nameOut, 0, length, buf);
+  }
+
+  if (buf != NULL)
+    free(buf);
+
+  return rc;
+}
+
+JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1get_1info_1attribute_1count
+  (JNIEnv* env, jclass self, jlong readerPtr, jintArray countOut) {
+  (void)self;
+  tiledb_vcf_reader_t* reader = (tiledb_vcf_reader_t*)readerPtr;
+  if (reader == 0) {
+    return TILEDB_VCF_ERR;
+  }
+
+  int32_t count;
+  int32_t rc = tiledb_vcf_reader_get_info_attribute_count(reader, &count);
+  if (rc == TILEDB_VCF_OK) {
+    return set_out_param_int32(env, count, countOut);
+  }
+
+    return rc;
+}
+
+JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1get_1info_1attribute_1name
+  (JNIEnv* env, jclass self, jlong readerPtr, jint index, jbyteArray nameOut) {
+  (void)self;
+  tiledb_vcf_reader_t* reader = (tiledb_vcf_reader_t*)readerPtr;
+  if (reader == 0) {
+    return TILEDB_VCF_ERR;
+  }
+
+  char *buf;
+  int32_t rc = tiledb_vcf_reader_get_info_attribute_name(reader, index, &buf);
+  if (rc == TILEDB_VCF_OK) {
+//    nameOut = (*env)->NewStringUTF(env, buf);
+    int length = strlen(buf);
+    (*env)->SetByteArrayRegion(env, nameOut, 0, length, buf);
+  }
+
+  if (buf != NULL)
+    free(buf);
+
+  return rc;
+}
+
 JNIEXPORT jint JNICALL
 Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1get_1dataset_1version(
     JNIEnv* env, jclass self, jlong readerPtr, jintArray versionOut) {

--- a/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.c
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.c
@@ -529,7 +529,7 @@ JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1rea
   }
 
   int32_t count;
-  int32_t rc = tiledb_vcf_reader_get_attribute_count(reader, &count);
+  int32_t rc = tiledb_vcf_reader_get_queryable_attribute_count(reader, &count);
   if (rc == TILEDB_VCF_OK) {
     return set_out_param_int32(env, count, countOut);
   }
@@ -546,15 +546,11 @@ JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1rea
   }
 
   char *buf;
-  int32_t rc = tiledb_vcf_reader_get_attribute_name(reader, index, &buf);
+  int32_t rc = tiledb_vcf_reader_get_queryable_attribute_name(reader, index, &buf);
   if (rc == TILEDB_VCF_OK) {
-//    nameOut = (*env)->NewStringUTF(env, buf);
     int length = strlen(buf);
     (*env)->SetByteArrayRegion(env, nameOut, 0, length, buf);
   }
-
-  if (buf != NULL)
-    free(buf);
 
   return rc;
 }
@@ -569,11 +565,11 @@ JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1rea
 
   int32_t count;
   int32_t rc = tiledb_vcf_reader_get_fmt_attribute_count(reader, &count);
-    if (rc == TILEDB_VCF_OK) {
-      return set_out_param_int32(env, count, countOut);
-    }
+  if (rc == TILEDB_VCF_OK) {
+    return set_out_param_int32(env, count, countOut);
+  }
 
-    return rc;
+  return rc;
 }
 
 JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1get_1fmt_1attribute_1name
@@ -587,13 +583,9 @@ JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1rea
   char *buf;
   int32_t rc = tiledb_vcf_reader_get_fmt_attribute_name(reader, index, &buf);
   if (rc == TILEDB_VCF_OK) {
-//    nameOut = (*env)->NewStringUTF(env, buf);
     int length = strlen(buf);
     (*env)->SetByteArrayRegion(env, nameOut, 0, length, buf);
   }
-
-  if (buf != NULL)
-    free(buf);
 
   return rc;
 }
@@ -612,7 +604,7 @@ JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1rea
     return set_out_param_int32(env, count, countOut);
   }
 
-    return rc;
+  return rc;
 }
 
 JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1get_1info_1attribute_1name
@@ -626,13 +618,9 @@ JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1rea
   char *buf;
   int32_t rc = tiledb_vcf_reader_get_info_attribute_name(reader, index, &buf);
   if (rc == TILEDB_VCF_OK) {
-//    nameOut = (*env)->NewStringUTF(env, buf);
     int length = strlen(buf);
     (*env)->SetByteArrayRegion(env, nameOut, 0, length, buf);
   }
-
-  if (buf != NULL)
-    free(buf);
 
   return rc;
 }

--- a/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.h
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.h
@@ -185,6 +185,54 @@ JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1rea
 
 /*
  * Class:     io_tiledb_libvcfnative_LibVCFNative
+ * Method:    tiledb_vcf_reader_get_attribute_count
+ * Signature: (J[I)I
+ */
+JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1get_1attribute_1count
+  (JNIEnv *, jclass, jlong, jintArray);
+
+/*
+ * Class:     io_tiledb_libvcfnative_LibVCFNative
+ * Method:    tiledb_vcf_reader_get_attribute_name
+ * Signature: (JI[B)I
+ */
+JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1get_1attribute_1name
+  (JNIEnv *, jclass, jlong, jint, jbyteArray);
+
+/*
+ * Class:     io_tiledb_libvcfnative_LibVCFNative
+ * Method:    tiledb_vcf_reader_get_fmt_attribute_count
+ * Signature: (J[I)I
+ */
+JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1get_1fmt_1attribute_1count
+  (JNIEnv *, jclass, jlong, jintArray);
+
+/*
+ * Class:     io_tiledb_libvcfnative_LibVCFNative
+ * Method:    tiledb_vcf_reader_get_fmt_attribute_name
+ * Signature: (JI[B)I
+ */
+JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1get_1fmt_1attribute_1name
+  (JNIEnv *, jclass, jlong, jint, jbyteArray);
+
+/*
+ * Class:     io_tiledb_libvcfnative_LibVCFNative
+ * Method:    tiledb_vcf_reader_get_info_attribute_count
+ * Signature: (J[I)I
+ */
+JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1get_1info_1attribute_1count
+  (JNIEnv *, jclass, jlong, jintArray);
+
+/*
+ * Class:     io_tiledb_libvcfnative_LibVCFNative
+ * Method:    tiledb_vcf_reader_get_info_attribute_name
+ * Signature: (JI[B)I
+ */
+JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1get_1info_1attribute_1name
+  (JNIEnv *, jclass, jlong, jint, jbyteArray);
+
+/*
+ * Class:     io_tiledb_libvcfnative_LibVCFNative
  * Method:    tiledb_vcf_reader_get_dataset_version
  * Signature: (J[I)I
  */

--- a/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.java
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.java
@@ -83,6 +83,23 @@ public class LibVCFNative {
   public static final native int tiledb_vcf_reader_get_attribute_type(
       long readerPtr, String attribute, int[] datatype, int[] varLen, int[] nullable, int[] isList);
 
+  public static final native int tiledb_vcf_reader_get_attribute_count(long readerPtr, int[] count);
+
+  public static final native int tiledb_vcf_reader_get_attribute_name(
+      long readerPtr, int index, byte[] name);
+
+  public static final native int tiledb_vcf_reader_get_fmt_attribute_count(
+      long readerPtr, int[] count);
+
+  public static final native int tiledb_vcf_reader_get_fmt_attribute_name(
+      long readerPtr, int index, byte[] name);
+
+  public static final native int tiledb_vcf_reader_get_info_attribute_count(
+      long readerPtr, int[] count);
+
+  public static final native int tiledb_vcf_reader_get_info_attribute_name(
+      long readerPtr, int index, byte[] name);
+
   public static final native int tiledb_vcf_reader_get_dataset_version(
       long readerPtr, int[] version);
 

--- a/apis/java/src/main/java/io/tiledb/libvcfnative/NativeLibLoader.java
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/NativeLibLoader.java
@@ -48,8 +48,13 @@ public class NativeLibLoader {
     String versionedLibName;
     try {
       versionedLibName = getVersionedName();
-      logger.info("Loaded libtiledb library: " + versionedLibName);
-      loadNativeLib(versionedLibName, false);
+      if (versionedLibName != null) {
+        logger.info("Loaded libtiledb library: " + versionedLibName);
+        loadNativeLib(versionedLibName, false);
+      } else {
+        logger.info(
+            "libtiledb library not in JAR, assuming system version exists or linker errors will occur");
+      }
     } catch (java.lang.UnsatisfiedLinkError e) {
       // If a native library fails to link, we fall back to depending on the system
       // dynamic linker to satisfy the requirement. Therefore, we do nothing here

--- a/apis/java/src/main/java/io/tiledb/libvcfnative/VCFReader.java
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/VCFReader.java
@@ -144,8 +144,6 @@ public class VCFReader implements AutoCloseable {
       int j;
       for (j = 0; j < nameBytes.length && nameBytes[j] != 0; j++) {}
       String name = new String(nameBytes, 0, j);
-      if (name.equals("real_start_pos"))
-        continue;
       res.put(name, getAttributeDatatype(name));
     }
 

--- a/apis/java/src/main/java/io/tiledb/libvcfnative/VCFReader.java
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/VCFReader.java
@@ -57,6 +57,10 @@ public class VCFReader implements AutoCloseable {
     }
   }
 
+  public final Map<String, AttributeTypeInfo> attributes;
+  public final Map<String, AttributeTypeInfo> fmtAttributes;
+  public final Map<String, AttributeTypeInfo> infoAttributes;
+
   public VCFReader(
       String uri, String[] samples, Optional<URI> samplesURI, Optional<String> config) {
     long[] readerPtrArray = new long[1];
@@ -87,7 +91,7 @@ public class VCFReader implements AutoCloseable {
       throw new RuntimeException("Error initializing reader object: " + msg);
     }
 
-    if (samples.length > 0) {
+    if (samples != null && samples.length > 0) {
       String samplesCSV = String.join(",", samples);
       rc = LibVCFNative.tiledb_vcf_reader_set_samples(readerPtrArray[0], samplesCSV);
       if (rc != 0) {
@@ -115,6 +119,87 @@ public class VCFReader implements AutoCloseable {
 
     readerPtr = readerPtrArray[0];
     buffers = new HashMap<>();
+
+    attributes = compileAttributeList();
+    fmtAttributes = compileFmtAttributeList();
+    infoAttributes = compileInfoAttributeList();
+  }
+
+  private Map<String, AttributeTypeInfo> compileAttributeList() {
+    int[] count = new int[1];
+    int rc = LibVCFNative.tiledb_vcf_reader_get_attribute_count(readerPtr, count);
+    if (rc != 0) {
+      String msg = getLastErrorMessage();
+      throw new RuntimeException("Error compiling list of dataset attributes: " + msg);
+    }
+
+    Map<String, AttributeTypeInfo> res = new HashMap<>();
+    for (int i = 0; i < count[0]; i++) {
+      byte[] nameBytes = new byte[1024];
+      rc = LibVCFNative.tiledb_vcf_reader_get_attribute_name(readerPtr, i, nameBytes);
+      if (rc != 0) {
+        String msg = getLastErrorMessage();
+        throw new RuntimeException("Error compiling list of dataset attributes: " + msg);
+      }
+      int j;
+      for (j = 0; j < nameBytes.length && nameBytes[j] != 0; j++) {}
+      String name = new String(nameBytes, 0, j);
+      if (name.equals("real_start_pos"))
+        continue;
+      res.put(name, getAttributeDatatype(name));
+    }
+
+    return res;
+  }
+
+  private Map<String, AttributeTypeInfo> compileFmtAttributeList() {
+    int[] count = new int[1];
+    int rc = LibVCFNative.tiledb_vcf_reader_get_fmt_attribute_count(readerPtr, count);
+    if (rc != 0) {
+      String msg = getLastErrorMessage();
+      throw new RuntimeException("Error compiling list of dataset attributes: " + msg);
+    }
+
+    Map<String, AttributeTypeInfo> res = new HashMap<>();
+    for (int i = 0; i < count[0]; i++) {
+      byte[] nameBytes = new byte[1024];
+      rc = LibVCFNative.tiledb_vcf_reader_get_fmt_attribute_name(readerPtr, i, nameBytes);
+      if (rc != 0) {
+        String msg = getLastErrorMessage();
+        throw new RuntimeException("Error compiling list of dataset attributes: " + msg);
+      }
+      int j;
+      for (j = 0; j < nameBytes.length && nameBytes[j] != 0; j++) {}
+      String name = new String(nameBytes, 0, j);
+      res.put(name, getAttributeDatatype(name));
+    }
+
+    return res;
+  }
+
+  private Map<String, AttributeTypeInfo> compileInfoAttributeList() {
+    int[] count = new int[1];
+    int rc = LibVCFNative.tiledb_vcf_reader_get_info_attribute_count(readerPtr, count);
+    if (rc != 0) {
+      String msg = getLastErrorMessage();
+      throw new RuntimeException("Error compiling list of dataset attributes: " + msg);
+    }
+
+    Map<String, AttributeTypeInfo> res = new HashMap<>();
+    for (int i = 0; i < count[0]; i++) {
+      byte[] nameBytes = new byte[1024];
+      rc = LibVCFNative.tiledb_vcf_reader_get_info_attribute_name(readerPtr, i, nameBytes);
+      if (rc != 0) {
+        String msg = getLastErrorMessage();
+        throw new RuntimeException("Error compiling list of dataset attributes: " + msg);
+      }
+      int j;
+      for (j = 0; j < nameBytes.length && nameBytes[j] != 0; j++) {}
+      String name = new String(nameBytes, 0, j);
+      res.put(name, getAttributeDatatype(name));
+    }
+
+    return res;
   }
 
   private String getLastErrorMessage() {

--- a/apis/java/src/test/java/io/tiledb/libvcfnative/VCFReaderTest.java
+++ b/apis/java/src/test/java/io/tiledb/libvcfnative/VCFReaderTest.java
@@ -206,4 +206,18 @@ public class VCFReaderTest {
     reader.setStatsEnabled(true);
     Assert.assertNotNull(reader.stats());
   }
+
+  /**
+   * * Checks that the reader attribute details are initialized in constructor
+   *
+   * @throws IOException
+   */
+  @Test
+  public void testAttributes() throws IOException {
+    VCFReader reader = getVFCReader(Optional.of(new String[] {getSamples()[0]}), Optional.empty());
+
+    Assert.assertTrue(reader.attributes.size() > 0);
+    Assert.assertTrue(reader.fmtAttributes.size() > 0);
+    Assert.assertTrue(reader.infoAttributes.size() > 0);
+  }
 }

--- a/apis/spark/src/main/java/io/tiledb/util/CredentialProviderUtils.java
+++ b/apis/spark/src/main/java/io/tiledb/util/CredentialProviderUtils.java
@@ -17,7 +17,13 @@ public final class CredentialProviderUtils {
   private static final String TILEDB_SECRET_KEY_PROP = "tiledb.vfs.s3.aws_secret_access_key";
   private static final String TILEDB_SESSION_TOKEN_PROP = "tiledb.vfs.s3.aws_session_token";
 
-  /** Builds a credentials provider using Java's reflection API. */
+  /**
+   * Builds a credentials provider using Java's reflection API.
+   *
+   * @param className class of credential provider
+   * @param roleArn IAM role arn to use
+   * @return credential provider
+   */
   public static Optional<AWSSessionCredentialsProvider> get(
       final String className, final String roleArn) {
 
@@ -35,7 +41,12 @@ public final class CredentialProviderUtils {
     }
   }
 
-  /** Builds a key-value configuration map of tile-db AWS credentials. */
+  /**
+   * Builds a key-value configuration map of tile-db AWS credentials.
+   *
+   * @param provider aws credential provider
+   * @return map of configuration
+   */
   public static Map<String, String> buildConfigMap(final AWSSessionCredentialsProvider provider) {
     final AWSSessionCredentials credentials = provider.getCredentials();
     return ImmutableMap.of(

--- a/apis/spark/src/main/java/io/tiledb/vcf/VCFDataSourceOptions.java
+++ b/apis/spark/src/main/java/io/tiledb/vcf/VCFDataSourceOptions.java
@@ -132,6 +132,7 @@ public class VCFDataSourceOptions implements Serializable {
   /**
    * Generic parser of key-value property maps into a CSV.
    *
+   * @param configMap csv config map
    * @return Optional CSV String of config parameters
    */
   protected static Optional<String> getConfigCSV(final Map<String, String> configMap) {
@@ -153,6 +154,8 @@ public class VCFDataSourceOptions implements Serializable {
   /**
    * Combines two optional configuration into one.
    *
+   * @param first first config to combine
+   * @param second second config to combine
    * @return Optional CSV String of config parameters.
    */
   protected static Optional<String> combineCsvOptions(

--- a/apis/spark/src/main/java/io/tiledb/vcf/VCFDataSourceReader.java
+++ b/apis/spark/src/main/java/io/tiledb/vcf/VCFDataSourceReader.java
@@ -29,7 +29,7 @@ public class VCFDataSourceReader
   public VCFDataSourceReader(URI uri, VCFDataSourceOptions options) {
     this.uri = uri;
     this.options = options;
-    this.schema = new VCFSparkSchema();
+    this.schema = new VCFSparkSchema(uri, options);
     this.pushedSampleNames = new ArrayList<>();
     this.pushedFilters = new ArrayList<>();
   }

--- a/apis/spark/src/main/java/io/tiledb/vcf/VCFSparkSchema.java
+++ b/apis/spark/src/main/java/io/tiledb/vcf/VCFSparkSchema.java
@@ -191,7 +191,7 @@ public class VCFSparkSchema implements Serializable {
   /**
    * Create a new field for the spark schema
    *
-   * @param name     field name to add
+   * @param name field name to add
    * @param typeInfo field type info
    * @return StructField
    */
@@ -208,7 +208,7 @@ public class VCFSparkSchema implements Serializable {
   /**
    * Create a new field for the spark schema
    *
-   * @param name     field name to add
+   * @param name field name to add
    * @param typeInfo field type info
    * @return StructField
    */
@@ -246,7 +246,7 @@ public class VCFSparkSchema implements Serializable {
   /**
    * Create a new array field for the spark schema
    *
-   * @param name     field name to add
+   * @param name field name to add
    * @param typeInfo field type info
    * @return StructField
    */

--- a/apis/spark/src/test/java/io/tiledb/vcf/VCFDatasourceTest.java
+++ b/apis/spark/src/test/java/io/tiledb/vcf/VCFDatasourceTest.java
@@ -53,33 +53,55 @@ public class VCFDatasourceTest extends SharedJavaSparkSession {
   public void testSchema() {
     SparkSession spark = session();
     Dataset<Row> dfRead =
-        spark.read().format("io.tiledb.vcf.VCFDataSource").option("uri", "s3://foo/bar").load();
+        spark
+            .read()
+            .format("io.tiledb.vcf.VCFDataSource")
+            .option("uri", testSampleGroupURI("ingested_2samples"))
+            .load();
 
     dfRead.createOrReplaceTempView("vcf");
 
     long numColumns = spark.sql("SHOW COLUMNS FROM vcf").count();
-    Assert.assertEquals(numColumns, 14l);
+    Assert.assertEquals(numColumns, 32l);
 
     List<Row> colNameList = spark.sql("SHOW COLUMNS FROM vcf").collectAsList();
     List<String> colNames =
         colNameList.stream().map(r -> r.getString(0)).collect(Collectors.toList());
     Assert.assertEquals(
-        colNames,
         Arrays.asList(
-            "sampleName",
-            "contig",
-            "posStart",
-            "posEnd",
-            "alleles",
-            "filter",
-            "genotype",
-            "fmt_DP",
-            "fmt_GQ",
+            "fmt_SB",
             "fmt_MIN_DP",
+            "info_DP",
+            "info_ClippingRankSum",
+            "info_ReadPosRankSum",
             "fmt",
-            "info",
             "queryBedStart",
-            "queryBedEnd"));
+            "fmt_AD",
+            "posStart",
+            "info_BaseQRankSum",
+            "info_MLEAF",
+            "posEnd",
+            "fmt_GQ",
+            "info_MLEAC",
+            "genotype",
+            "id",
+            "alleles",
+            "info",
+            "sampleName",
+            "info_MQ",
+            "queryBedEnd",
+            "info_MQ0",
+            "fmt_PL",
+            "filter",
+            "info_HaplotypeScore",
+            "contig",
+            "info_DS",
+            "info_InbreedingCoeff",
+            "info_END",
+            "fmt_DP",
+            "info_MQRankSum",
+            "qual"),
+        colNames);
   }
 
   @Test(expected = org.apache.spark.sql.AnalysisException.class)

--- a/libtiledbvcf/src/c_api/tiledbvcf.cc
+++ b/libtiledbvcf/src/c_api/tiledbvcf.cc
@@ -576,23 +576,25 @@ int32_t tiledb_vcf_reader_get_last_error(
   return TILEDB_VCF_OK;
 }
 
-int32_t tiledb_vcf_reader_get_attribute_count(
+int32_t tiledb_vcf_reader_get_queryable_attribute_count(
     tiledb_vcf_reader_t* reader, int32_t* count) {
   if (sanity_check(reader) == TILEDB_VCF_ERR || count == nullptr)
     return TILEDB_VCF_ERR;
 
-  if (SAVE_ERROR_CATCH(reader, reader->reader_->attribute_count(count)))
+  if (SAVE_ERROR_CATCH(
+          reader, reader->reader_->queryable_attribute_count(count)))
     return TILEDB_VCF_ERR;
 
   return TILEDB_VCF_OK;
 }
 
-int32_t tiledb_vcf_reader_get_attribute_name(
+int32_t tiledb_vcf_reader_get_queryable_attribute_name(
     tiledb_vcf_reader_t* reader, int32_t index, char** name) {
   if (sanity_check(reader) == TILEDB_VCF_ERR || name == nullptr)
     return TILEDB_VCF_ERR;
 
-  if (SAVE_ERROR_CATCH(reader, reader->reader_->attribute_name(index, name)))
+  if (SAVE_ERROR_CATCH(
+          reader, reader->reader_->queryable_attribute_name(index, name)))
     return TILEDB_VCF_ERR;
 
   return TILEDB_VCF_OK;

--- a/libtiledbvcf/src/c_api/tiledbvcf.cc
+++ b/libtiledbvcf/src/c_api/tiledbvcf.cc
@@ -576,6 +576,74 @@ int32_t tiledb_vcf_reader_get_last_error(
   return TILEDB_VCF_OK;
 }
 
+int32_t tiledb_vcf_reader_get_attribute_count(
+    tiledb_vcf_reader_t* reader, int32_t* count) {
+  if (sanity_check(reader) == TILEDB_VCF_ERR || count == nullptr)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(reader, reader->reader_->attribute_count(count)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
+int32_t tiledb_vcf_reader_get_attribute_name(
+    tiledb_vcf_reader_t* reader, int32_t index, char** name) {
+  if (sanity_check(reader) == TILEDB_VCF_ERR || name == nullptr)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(reader, reader->reader_->attribute_name(index, name)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
+int32_t tiledb_vcf_reader_get_fmt_attribute_count(
+    tiledb_vcf_reader_t* reader, int32_t* count) {
+  if (sanity_check(reader) == TILEDB_VCF_ERR || count == nullptr)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(reader, reader->reader_->fmt_attribute_count(count)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
+int32_t tiledb_vcf_reader_get_fmt_attribute_name(
+    tiledb_vcf_reader_t* reader, int32_t index, char** name) {
+  if (sanity_check(reader) == TILEDB_VCF_ERR || name == nullptr)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          reader, reader->reader_->fmt_attribute_name(index, name)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
+int32_t tiledb_vcf_reader_get_info_attribute_count(
+    tiledb_vcf_reader_t* reader, int32_t* count) {
+  if (sanity_check(reader) == TILEDB_VCF_ERR || count == nullptr)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(reader, reader->reader_->info_attribute_count(count)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
+int32_t tiledb_vcf_reader_get_info_attribute_name(
+    tiledb_vcf_reader_t* reader, int32_t index, char** name) {
+  if (sanity_check(reader) == TILEDB_VCF_ERR || name == nullptr)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          reader, reader->reader_->info_attribute_name(index, name)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
 /* ********************************* */
 /*              WRITER               */
 /* ********************************* */

--- a/libtiledbvcf/src/c_api/tiledbvcf.h
+++ b/libtiledbvcf/src/c_api/tiledbvcf.h
@@ -722,6 +722,66 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_attribute_type(
     int32_t* list);
 
 /**
+ * Get count of materialized attributes in the array
+ * @param reader VCF reader object
+ * @param count int32_t which is set to count of attributes
+ * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
+ */
+TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_attribute_count(
+    tiledb_vcf_reader_t* reader, int32_t* count);
+
+/**
+ * Fetch name of a materialized attribute from the dataset
+ * @param reader VCF reader object
+ * @param index attribute to fetch name of
+ * @param name char* returned as name, note: the caller is responsible for
+ * freeing the char*
+ * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
+ */
+TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_attribute_name(
+    tiledb_vcf_reader_t* reader, int32_t index, char** name);
+
+/**
+ * Get count of fmt attributes in the array
+ * @param reader VCF reader object
+ * @param count int32_t which is set to count of attributes
+ * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
+ */
+TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_fmt_attribute_count(
+    tiledb_vcf_reader_t* reader, int32_t* count);
+
+/**
+ * Fetch name of a fmt attribute from the dataset
+ * @param reader VCF reader object
+ * @param index attribute to fetch name of
+ * @param name char* returned as name, note: the caller is responsible for
+ * freeing the char*
+ * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
+ */
+TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_fmt_attribute_name(
+    tiledb_vcf_reader_t* reader, int32_t index, char** name);
+
+/**
+ * Get count of info attributes in the array
+ * @param reader VCF reader object
+ * @param count int32_t which is set to count of attributes
+ * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
+ */
+TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_info_attribute_count(
+    tiledb_vcf_reader_t* reader, int32_t* count);
+
+/**
+ * Fetch name of an info attribute from the dataset
+ * @param reader VCF reader object
+ * @param index attribute to fetch name of
+ * @param name char* returned as name, note: the caller is responsible for
+ * freeing the char*
+ * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
+ */
+TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_info_attribute_name(
+    tiledb_vcf_reader_t* reader, int32_t index, char** name);
+
+/**
  * Returns the version number of the TileDB VCF dataset.
  *
  * @param reader VCF reader object

--- a/libtiledbvcf/src/c_api/tiledbvcf.h
+++ b/libtiledbvcf/src/c_api/tiledbvcf.h
@@ -727,18 +727,17 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_attribute_type(
  * @param count int32_t which is set to count of attributes
  * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
  */
-TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_attribute_count(
+TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_queryable_attribute_count(
     tiledb_vcf_reader_t* reader, int32_t* count);
 
 /**
  * Fetch name of a materialized attribute from the dataset
  * @param reader VCF reader object
  * @param index attribute to fetch name of
- * @param name char* returned as name, note: the caller is responsible for
- * freeing the char*
+ * @param name char* returned as name
  * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
  */
-TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_attribute_name(
+TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_queryable_attribute_name(
     tiledb_vcf_reader_t* reader, int32_t index, char** name);
 
 /**
@@ -754,8 +753,7 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_fmt_attribute_count(
  * Fetch name of a fmt attribute from the dataset
  * @param reader VCF reader object
  * @param index attribute to fetch name of
- * @param name char* returned as name, note: the caller is responsible for
- * freeing the char*
+ * @param name char* returned as name
  * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
  */
 TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_fmt_attribute_name(
@@ -774,8 +772,7 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_info_attribute_count(
  * Fetch name of an info attribute from the dataset
  * @param reader VCF reader object
  * @param index attribute to fetch name of
- * @param name char* returned as name, note: the caller is responsible for
- * freeing the char*
+ * @param name char* returned as name
  * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
  */
 TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_info_attribute_name(

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -823,7 +823,7 @@ std::pair<std::string, std::string> TileDBVCFDataset::split_info_fmt_attr_name(
   return {kind, name};
 }
 
-std::unordered_set<std::string> TileDBVCFDataset::builtin_attributes_v3() {
+std::set<std::string> TileDBVCFDataset::builtin_attributes_v3() {
   return {AttrNames::V3::real_start_pos,
           AttrNames::V3::end_pos,
           AttrNames::V3::qual,
@@ -834,7 +834,7 @@ std::unordered_set<std::string> TileDBVCFDataset::builtin_attributes_v3() {
           AttrNames::V3::fmt};
 }
 
-std::unordered_set<std::string> TileDBVCFDataset::builtin_attributes_v2() {
+std::set<std::string> TileDBVCFDataset::builtin_attributes_v2() {
   return {AttrNames::V2::pos,
           AttrNames::V2::real_end,
           AttrNames::V2::qual,
@@ -856,12 +856,12 @@ bool TileDBVCFDataset::attribute_is_fixed_len(const std::string& attr) {
          attr == AttrNames::V2::qual;
 }
 
-std::unordered_set<std::string> TileDBVCFDataset::all_attributes() const {
+std::set<std::string> TileDBVCFDataset::all_attributes() const {
   if (!open_)
     throw std::invalid_argument(
         "Cannot get attributes from dataset; dataset is not open.");
 
-  std::unordered_set<std::string> result;
+  std::set<std::string> result;
   if (metadata_.version == Version::V2) {
     result = builtin_attributes_v2();
   } else {
@@ -915,6 +915,14 @@ std::string TileDBVCFDataset::vcf_headers_uri(
 
 bool TileDBVCFDataset::cloud_dataset(std::string root_uri) {
   return utils::starts_with(root_uri, "tiledb://");
+}
+
+std::map<std::string, int> TileDBVCFDataset::info_field_types() {
+  return info_field_types_;
+}
+
+std::map<std::string, int> TileDBVCFDataset::fmt_field_types() {
+  return fmt_field_types_;
 }
 
 }  // namespace vcf

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -222,22 +222,29 @@ class TileDBVCFDataset {
       const std::string& attr_name);
 
   /** Return a set of the v3 attribute names for the "builtin" attributes. */
-  static std::unordered_set<std::string> builtin_attributes_v3();
+  static std::set<std::string> builtin_attributes_v3();
 
   /** Return a set of the v3 attribute names for the "builtin" attributes. */
-  static std::unordered_set<std::string> builtin_attributes_v2();
+  static std::set<std::string> builtin_attributes_v2();
 
   /** Returns true if the builtin attribute is fixed-len in the schema. */
   static bool attribute_is_fixed_len(const std::string& attr);
 
-  /** Returns a set of all the attribute names in the dataset. */
-  std::unordered_set<std::string> all_attributes() const;
+  /** Returns a set of all the attribute names in the dataset. This is a set as
+   * we rely on the order for the attribute_index function */
+  std::set<std::string> all_attributes() const;
 
   /** Returns the BCF_HT_ type for the info field of the given name. */
   int info_field_type(const std::string& name) const;
 
   /** Returns the BCF_HT_ type for the format field of the given name. */
   int fmt_field_type(const std::string& name) const;
+
+  /** Map of info field name -> hstlib type. */
+  std::map<std::string, int> info_field_types();
+
+  /** Map of fmt field name -> hstlib type. */
+  std::map<std::string, int> fmt_field_types();
 
  private:
   /* ********************************* */

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -246,6 +246,19 @@ class TileDBVCFDataset {
   /** Map of fmt field name -> hstlib type. */
   std::map<std::string, int> fmt_field_types();
 
+  /**
+   * Get queryable attribute count
+   * @return
+   */
+  int32_t queryable_attribute_count() const;
+
+  /**
+   * Get attribute name by index
+   * @param index
+   * @return
+   */
+  const char* queryable_attribute_name(int32_t index) const;
+
  private:
   /* ********************************* */
   /*          PRIVATE ATTRIBUTES       */
@@ -265,6 +278,9 @@ class TileDBVCFDataset {
 
   /** Map of fmt field name -> hstlib type. */
   std::map<std::string, int> fmt_field_types_;
+
+  /** List of all attributes of vcf for querying */
+  std::vector<std::vector<char>> vcf_attributes_;
 
   /* ********************************* */
   /*          STATIC METHODS           */

--- a/libtiledbvcf/src/read/bcf_exporter.cc
+++ b/libtiledbvcf/src/read/bcf_exporter.cc
@@ -98,7 +98,7 @@ void BCFExporter::finalize_export(
     file_info_.erase(file_it);
 }
 
-std::unordered_set<std::string> BCFExporter::array_attributes_required() const {
+std::set<std::string> BCFExporter::array_attributes_required() const {
   // TODO: currently we require all attributes for record recovery.
   return dataset_->all_attributes();
 }

--- a/libtiledbvcf/src/read/bcf_exporter.h
+++ b/libtiledbvcf/src/read/bcf_exporter.h
@@ -50,7 +50,7 @@ class BCFExporter : public Exporter {
   void finalize_export(
       const SampleAndId& sample, const bcf_hdr_t* hdr) override;
 
-  std::unordered_set<std::string> array_attributes_required() const override;
+  std::set<std::string> array_attributes_required() const override;
 
  private:
   /** Number of records to buffer for a file before flushing to disk. */

--- a/libtiledbvcf/src/read/exporter.h
+++ b/libtiledbvcf/src/read/exporter.h
@@ -94,7 +94,7 @@ class Exporter {
    * Returns a list of dataset array attribute names are required to be read to
    * satisfy the particular exporter requirements.
    */
-  virtual std::unordered_set<std::string> array_attributes_required() const = 0;
+  virtual std::set<std::string> array_attributes_required() const = 0;
 
  protected:
   /** The dataset. */

--- a/libtiledbvcf/src/read/in_memory_exporter.cc
+++ b/libtiledbvcf/src/read/in_memory_exporter.cc
@@ -111,8 +111,7 @@ InMemoryExporter::UserBuffer* InMemoryExporter::get_buffer(
   return buff;
 }
 
-std::unordered_set<std::string> InMemoryExporter::array_attributes_required()
-    const {
+std::set<std::string> InMemoryExporter::array_attributes_required() const {
   if (dataset_ == nullptr)
     throw std::runtime_error(
         "Error getting required attributes; no dataset is initialized.");
@@ -123,7 +122,7 @@ std::unordered_set<std::string> InMemoryExporter::array_attributes_required()
 
   const unsigned version = dataset_->metadata().version;
 
-  std::unordered_set<std::string> result;
+  std::set<std::string> result;
   for (const auto& it : user_buffers_) {
     switch (it.second.attr) {
       case ExportableAttribute::SampleName:

--- a/libtiledbvcf/src/read/in_memory_exporter.h
+++ b/libtiledbvcf/src/read/in_memory_exporter.h
@@ -71,7 +71,7 @@ class InMemoryExporter : public Exporter {
    * Based on the buffers that have been set, returns the list of array
    * attributes that must be read from the TileDB array.
    */
-  std::unordered_set<std::string> array_attributes_required() const override;
+  std::set<std::string> array_attributes_required() const override;
 
   /** Resets any state of the exporter. */
   void reset() override;

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -1317,5 +1317,65 @@ void Reader::check_partitioning(
         std::to_string(num_partitions) + ".");
 }
 
+void Reader::attribute_count(int32_t* count) {
+  if (count == nullptr)
+    throw std::runtime_error("count must be non-null in attribute_count");
+
+  *count = this->dataset_->all_attributes().size();
+}
+
+void Reader::attribute_name(int32_t index, char** name) {
+  auto all_attributes = this->dataset_->all_attributes();
+  auto iter = all_attributes.begin();
+  std::advance(iter, index);
+  std::string s = *iter;
+  // end_pos, start_pos and filter_ids have different vfc attribute names
+  // compared to ondisk names we should unify this in the future
+  if (s == "end_pos")
+    s = "pos_end";
+  else if (s == "start_pos")
+    s = "pos_start";
+  else if (s == "filter_ids")
+    s = "filters";
+
+  int32_t size = s.length();
+  *name = static_cast<char*>(malloc(size + 1));
+  memcpy(*name, s.c_str(), size + 1);
+}
+
+void Reader::fmt_attribute_count(int32_t* count) {
+  if (count == nullptr)
+    throw std::runtime_error("count must be non-null in attribute_count");
+
+  *count = this->dataset_->fmt_field_types().size();
+}
+
+void Reader::fmt_attribute_name(int32_t index, char** name) {
+  auto fmt_attributes = this->dataset_->fmt_field_types();
+  auto iter = fmt_attributes.begin();
+  std::advance(iter, index);
+  std::string s = "fmt_" + iter->first;
+  int32_t size = s.length();
+  *name = static_cast<char*>(malloc(size + 1));
+  memcpy(*name, s.c_str(), size + 1);
+}
+
+void Reader::info_attribute_count(int32_t* count) {
+  if (count == nullptr)
+    throw std::runtime_error("count must be non-null in attribute_count");
+
+  *count = this->dataset_->info_field_types().size();
+}
+
+void Reader::info_attribute_name(int32_t index, char** name) {
+  auto info_attributes = this->dataset_->info_field_types();
+  auto iter = info_attributes.begin();
+  std::advance(iter, index);
+  std::string s = "info_" + iter->first;
+  int32_t size = s.length();
+  *name = static_cast<char*>(malloc(size + 1));
+  memcpy(*name, s.c_str(), size + 1);
+}
+
 }  // namespace vcf
 }  // namespace tiledb

--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -260,6 +260,45 @@ class Reader {
   void get_buffer_validity_bitmap(
       int32_t buffer_idx, const char** name, uint8_t** buff) const;
 
+  /**
+   * Get the count of materialized attributes
+   * @param count of attributes
+   */
+  void attribute_count(int32_t* count);
+
+  /**
+   * Get a materialized attribute name by index
+   * @param index of attribute to fetch
+   * @param name of attribute
+   */
+  void attribute_name(int32_t index, char** name);
+
+  /**
+   * Get the count of fmt attributes
+   * @param count of attributes
+   */
+  void fmt_attribute_count(int32_t* count);
+
+  /**
+   * Get a fmt attribute name by index
+   * @param index of attribute to fetch
+   * @param name of attribute
+   */
+  void fmt_attribute_name(int32_t index, char** name);
+
+  /**
+   * Get the count of info attributes
+   * @param count of attributes
+   */
+  void info_attribute_count(int32_t* count);
+
+  /**
+   * Get an info attribute name by index
+   * @param index of attribute to fetch
+   * @param name of attribute
+   */
+  void info_attribute_name(int32_t index, char** name);
+
  private:
   /* ********************************* */
   /*           PRIVATE DATATYPES       */

--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -264,14 +264,14 @@ class Reader {
    * Get the count of materialized attributes
    * @param count of attributes
    */
-  void attribute_count(int32_t* count);
+  void queryable_attribute_count(int32_t* count);
 
   /**
    * Get a materialized attribute name by index
    * @param index of attribute to fetch
    * @param name of attribute
    */
-  void attribute_name(int32_t index, char** name);
+  void queryable_attribute_name(int32_t index, char** name);
 
   /**
    * Get the count of fmt attributes

--- a/libtiledbvcf/src/read/tsv_exporter.cc
+++ b/libtiledbvcf/src/read/tsv_exporter.cc
@@ -240,7 +240,7 @@ bool TSVExporter::export_record(
   return true;
 }
 
-std::unordered_set<std::string> TSVExporter::array_attributes_required() const {
+std::set<std::string> TSVExporter::array_attributes_required() const {
   // TODO: currently we require all attributes for record recovery.
   return dataset_->all_attributes();
 }

--- a/libtiledbvcf/src/read/tsv_exporter.h
+++ b/libtiledbvcf/src/read/tsv_exporter.h
@@ -55,7 +55,7 @@ class TSVExporter : public Exporter {
       const ReadQueryResults& query_results,
       uint64_t cell_idx) override;
 
-  std::unordered_set<std::string> array_attributes_required() const override;
+  std::set<std::string> array_attributes_required() const override;
 
  private:
   struct OutputField {

--- a/libtiledbvcf/test/src/unit-c-api-reader.cc
+++ b/libtiledbvcf/test/src/unit-c-api-reader.cc
@@ -261,17 +261,17 @@ TEST_CASE("C API: Reader get attributes", "[capi][reader]") {
 
   int32_t count = 0;
   REQUIRE(
-      tiledb_vcf_reader_get_attribute_count(reader, &count) == TILEDB_VCF_OK);
+      tiledb_vcf_reader_get_queryable_attribute_count(reader, &count) ==
+      TILEDB_VCF_OK);
 
   REQUIRE(count > 0);
 
   for (int32_t i = 0; i < count; i++) {
     char* attribute_name;
     REQUIRE(
-        tiledb_vcf_reader_get_attribute_name(reader, i, &attribute_name) ==
-        TILEDB_VCF_OK);
+        tiledb_vcf_reader_get_queryable_attribute_name(
+            reader, i, &attribute_name) == TILEDB_VCF_OK);
     REQUIRE(attribute_name != nullptr);
-    free(attribute_name);
   }
 
   count = 0;
@@ -287,7 +287,6 @@ TEST_CASE("C API: Reader get attributes", "[capi][reader]") {
         tiledb_vcf_reader_get_fmt_attribute_name(reader, i, &attribute_name) ==
         TILEDB_VCF_OK);
     REQUIRE(attribute_name != nullptr);
-    free(attribute_name);
   }
 
   count = 0;
@@ -303,7 +302,6 @@ TEST_CASE("C API: Reader get attributes", "[capi][reader]") {
         tiledb_vcf_reader_get_info_attribute_name(reader, i, &attribute_name) ==
         TILEDB_VCF_OK);
     REQUIRE(attribute_name != nullptr);
-    free(attribute_name);
   }
 
   tiledb_vcf_reader_free(&reader);

--- a/libtiledbvcf/test/src/unit-c-api-reader.cc
+++ b/libtiledbvcf/test/src/unit-c-api-reader.cc
@@ -244,6 +244,71 @@ TEST_CASE("C API: Reader set config", "[capi][query]") {
   tiledb_vcf_reader_free(&reader);
 }
 
+TEST_CASE("C API: Reader get attributes", "[capi][reader]") {
+  tiledb_vcf_reader_t* reader = nullptr;
+  REQUIRE(tiledb_vcf_reader_alloc(&reader) == TILEDB_VCF_OK);
+
+  std::string dataset_uri;
+  SECTION("- V2") {
+    dataset_uri = INPUT_ARRAYS_DIR_V2 + "/ingested_2samples";
+  }
+
+  SECTION("- V3") {
+    dataset_uri = INPUT_ARRAYS_DIR_V3 + "/ingested_2samples";
+  }
+
+  REQUIRE(tiledb_vcf_reader_init(reader, dataset_uri.c_str()) == TILEDB_VCF_OK);
+
+  int32_t count = 0;
+  REQUIRE(
+      tiledb_vcf_reader_get_attribute_count(reader, &count) == TILEDB_VCF_OK);
+
+  REQUIRE(count > 0);
+
+  for (int32_t i = 0; i < count; i++) {
+    char* attribute_name;
+    REQUIRE(
+        tiledb_vcf_reader_get_attribute_name(reader, i, &attribute_name) ==
+        TILEDB_VCF_OK);
+    REQUIRE(attribute_name != nullptr);
+    free(attribute_name);
+  }
+
+  count = 0;
+  REQUIRE(
+      tiledb_vcf_reader_get_fmt_attribute_count(reader, &count) ==
+      TILEDB_VCF_OK);
+
+  REQUIRE(count > 0);
+
+  for (int32_t i = 0; i < count; i++) {
+    char* attribute_name;
+    REQUIRE(
+        tiledb_vcf_reader_get_fmt_attribute_name(reader, i, &attribute_name) ==
+        TILEDB_VCF_OK);
+    REQUIRE(attribute_name != nullptr);
+    free(attribute_name);
+  }
+
+  count = 0;
+  REQUIRE(
+      tiledb_vcf_reader_get_info_attribute_count(reader, &count) ==
+      TILEDB_VCF_OK);
+
+  REQUIRE(count > 0);
+
+  for (int32_t i = 0; i < count; i++) {
+    char* attribute_name;
+    REQUIRE(
+        tiledb_vcf_reader_get_info_attribute_name(reader, i, &attribute_name) ==
+        TILEDB_VCF_OK);
+    REQUIRE(attribute_name != nullptr);
+    free(attribute_name);
+  }
+
+  tiledb_vcf_reader_free(&reader);
+}
+
 TEST_CASE("C API: Reader set regions", "[capi][reader]") {
   tiledb_vcf_reader_t* reader = nullptr;
   REQUIRE(tiledb_vcf_reader_alloc(&reader) == TILEDB_VCF_OK);


### PR DESCRIPTION
Allow spark schema to be dynamic based on materialized attributes and available fmt/info fields. A `select *` in spark will now pull in all available fields and a `df.schema()` will describe and show all possible fields.

Fields are still pushed down so a select with a fixed set of attributes will not select all possible fields.