### PR TITLE
Use-after-free in record heap

### DIFF
--- a/libtiledbvcf/src/write/writer_worker_v3.cc
+++ b/libtiledbvcf/src/write/writer_worker_v3.cc
@@ -138,8 +138,9 @@ bool WriterWorkerV3::resume() {
     // exceed the max memory allocation, we'll stop processing at this record.
     bool overflowed = !buffer_record(contig_offset, top);
 
+    const bool is_end_node = top.end_node;
     record_heap_.pop();
-    if (top.end_node && vcf->is_open() && vcf->next()) {
+    if (is_end_node && vcf->is_open() && vcf->next()) {
       bcf1_t* r = vcf->curr_rec();
 
       const uint32_t local_end_pos = VCF::get_end_pos(vcf->hdr(), r, &val_);


### PR DESCRIPTION
This fixes an instance of accessing a reference to a node in the record
heap after it has been popped (and freed). In my testing, this manifests as
adding extraneous records to the heap, causing a failure when trying to read
more than exists from the buffered VCF records:

`Error getting contig name from VCF; current record is null.`