### PR TITLE
Rename python TileDBVCFDataset to Dataset

### DIFF
--- a/apis/python/src/tiledbvcf/__init__.py
+++ b/apis/python/src/tiledbvcf/__init__.py
@@ -26,7 +26,7 @@ def _load_libs():
 _load_libs()
 
 # Load basic modules first
-from .dataset import (ReadConfig, TileDBVCFDataset)
+from .dataset import (ReadConfig, TileDBVCFDataset, Dataset)
 
 # Load dask additions, if dask is available
 try:

--- a/apis/python/src/tiledbvcf/dask_functions.py
+++ b/apis/python/src/tiledbvcf/dask_functions.py
@@ -1,7 +1,7 @@
 import dask
 import dask.dataframe
 
-from .dataset import (ReadConfig, TileDBVCFDataset)
+from .dataset import (ReadConfig, Dataset)
 
 
 class ReadArgs(object):
@@ -20,7 +20,7 @@ class ReadArgs(object):
 
 
 def _read_partition(read_args):
-    ds = TileDBVCFDataset(read_args.uri, 'r', read_args.cfg)
+    ds = Dataset(read_args.uri, 'r', read_args.cfg)
     df = ds.read(attrs=read_args.attrs, samples=read_args.samples,
                  regions=read_args.regions, samples_file=read_args.samples_file,
                  bed_file=read_args.bed_file)
@@ -84,5 +84,5 @@ def read_dask(self, attrs, region_partitions=1, sample_partitions=1,
 
 
 # Patch functions and members into dataset class
-TileDBVCFDataset.read_dask = read_dask
-TileDBVCFDataset.map_dask = map_dask
+Dataset.read_dask = read_dask
+Dataset.map_dask = map_dask

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import sys
+import warnings
 
 from collections import namedtuple
 from . import libtiledbvcf
@@ -21,7 +22,7 @@ ReadConfig = namedtuple('ReadConfig', [
 ReadConfig.__new__.__defaults__ = (None,) * 6#len(ReadConfig._fields)
 
 
-class TileDBVCFDataset(object):
+class Dataset(object):
     """A handle on a TileDB-VCF dataset."""
 
     def __init__(self, uri, mode='r', cfg=None, stats=False):
@@ -209,3 +210,19 @@ class TileDBVCFDataset(object):
             raise Exception('Stats not enabled')
 
         return self.reader.get_tiledb_stats();
+
+class TileDBVCFDataset(Dataset):
+    """A handle on a TileDB-VCF dataset."""
+
+    def __init__(self, uri, mode='r', cfg=None, stats=False):
+        """ Initializes a TileDB-VCF dataset for interaction.
+
+        :param uri: URI of TileDB-VCF dataset
+        :param mode: Mode of operation.
+        :type mode: 'r' or 'w'
+        """
+        warnings.warn(
+            "TileDBVCFDataset is deprecated, use Dataset instead",
+            DeprecationWarning
+        )
+        super().__init__(uri, mode, cfg, stats)

--- a/apis/python/tests/test_dask.py
+++ b/apis/python/tests/test_dask.py
@@ -39,7 +39,7 @@ def _check_dfs(expected, actual):
 
 @pytest.fixture
 def test_ds():
-    return tiledbvcf.TileDBVCFDataset(
+    return tiledbvcf.Dataset(
         os.path.join(TESTS_INPUT_DIR, 'arrays/v3/ingested_2samples'))
 
 
@@ -86,7 +86,7 @@ def test_incomplete_reads():
     # Using undocumented "0 MB" budget to test incomplete reads.
     uri = os.path.join(TESTS_INPUT_DIR, 'arrays/v3/ingested_2samples')
     cfg = tiledbvcf.ReadConfig(memory_budget_mb=0)
-    test_ds = tiledbvcf.TileDBVCFDataset(uri, mode='r', cfg=cfg)
+    test_ds = tiledbvcf.Dataset(uri, mode='r', cfg=cfg)
 
     expected_df = pd.DataFrame(
         {'sample_name': pd.Series(
@@ -144,7 +144,7 @@ def test_map_incomplete():
     # Using undocumented "0 MB" budget to test incomplete reads.
     uri = os.path.join(TESTS_INPUT_DIR, 'arrays/v3/ingested_2samples')
     cfg = tiledbvcf.ReadConfig(memory_budget_mb=0)
-    test_ds = tiledbvcf.TileDBVCFDataset(uri, mode='r', cfg=cfg)
+    test_ds = tiledbvcf.Dataset(uri, mode='r', cfg=cfg)
 
     expected_df = pd.DataFrame(
         {'sample_name': pd.Series(['HG00280', 'HG01762']),


### PR DESCRIPTION
Rename python TileDBVCFDataset to Dataset. TileDBVCFDataset is left with a deprecation warning.