### PR TITLE
 Add python support for scratch space

### DIFF
--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -45,6 +45,7 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("set_extra_attributes", &Writer::set_extra_attributes)
       .def("set_checksum", &Writer::set_checksum)
       .def("set_allow_duplicates", &Writer::set_allow_duplicates)
+      .def("set_scratch_space", &Writer::set_scratch_space)
       .def("create_dataset", &Writer::create_dataset)
       .def("register_samples", &Writer::register_samples)
       .def("ingest_samples", &Writer::ingest_samples);

--- a/apis/python/src/tiledbvcf/binding/writer.cc
+++ b/apis/python/src/tiledbvcf/binding/writer.cc
@@ -101,6 +101,13 @@ void Writer::set_allow_duplicates(const bool &allow_duplicates) {
   check_error(writer, tiledb_vcf_writer_set_allow_duplicates(writer, allow_duplicates));
 }
 
+void Writer::set_scratch_space(const std::string& path, int64_t size) {
+  auto writer = ptr.get();
+  check_error(
+    writer,
+    tiledb_vcf_writer_set_scratch_space(writer, path.c_str(), size));
+}
+
 void Writer::create_dataset() {
   auto writer = ptr.get();
   check_error(writer, tiledb_vcf_writer_create_dataset(writer));

--- a/apis/python/src/tiledbvcf/binding/writer.h
+++ b/apis/python/src/tiledbvcf/binding/writer.h
@@ -68,6 +68,11 @@ class Writer {
   */
   void set_allow_duplicates(const bool& allow_duplicates);
 
+  /**
+    [Creation only] Allocates scratch space for downloading sample files
+  */
+  void set_scratch_space(const std::string& path, int64_t size);
+
   void create_dataset();
 
   void register_samples();

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -170,7 +170,7 @@ class Dataset(object):
 
         return self.reader.result_num_records()
 
-    def ingest_samples(self, sample_uris=None, extra_attrs=None, checksum_type=None, allow_duplicates=True):
+    def ingest_samples(self, sample_uris=None, extra_attrs=None, checksum_type=None, allow_duplicates=True, scratch_space_path=None, scratch_space_size=None):
         """Ingest samples
 
         :param list of str samples: CSV list of sample names to include in
@@ -191,6 +191,11 @@ class Dataset(object):
             self.writer.set_checksum(checksum_type)
 
         self.writer.set_allow_duplicates(allow_duplicates)
+
+        if scratch_space_path is not None and scratch_space_size is not None:
+            self.writer.set_scratch_space(scratch_space_path, scratch_space_size)
+        elif scratch_space_path is not None or scratch_space_size is not None:
+            raise Exception('Must set both scratch_space_path and scratch_space_size to use scratch space')
 
         self.writer.set_samples(','.join(sample_uris))
 

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -177,9 +177,14 @@ class Dataset(object):
             the count.
         :param list of str extra_attrs: CSV list of extra attributes to
             materialize from fmt field
-        :param str checksum_type: Optional override checksum type for creating new dataset
-            valid values are sha256, md5 or none.
+        :param str checksum_type: Optional override checksum type for creating
+            new dataset valid values are sha256, md5 or none.
+        :param str scratch_space_path: Directory used for local storage of
+            downloaded remote samples.
+        :param int scratch_space_size: Amount of local storage that can be used
+            for downloading remote samples (MB).
         """
+
         if self.mode != 'w':
             raise Exception('Dataset not open in write mode')
 

--- a/libtiledbvcf/src/c_api/tiledbvcf.cc
+++ b/libtiledbvcf/src/c_api/tiledbvcf.cc
@@ -800,6 +800,13 @@ int32_t tiledb_vcf_writer_get_last_error(
   return TILEDB_VCF_OK;
 }
 
+int32_t tiledb_vcf_writer_set_scratch_space(
+    tiledb_vcf_writer_t* writer, const char* path, uint64_t size) {
+  writer->writer_->set_scratch_space(path, size);
+
+  return TILEDB_VCF_OK;
+}
+
 /* ********************************* */
 /*               ERROR               */
 /* ********************************* */

--- a/libtiledbvcf/src/c_api/tiledbvcf.h
+++ b/libtiledbvcf/src/c_api/tiledbvcf.h
@@ -924,6 +924,19 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_store(tiledb_vcf_writer_t* writer);
 TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_get_last_error(
     tiledb_vcf_writer_t* writer, tiledb_vcf_error_t** error);
 
+/**
+ * Set scratch space for ingestion or registration
+ *
+ * @param writer VCF writer object
+ * @param path Directory used for local storage of downloaded remote samples
+ * @param size_mb Amount of local storage that can be used for downloading
+ * remote samples (MB)
+ * @
+ * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
+ */
+TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_set_scratch_space(
+    tiledb_vcf_writer_t* writer, const char* path, uint64_t size_mb);
+
 /* ********************************* */
 /*               ERROR               */
 /* ********************************* */

--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -370,5 +370,13 @@ std::vector<Region> Writer::prepare_region_list(
   return result;
 }
 
+void Writer::set_scratch_space(const std::string path, uint64_t size) {
+  ScratchSpaceInfo scratchSpaceInfo;
+  scratchSpaceInfo.path = path;
+  scratchSpaceInfo.size_mb = size;
+  this->registration_params_.scratch_space = scratchSpaceInfo;
+  this->ingestion_params_.scratch_space = scratchSpaceInfo;
+}
+
 }  // namespace vcf
 }  // namespace tiledb

--- a/libtiledbvcf/src/write/writer.h
+++ b/libtiledbvcf/src/write/writer.h
@@ -144,6 +144,9 @@ class Writer {
   /** Ingests samples based on parameters that have been set. */
   void ingest_samples();
 
+  /** Set ingestion scatch space for ingestion or registration */
+  void set_scratch_space(const std::string path, uint64_t size);
+
  private:
   /* ********************************* */
   /*          PRIVATE ATTRIBUTES       */


### PR DESCRIPTION
 Add python support for scratch space

Two new parameters are added to the ingest_samples for `scratch_space_path` and `scratch_space_size`. A c-api is also exposed.