### PR TITLE
VCF record iteration for overlapping records

### DIFF
--- a/libtiledbvcf/src/utils/sample_utils.h
+++ b/libtiledbvcf/src/utils/sample_utils.h
@@ -47,15 +47,6 @@
 namespace tiledb {
 namespace vcf {
 
-/** Alias for unique_ptr to bcf_hdr_t. */
-typedef std::unique_ptr<bcf_hdr_t, decltype(&bcf_hdr_destroy)> SafeBCFHdr;
-
-/** Alias for unique_ptr to bcf1_t. */
-typedef std::unique_ptr<bcf1_t, decltype(&bcf_destroy)> SafeBCFRec;
-
-/** Alias for unique_ptr to htsFile. */
-typedef std::unique_ptr<htsFile, decltype(&hts_close)> SafeBCFFh;
-
 /** Struct holding information about available scratch disk space. */
 struct ScratchSpaceInfo {
   std::string path = "";


### PR DESCRIPTION
Currently, we buffer VCF records into memory and store the minimum start
position and maximum end position of these buffered records. When we iterate
to buffer the next set of VCF records, we seek to the maximum end position
and read from there. This breaks if there are any overlapping records.

This patch chanes the behavior from open+seek on each iteration to opening
once on the first iteration and making use of the internal htslib iterator
to move between records.