### PR TITLE
Add option to enable verbose output for spark and python

### DIFF
--- a/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.c
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.c
@@ -642,6 +642,16 @@ Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1get_1dataset_1vers
 
   return rc;
 }
+JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1set_1verbose
+  (JNIEnv* env, jclass self, jlong readerPtr, jboolean verbose) {
+  (void)self;
+  tiledb_vcf_reader_t* reader = (tiledb_vcf_reader_t*)readerPtr;
+  if (reader == 0) {
+    return TILEDB_VCF_ERR;
+  }
+
+  return tiledb_vcf_reader_set_verbose(reader, verbose);
+}
 
 JNIEXPORT jstring JNICALL
 Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1get_1last_1error_1message(

--- a/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.h
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.h
@@ -241,6 +241,14 @@ JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1rea
 
 /*
  * Class:     io_tiledb_libvcfnative_LibVCFNative
+ * Method:    tiledb_vcf_reader_set_verbose
+ * Signature: (JZ)I
+ */
+JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1set_1verbose
+  (JNIEnv *, jclass, jlong, jboolean);
+
+/*
+ * Class:     io_tiledb_libvcfnative_LibVCFNative
  * Method:    tiledb_vcf_reader_get_last_error_message
  * Signature: (J)Ljava/lang/String;
  */

--- a/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.java
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.java
@@ -103,6 +103,8 @@ public class LibVCFNative {
   public static final native int tiledb_vcf_reader_get_dataset_version(
       long readerPtr, int[] version);
 
+  public static final native int tiledb_vcf_reader_set_verbose(long readerPtr, boolean verbose);
+
   public static final native String tiledb_vcf_reader_get_last_error_message(long readerPtr);
 
   public static final native int tiledb_vcf_reader_set_tiledb_stats_enabled(

--- a/apis/java/src/main/java/io/tiledb/libvcfnative/VCFReader.java
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/VCFReader.java
@@ -438,6 +438,15 @@ public class VCFReader implements AutoCloseable {
     }
   }
 
+  public VCFReader setVerbose(boolean verbose) {
+    int rc = LibVCFNative.tiledb_vcf_reader_set_verbose(this.readerPtr, verbose);
+    if (rc != 0) {
+      String msg = getLastErrorMessage();
+      throw new RuntimeException("Error setting verbose: " + msg);
+    }
+    return this;
+  }
+
   public VCFReader setStatsEnabled(boolean statsEnabled) {
     int rc = LibVCFNative.tiledb_vcf_reader_set_tiledb_stats_enabled(this.readerPtr, statsEnabled);
     if (rc != 0) {

--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -30,6 +30,7 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("set_tiledb_config", &Reader::set_tiledb_config)
       .def("set_attributes", &Reader::set_attributes)
       .def("set_tiledb_stats_enabled", &Reader::set_tiledb_stats_enabled)
+      .def("set_verbose", &Reader::set_verbose)
       .def("read", &Reader::read)
       .def("get_buffers", &Reader::get_buffers)
       .def("get_results_arrow", &Reader::get_results_arrow)
@@ -48,5 +49,6 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("set_scratch_space", &Writer::set_scratch_space)
       .def("create_dataset", &Writer::create_dataset)
       .def("register_samples", &Writer::register_samples)
+      .def("set_verbose", &Writer::set_verbose)
       .def("ingest_samples", &Writer::ingest_samples);
 }

--- a/apis/python/src/tiledbvcf/binding/reader.cc
+++ b/apis/python/src/tiledbvcf/binding/reader.cc
@@ -145,6 +145,11 @@ void Reader::set_tiledb_config(const std::string& config_str) {
       reader, tiledb_vcf_reader_set_tiledb_config(reader, config_str.c_str()));
 }
 
+void Reader::set_verbose(bool verbose) {
+   auto reader = ptr.get();
+   check_error(reader, tiledb_vcf_reader_set_verbose(reader, verbose));
+}
+
 void Reader::read() {
   auto reader = ptr.get();
   alloc_buffers();

--- a/apis/python/src/tiledbvcf/binding/reader.h
+++ b/apis/python/src/tiledbvcf/binding/reader.h
@@ -115,6 +115,13 @@ class Reader {
   /** Fetches TileDB statistics */
   std::string get_tiledb_stats();
 
+  /**
+  * Set reader verbose output mode
+  *
+  * @param verbose mode
+  */
+  void set_verbose(bool verbose);
+
  private:
   /** Buffer struct to hold attribute data read from the dataset. */
   struct BufferInfo {

--- a/apis/python/src/tiledbvcf/binding/writer.cc
+++ b/apis/python/src/tiledbvcf/binding/writer.cc
@@ -108,6 +108,11 @@ void Writer::set_scratch_space(const std::string& path, int64_t size) {
     tiledb_vcf_writer_set_scratch_space(writer, path.c_str(), size));
 }
 
+void Writer::set_verbose(bool verbose) {
+   auto writer = ptr.get();
+   check_error(writer, tiledb_vcf_writer_set_verbose(writer, verbose));
+}
+
 void Writer::create_dataset() {
   auto writer = ptr.get();
   check_error(writer, tiledb_vcf_writer_create_dataset(writer));

--- a/apis/python/src/tiledbvcf/binding/writer.h
+++ b/apis/python/src/tiledbvcf/binding/writer.h
@@ -79,6 +79,13 @@ class Writer {
 
   void ingest_samples();
 
+  /**
+  * Set writer verbose output mode
+  *
+  * @param verbose mode
+  */
+  void set_verbose(bool verbose);
+
  private:
   /** Helper function to free a C writer instance */
   static void deleter(tiledb_vcf_writer_t* w);

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -25,12 +25,15 @@ ReadConfig.__new__.__defaults__ = (None,) * 6#len(ReadConfig._fields)
 class Dataset(object):
     """A handle on a TileDB-VCF dataset."""
 
-    def __init__(self, uri, mode='r', cfg=None, stats=False):
+    def __init__(self, uri, mode='r', cfg=None, stats=False, verbose=False):
         """ Initializes a TileDB-VCF dataset for interaction.
 
         :param uri: URI of TileDB-VCF dataset
         :param mode: Mode of operation.
         :type mode: 'r' or 'w'
+        :param cfg: TileDB VCF configuration (optional)
+        :param stats: Enable or disable TileDB stats (optional)
+        :param verbose: Enable or disable TileDB VCF verbose output (optional)
         """
         self.uri = uri
         self.mode = mode
@@ -40,9 +43,11 @@ class Dataset(object):
             self._set_read_cfg(cfg)
             self.reader.init(uri)
             self.reader.set_tiledb_stats_enabled(stats)
+            self.reader.set_verbose(verbose)
         elif self.mode == 'w':
             self.writer = libtiledbvcf.Writer()
             self.writer.init(uri)
+            self.writer.set_verbose(verbose)
             if cfg is not None:
                 raise Exception('Config not supported in write mode')
         else:
@@ -224,15 +229,18 @@ class Dataset(object):
 class TileDBVCFDataset(Dataset):
     """A handle on a TileDB-VCF dataset."""
 
-    def __init__(self, uri, mode='r', cfg=None, stats=False):
+    def __init__(self, uri, mode='r', cfg=None, stats=False, verbose=False):
         """ Initializes a TileDB-VCF dataset for interaction.
 
         :param uri: URI of TileDB-VCF dataset
         :param mode: Mode of operation.
         :type mode: 'r' or 'w'
+        :param cfg: TileDB VCF configuration (optional)
+        :param stats: Enable or disable TileDB stats (optional)
+        :param verbose: Enable or disable TileDB VCF verbose output (optional)
         """
         warnings.warn(
             "TileDBVCFDataset is deprecated, use Dataset instead",
             DeprecationWarning
         )
-        super().__init__(uri, mode, cfg, stats)
+        super().__init__(uri, mode, cfg, stats, verbose)

--- a/apis/spark/src/main/java/io/tiledb/vcf/VCFDataSourceOptions.java
+++ b/apis/spark/src/main/java/io/tiledb/vcf/VCFDataSourceOptions.java
@@ -124,6 +124,14 @@ public class VCFDataSourceOptions implements Serializable {
     return Optional.empty();
   }
 
+  /** @return If TileDB-VCF reader should be set to verbose output mode */
+  public Optional<Boolean> getVerbose() {
+    if (options.containsKey("verbose")) {
+      return Optional.of(Boolean.parseBoolean(options.get("verbose")));
+    }
+    return Optional.empty();
+  }
+
   /** @return Optional CSV String of config parameters */
   public Optional<String> getConfigCSV() {
     return getConfigCSV(options);

--- a/apis/spark/src/main/java/io/tiledb/vcf/VCFInputPartitionReader.java
+++ b/apis/spark/src/main/java/io/tiledb/vcf/VCFInputPartitionReader.java
@@ -261,7 +261,13 @@ public class VCFInputPartitionReader implements InputPartitionReader<ColumnarBat
     // Set sort regions
     Optional<Boolean> sortRegions = options.getSortRegions();
     if (sortRegions.isPresent()) {
-      vcfReader.setSortRegions(sortRegions.get().booleanValue());
+      vcfReader.setSortRegions(sortRegions.get());
+    }
+
+    // Set verbose
+    Optional<Boolean> verbose = options.getVerbose();
+    if (verbose.isPresent()) {
+      vcfReader.setVerbose(verbose.get());
     }
 
     // Enable VCFReader stats

--- a/libtiledbvcf/src/c_api/tiledbvcf.cc
+++ b/libtiledbvcf/src/c_api/tiledbvcf.cc
@@ -646,6 +646,17 @@ int32_t tiledb_vcf_reader_get_info_attribute_name(
   return TILEDB_VCF_OK;
 }
 
+int32_t tiledb_vcf_reader_set_verbose(
+    tiledb_vcf_reader_t* reader, const bool verbose) {
+  if (sanity_check(reader) == TILEDB_VCF_ERR)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(reader, reader->reader_->set_verbose(verbose)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
 /* ********************************* */
 /*              WRITER               */
 /* ********************************* */
@@ -803,6 +814,17 @@ int32_t tiledb_vcf_writer_get_last_error(
 int32_t tiledb_vcf_writer_set_scratch_space(
     tiledb_vcf_writer_t* writer, const char* path, uint64_t size) {
   writer->writer_->set_scratch_space(path, size);
+
+  return TILEDB_VCF_OK;
+}
+
+int32_t tiledb_vcf_writer_set_verbose(
+    tiledb_vcf_writer_t* writer, const bool verbose) {
+  if (sanity_check(writer) == TILEDB_VCF_ERR)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(writer, writer->writer_->set_verbose(verbose)))
+    return TILEDB_VCF_ERR;
 
   return TILEDB_VCF_OK;
 }

--- a/libtiledbvcf/src/c_api/tiledbvcf.h
+++ b/libtiledbvcf/src/c_api/tiledbvcf.h
@@ -779,6 +779,14 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_info_attribute_name(
     tiledb_vcf_reader_t* reader, int32_t index, char** name);
 
 /**
+ * Sets verbose mode on or off
+ * @param reader VCF reader object
+ * @param verbose setting
+ */
+TILEDBVCF_EXPORT int32_t
+tiledb_vcf_reader_set_verbose(tiledb_vcf_reader_t* reader, bool verbose);
+
+/**
  * Returns the version number of the TileDB VCF dataset.
  *
  * @param reader VCF reader object
@@ -936,6 +944,14 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_get_last_error(
  */
 TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_set_scratch_space(
     tiledb_vcf_writer_t* writer, const char* path, uint64_t size_mb);
+
+/**
+ * Sets verbose mode on or off
+ * @param reader VCF writter object
+ * @param verbose setting
+ */
+TILEDBVCF_EXPORT int32_t
+tiledb_vcf_writer_set_verbose(tiledb_vcf_writer_t* writer, bool verbose);
 
 /* ********************************* */
 /*               ERROR               */

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -1372,5 +1372,9 @@ void Reader::info_attribute_name(int32_t index, char** name) {
   }
 }
 
+void Reader::set_verbose(const bool& verbose) {
+  params_.verbose = verbose;
+}
+
 }  // namespace vcf
 }  // namespace tiledb

--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -299,6 +299,12 @@ class Reader {
    */
   void info_attribute_name(int32_t index, char** name);
 
+  /**
+   * Sets verbose mode on or off
+   * @param verbose setting
+   */
+  void set_verbose(const bool& verbose);
+
  private:
   /* ********************************* */
   /*           PRIVATE DATATYPES       */

--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -378,5 +378,9 @@ void Writer::set_scratch_space(const std::string path, uint64_t size) {
   this->ingestion_params_.scratch_space = scratchSpaceInfo;
 }
 
+void Writer::set_verbose(const bool& verbose) {
+  ingestion_params_.verbose = verbose;
+}
+
 }  // namespace vcf
 }  // namespace tiledb

--- a/libtiledbvcf/src/write/writer.h
+++ b/libtiledbvcf/src/write/writer.h
@@ -147,6 +147,12 @@ class Writer {
   /** Set ingestion scatch space for ingestion or registration */
   void set_scratch_space(const std::string path, uint64_t size);
 
+  /**
+   * Sets verbose mode on or off
+   * @param verbose setting
+   */
+  void set_verbose(const bool& verbose);
+
  private:
   /* ********************************* */
   /*          PRIVATE ATTRIBUTES       */


### PR DESCRIPTION
Add option to enable verbose output for spark and python. Python supports verbose output for reader and writer. Spark is reader only. This is helpful in debugging.

Python has a new parameter for the `Dataset` constructor.

Spark as a new driver option `verbose` , `.option("verbose", true)`