### PR TITLE
Heap-node ownership of buffered records

### DIFF
--- a/libtiledbvcf/src/CMakeLists.txt
+++ b/libtiledbvcf/src/CMakeLists.txt
@@ -47,7 +47,9 @@ set(TILEDB_VCF_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/utils/sample_utils.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/utils/utils.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/vcf/region.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/vcf/vcf.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/vcf/vcf_utils.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/vcf/vcf_v2.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/vcf/vcf_v3.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/write/record_heap_v2.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/write/record_heap_v3.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/write/writer.cc

--- a/libtiledbvcf/src/cli/tiledbvcf.cc
+++ b/libtiledbvcf/src/cli/tiledbvcf.cc
@@ -33,7 +33,6 @@
 #include "read/reader.h"
 #include "utils/utils.h"
 #include "vcf/region.h"
-#include "vcf/vcf.h"
 #include "write/writer.h"
 
 using namespace tiledb::vcf;
@@ -427,8 +426,7 @@ int main(int argc, char** argv) {
        ((option("-f", "--samples-file") %
              "Path to file with 1 sample name per line" &
          value("path", export_args.samples_file_uri)) |
-        (option("-s", "--sample-names") %
-             "CSV list of sample names to export" &
+        (option("-s", "--sample-names") % "CSV list of sample names to export" &
          value("samples").call([&](const std::string& s) {
            export_args.sample_names = utils::split(s, ',');
          }))),

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -32,7 +32,7 @@
 #include "base64/base64.h"
 #include "dataset/tiledbvcfdataset.h"
 #include "utils/utils.h"
-#include "vcf/vcf.h"
+#include "vcf/vcf_utils.h"
 
 namespace tiledb {
 namespace vcf {
@@ -802,7 +802,7 @@ void TileDBVCFDataset::register_samples_helper(
     std::map<uint32_t, std::string>* sample_headers) {
   for (size_t i = 0; i < headers.size(); i++) {
     const auto& hdr = headers[i];
-    auto hdr_samples = VCF::hdr_get_samples(hdr.get());
+    auto hdr_samples = VCFUtils::hdr_get_samples(hdr.get());
     if (hdr_samples.size() > 1)
       throw std::invalid_argument(
           "Error registering samples; a file has more than 1 sample. "
@@ -815,12 +815,13 @@ void TileDBVCFDataset::register_samples_helper(
           "Error registering samples; sample " + s + " already exists.");
     sample_set->insert(s);
 
-    (*sample_headers)[metadata->free_sample_id] = VCF::hdr_to_string(hdr.get());
+    (*sample_headers)[metadata->free_sample_id] =
+        VCFUtils::hdr_to_string(hdr.get());
     metadata->all_samples.push_back(s);
     metadata->sample_ids[s] = metadata->free_sample_id++;
     if (metadata->contig_offsets.empty()) {
-      metadata->contig_offsets =
-          VCF::hdr_get_contig_offsets(hdr.get(), &metadata->contig_lengths);
+      metadata->contig_offsets = VCFUtils::hdr_get_contig_offsets(
+          hdr.get(), &metadata->contig_lengths);
       metadata->total_contig_length = 0;
       for (const auto& it : metadata->contig_lengths)
         metadata->total_contig_length += it.second;

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -38,6 +38,7 @@
 #include <tiledb/tiledb>
 
 #include "utils/sample_utils.h"
+#include "vcf/region.h"
 
 namespace tiledb {
 namespace vcf {

--- a/libtiledbvcf/src/read/exporter.h
+++ b/libtiledbvcf/src/read/exporter.h
@@ -30,6 +30,7 @@
 #include "dataset/tiledbvcfdataset.h"
 #include "read/export_format.h"
 #include "read_query_results.h"
+#include "vcf/region.h"
 
 namespace tiledb {
 namespace vcf {

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -970,7 +970,7 @@ std::vector<SampleAndId> Reader::prepare_sample_names() const {
 
   for (const std::string& s : params_.sample_names) {
     std::string name;
-    if (!VCF::normalize_sample_name(s, &name))
+    if (!VCFUtils::normalize_sample_name(s, &name))
       throw std::runtime_error(
           "Error preparing sample list for export; sample name '" + s +
           "' is invalid.");
@@ -989,7 +989,7 @@ std::vector<SampleAndId> Reader::prepare_sample_names() const {
     const auto& metadata = dataset_->metadata();
     auto per_line = [&metadata, &result](std::string* line) {
       std::string name;
-      if (!VCF::normalize_sample_name(*line, &name))
+      if (!VCFUtils::normalize_sample_name(*line, &name))
         throw std::runtime_error(
             "Error preparing sample list for export; sample name '" + *line +
             "' is invalid.");

--- a/libtiledbvcf/src/utils/sample_utils.cc
+++ b/libtiledbvcf/src/utils/sample_utils.cc
@@ -27,7 +27,6 @@
 #include "utils/sample_utils.h"
 #include "utils/buffer.h"
 #include "utils/utils.h"
-#include "vcf/vcf.h"
 
 namespace tiledb {
 namespace vcf {

--- a/libtiledbvcf/src/utils/sample_utils.h
+++ b/libtiledbvcf/src/utils/sample_utils.h
@@ -42,7 +42,7 @@
 
 #include "utils/buffer.h"
 #include "utils/utils.h"
-#include "vcf/vcf.h"
+#include "vcf/vcf_utils.h"
 
 namespace tiledb {
 namespace vcf {
@@ -194,7 +194,7 @@ class SampleUtils {
         }
 
         // Allocate a header struct and try to parse from the local file.
-        SafeBCFHdr hdr(VCF::hdr_read_header(path), bcf_hdr_destroy);
+        SafeBCFHdr hdr(VCFUtils::hdr_read_header(path), bcf_hdr_destroy);
         if (hdr != nullptr) {
           result.push_back(process(std::move(hdr)));
           break;

--- a/libtiledbvcf/src/vcf/htslib_value.h
+++ b/libtiledbvcf/src/vcf/htslib_value.h
@@ -27,6 +27,8 @@
 #ifndef TILEDB_VCF_HTSLIB_VALUE_H
 #define TILEDB_VCF_HTSLIB_VALUE_H
 
+#include "utils/utils.h"
+
 namespace tiledb {
 namespace vcf {
 

--- a/libtiledbvcf/src/vcf/vcf_utils.cc
+++ b/libtiledbvcf/src/vcf/vcf_utils.cc
@@ -1,0 +1,164 @@
+/**
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2020 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "vcf/vcf_utils.h"
+
+namespace tiledb {
+namespace vcf {
+
+uint32_t VCFUtils::get_end_pos(
+    bcf_hdr_t* hdr, bcf1_t* rec, HtslibValueMem* val) {
+  val->ndst = HtslibValueMem::convert_ndst_for_type(
+      val->ndst, BCF_HT_INT, &val->type_for_ndst);
+  int rc =
+      bcf_get_info_values(hdr, rec, "END", &val->dst, &val->ndst, BCF_HT_INT);
+  if (rc > 0) {
+    assert(val->dst);
+    assert(val->ndst >= 1);
+    uint32_t copy = ((uint32_t*)val->dst)[0];
+    assert(copy > 0);
+    copy -= 1;
+    return copy;
+  } else {
+    return (uint32_t)rec->pos + rec->rlen - 1;
+  }
+}
+
+bcf_hdr_t* VCFUtils::hdr_read_header(const std::string& path) {
+  auto fh = vcf_open(path.c_str(), "r");
+  if (!fh)
+    return nullptr;
+  auto hdr = bcf_hdr_read(fh);
+  vcf_close(fh);
+  return hdr;
+}
+
+std::vector<std::string> VCFUtils::hdr_get_samples(bcf_hdr_t* hdr) {
+  if (!hdr)
+    throw std::invalid_argument(
+        "Cannot get samples from header; bad VCF header.");
+  std::vector<std::string> ret;
+  const auto nsamp = bcf_hdr_nsamples(hdr);
+  for (int i = 0; i < nsamp; ++i) {
+    std::string normalized;
+    if (!VCFUtils::normalize_sample_name(hdr->samples[i], &normalized))
+      throw std::runtime_error(
+          "Cannot get samples from header; VCF header contains sample name "
+          "with invalid characters: '" +
+          std::string(hdr->samples[i]) + "'");
+    ret.push_back(normalized);
+  }
+  return ret;
+}
+
+std::string VCFUtils::hdr_to_string(bcf_hdr_t* hdr) {
+  if (!hdr)
+    throw std::invalid_argument(
+        "Cannot convert header to string; bad VCF header.");
+  kstring_t t = {0, 0, 0};
+  auto tmp = bcf_hdr_dup(hdr);
+
+  int res = 0;
+  res = bcf_hdr_set_samples(tmp, 0, 0);
+  if (res != 0) {
+    if (res == -1) {
+      throw std::invalid_argument(
+          "Cannot set VCF samples; possibly bad VCF header.");
+    } else if (res > 0) {
+      throw std::runtime_error(
+          std::string("Cannot set VCF samples: list contains samples not "
+                      "present in VCF header, sample #:") +
+          std::to_string(res));
+    }
+  }
+  bcf_hdr_format(tmp, 0, &t);
+  std::string ret(t.s, t.l);
+  bcf_hdr_destroy(tmp);
+  free(t.s);
+  return ret;
+}
+
+std::map<std::string, uint32_t> VCFUtils::hdr_get_contig_offsets(
+    bcf_hdr_t* hdr, std::map<std::string, uint32_t>* contig_lengths) {
+  std::map<std::string, uint32_t> offsets;
+  if (!hdr)
+    throw std::invalid_argument(
+        "Cannot get contig offsets from header; bad VCF header.");
+  int nseq;
+  const char** seqnames = bcf_hdr_seqnames(hdr, &nseq);
+  uint32_t curr = 0;
+  for (int i = 0; i < nseq; ++i) {
+    std::string seqname(seqnames[i]);
+    bcf_hrec_t* hrec =
+        bcf_hdr_get_hrec(hdr, BCF_HL_CTG, "ID", seqname.c_str(), 0);
+    if (!hrec)
+      throw std::invalid_argument(
+          "Cannot get contig offsets from header; error reading contig header "
+          "line " +
+          std::to_string(i));
+    int j = bcf_hrec_find_key(hrec, "length");
+    if (j < 0)
+      throw std::invalid_argument(
+          "Cannot get contig offsets from header; contig def does not have "
+          "length");
+    auto length = strtol(hrec->vals[j], nullptr, 10);
+    offsets[seqname] = curr;
+    (*contig_lengths)[seqname] = length;
+    curr += length;
+  }
+  free(seqnames);
+  return offsets;
+}
+
+bool VCFUtils::normalize_sample_name(
+    const std::string& sample, std::string* normalized) {
+  if (sample.empty())
+    return false;
+
+  // Check for invalid chars
+  const size_t num_invalid = 3;
+  const char invalid_char_list[num_invalid] = {',', '\t', '\0'};
+  if (sample.find_first_of(invalid_char_list, 0, num_invalid) !=
+      std::string::npos)
+    return false;
+
+  // Trim leading/trailing whitespace
+  const std::string whitespace_chars = " \t\n\r\v\f";
+  auto first_non_wsp = sample.find_first_not_of(whitespace_chars);
+  auto last_non_wsp = sample.find_last_not_of(whitespace_chars);
+  if (first_non_wsp == std::string::npos)
+    return false;
+
+  if (normalized != nullptr) {
+    *normalized =
+        sample.substr(first_non_wsp, last_non_wsp - first_non_wsp + 1);
+  }
+
+  return true;
+}
+
+}  // namespace vcf
+}  // namespace tiledb

--- a/libtiledbvcf/src/vcf/vcf_utils.h
+++ b/libtiledbvcf/src/vcf/vcf_utils.h
@@ -1,0 +1,128 @@
+/**
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2020 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Utility routines for VCF.
+ */
+
+#ifndef TILEDB_VCF_VCF_UTILS_H
+#define TILEDB_VCF_VCF_UTILS_H
+
+#include <htslib/hts.h>
+#include <htslib/synced_bcf_reader.h>
+#include <htslib/vcf.h>
+#include <htslib/vcfutils.h>
+#include <map>
+
+#include "vcf/htslib_value.h"
+
+namespace tiledb {
+namespace vcf {
+
+/** Alias for unique_ptr to bcf_hdr_t. */
+typedef std::unique_ptr<bcf_hdr_t, decltype(&bcf_hdr_destroy)> SafeBCFHdr;
+
+/** Alias for unique_ptr to bcf1_t. */
+typedef std::unique_ptr<bcf1_t, decltype(&bcf_destroy)> SafeBCFRec;
+
+/** Alias for shared_ptr to bcf1_t. */
+typedef std::shared_ptr<bcf1_t> SafeSharedBCFRec;
+
+/** Alias for unique_ptr to htsFile. */
+typedef std::unique_ptr<htsFile, decltype(&hts_close)> SafeBCFFh;
+
+/** HTSFile index type. */
+enum class Idx { HTS, TBX };
+
+class VCFUtils {
+ public:
+  /**
+   * Helper function that returns the 0-based END position of the given record.
+   * If the record does not contain an END info field, this returns POS +
+   * len(REF) - 1.
+   *
+   * @param hdr Header instance for the record
+   * @param rec Record to get END position of
+   * @param val Reusable memory location for htslib values
+   * @return 0-based END position
+   */
+  static uint32_t get_end_pos(bcf_hdr_t* hdr, bcf1_t* rec, HtslibValueMem* val);
+
+  /**
+   * Helper function that reads an HTSlib header instance from the VCF/BCF file
+   * at the given path.
+   *
+   * @param path Path of VCF file
+   * @return Header instance read from the file, or null if a header cannot be
+   * read.
+   */
+  static bcf_hdr_t* hdr_read_header(const std::string& path);
+
+  /**
+   * Helper function that returns the normalized sample names from a header
+   * instance.
+   *
+   * @param hdr Header instance
+   * @return Sample names in the header.
+   */
+  static std::vector<std::string> hdr_get_samples(bcf_hdr_t* hdr);
+
+  /**
+   * Helper function that converts an HTSlib header instance to a string.
+   *
+   * @param hdr Header instance
+   * @return Stringified header
+   */
+  static std::string hdr_to_string(bcf_hdr_t* hdr);
+
+  /**
+   * Helper function that constructs a map of contig name -> global genomic
+   * offset.
+   *
+   * @param hdr Header instance
+   * @param contig_lengths Populated to store contig name -> length.
+   * @return Map of contig name -> global genomic position.
+   */
+  static std::map<std::string, uint32_t> hdr_get_contig_offsets(
+      bcf_hdr_t* hdr, std::map<std::string, uint32_t>* contig_lengths);
+
+  /**
+   * Helper function that normalizes a sample name:
+   *  - Remove leading/trailing whitespace
+   *  - Error on invalid chars (comma)
+   *
+   * @param sample Sample name to normalize
+   * @param normalized Set to the normalized sample name
+   * @return True if the sample name was normalized successfully
+   */
+  static bool normalize_sample_name(
+      const std::string& sample, std::string* normalized);
+};
+
+}  // namespace vcf
+}  // namespace tiledb
+
+#endif  // TILEDB_VCF_VCF_UTILS_H

--- a/libtiledbvcf/src/vcf/vcf_v2.cc
+++ b/libtiledbvcf/src/vcf/vcf_v2.cc
@@ -1,0 +1,423 @@
+/**
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "vcf/vcf_v2.h"
+
+namespace tiledb {
+namespace vcf {
+
+VCFV2::VCFV2()
+    : open_(false)
+    , path_("")
+    , index_path_("")
+    , buffer_offset_(0)
+    , max_record_buffer_size_(10000)
+    , hdr_(nullptr)
+    , index_tbx_(nullptr)
+    , index_hts_(nullptr) {
+}
+
+VCFV2::~VCFV2() {
+  close();
+}
+
+void VCFV2::open(const std::string& file, const std::string& index_file) {
+  if (open_)
+    close();
+  if (file.empty())
+    throw std::invalid_argument("Cannot open VCF file; path is empty");
+
+  path_ = file;
+  index_path_ = index_file;
+
+  SafeBCFFh fh(bcf_open(path_.c_str(), "r"), hts_close);
+  if (fh == nullptr)
+    throw std::runtime_error("Cannot open VCF file; bcf_open failed");
+  if (fh->format.compression != bgzf) {
+    close();
+    throw std::runtime_error(
+        "Cannot open VCF file; must be compressed with BGZF and indexed.");
+  }
+
+  hdr_ = bcf_hdr_read(fh.get());
+  if (hdr_ == nullptr) {
+    close();
+    throw std::runtime_error("Cannot open VCF file; bcf_hdr_read failed.");
+  }
+
+  switch (fh->format.format) {
+    case bcf:
+      index_hts_ = index_path_.empty() ?
+                       bcf_index_load(path_.c_str()) :
+                       bcf_index_load2(path_.c_str(), index_path_.c_str());
+      if (index_hts_ == nullptr) {
+        close();
+        throw std::runtime_error(
+            "Cannot open VCF file; failed to load BCF index.");
+      }
+      break;
+    case ::vcf:
+      index_tbx_ = index_path_.empty() ?
+                       tbx_index_load(path_.c_str()) :
+                       tbx_index_load2(path_.c_str(), index_path_.c_str());
+      if (index_tbx_ == nullptr) {
+        close();
+        throw std::runtime_error(
+            "Cannot open VCF file; failed to load TBX index.");
+      }
+      break;
+    default:
+      close();
+      throw std::runtime_error(
+          "Cannot open VCF file; must be VCF or BCF format.");
+      break;
+  }
+
+  open_ = true;
+}
+
+void VCFV2::close() {
+  destroy_buffer();
+
+  if (index_hts_ != nullptr) {
+    hts_idx_destroy(index_hts_);
+    index_hts_ = nullptr;
+  }
+
+  if (index_tbx_ != nullptr) {
+    tbx_destroy(index_tbx_);
+    index_tbx_ = nullptr;
+  }
+
+  if (hdr_ != nullptr) {
+    bcf_hdr_destroy(hdr_);
+    hdr_ = nullptr;
+  }
+
+  open_ = false;
+  path_.clear();
+  index_path_.clear();
+}
+
+bool VCFV2::is_open() const {
+  return open_;
+}
+
+bool VCFV2::next() {
+  if (!open_)
+    return false;
+
+  buffer_offset_ += sizeof(bcf1_t*);
+
+  if (buffer_offset_ < buffer_.size()) {
+    return true;
+  } else {
+    // Buffer the next records into `buffer_`.
+    read_records();
+
+    // Return true if any records were buffered.
+    return buffer_.size() > 0;
+  }
+}
+
+std::string VCFV2::contig_name() const {
+  if (!open_)
+    throw std::runtime_error(
+        "Error getting contig name from VCF; file not open.");
+  if (hdr_ == nullptr)
+    throw std::runtime_error(
+        "Error getting contig name from VCF; header is null.");
+  if (curr_rec() == nullptr)
+    throw std::runtime_error(
+        "Error getting contig name from VCF; current record is null.");
+  return std::string(bcf_seqname(hdr_, curr_rec()));
+}
+
+std::string VCFV2::sample_name() const {
+  if (!open_)
+    throw std::runtime_error(
+        "Error getting sample name from VCF; file not open.");
+  if (hdr_ == nullptr || bcf_hdr_nsamples(hdr_) == 0)
+    throw std::runtime_error(
+        "Error getting sample name from VCF; header has no samples.");
+  std::string unnormalized_name(hdr_->samples[0]);
+  std::string name;
+  if (!VCFUtils::normalize_sample_name(unnormalized_name, &name))
+    throw std::runtime_error(
+        "Error getting sample name from VCF; sample name has invalid "
+        "characters: '" +
+        std::string(unnormalized_name) + "'");
+  return name;
+}
+
+bool VCFV2::contig_has_records(const std::string& contig_name) const {
+  if (!open_)
+    throw std::runtime_error(
+        "Error checking empty contig in VCF; file not open.");
+
+  hts_idx_t* idx = index_tbx_ != nullptr ? index_tbx_->idx : index_hts_;
+  if (idx == nullptr)
+    throw std::runtime_error(
+        "Error checking empty contig in VCF; no index instance.");
+
+  int region_id = index_tbx_ != nullptr ?
+                      tbx_name2id(index_tbx_, contig_name.c_str()) :
+                      bcf_hdr_name2id(hdr_, contig_name.c_str());
+  if (region_id == -1)
+    return false;
+
+  uint64_t records, unused;
+  hts_idx_get_stat(idx, region_id, &records, &unused);
+  return records > 0;
+}
+
+void VCFV2::set_max_record_buff_size(uint64_t max_record_buffer_size) {
+  max_record_buffer_size_ = max_record_buffer_size;
+}
+
+bcf1_t* VCFV2::curr_rec() const {
+  if (buffer_.size() == 0)
+    return nullptr;
+  return buffer_.value<bcf1_t*>(buffer_offset_ / sizeof(bcf1_t*));
+}
+
+bcf_hdr_t* VCFV2::hdr() const {
+  return hdr_;
+}
+
+bool VCFV2::seek(const std::string& contig_name, uint32_t pos) {
+  if (!open_)
+    return false;
+
+  SafeBCFFh fh(bcf_open(path_.c_str(), "r"), hts_close);
+  if (fh == nullptr)
+    throw std::runtime_error("Error seeking in VCF; bcf_open failed");
+
+  record_iter_.reset();
+  if (fh->format.format == bcf) {
+    if (!record_iter_.init_bcf(
+            std::move(fh), hdr_, index_hts_, contig_name, pos))
+      return false;
+
+  } else {
+    if (fh->format.format != ::vcf)
+      throw std::runtime_error("Error seeking in VCF; unknown format.");
+
+    if (!record_iter_.init_tbx(
+            std::move(fh), hdr_, index_tbx_, contig_name, pos))
+      return false;
+  }
+
+  // Buffer the next records into `buffer_`.
+  read_records();
+
+  // Return true if any records were buffered.
+  return buffer_.size() > 0;
+}
+
+void VCFV2::read_records() {
+  // Reset the buffer but don't destroy it, so we can reuse any allocated
+  // record structs.
+  reset_buffer();
+
+  std::unique_ptr<bcf1_t, decltype(&bcf_destroy)> curr_rec(
+      bcf_init1(), bcf_destroy);
+  uint64_t num_records = 0;
+  std::string first_contig_name;
+  while (num_records < max_record_buffer_size_) {
+    if (!record_iter_.next(curr_rec.get()))
+      break;
+
+    // Iteration does not cross contigs.
+    std::string contig_name = bcf_seqname(hdr_, curr_rec.get());
+    if (first_contig_name.empty()) {
+      first_contig_name = contig_name;
+    } else if (first_contig_name != contig_name) {
+      break;
+    }
+
+    // Check to see if an old record was allocated that we can reuse.
+    bcf1_t** record_ptrs = buffer_.data<bcf1_t*>();
+    if ((num_records + 1) * sizeof(bcf1_t*) <= buffer_.alloced_size() &&
+        record_ptrs[num_records] != nullptr) {
+      auto* dst = record_ptrs[num_records];
+      bcf_copy(dst, curr_rec.get());
+      bcf_unpack(dst, BCF_UN_ALL);
+      // Update the size (zeroing out extra space).
+      buffer_.resize(buffer_.size() + sizeof(bcf1_t*), true);
+    } else {
+      auto* dup = bcf_dup(curr_rec.get());
+      bcf_unpack(dup, BCF_UN_ALL);
+      // Note: appending pointers here, not structs. Reserve space first so
+      // any extra alloced space gets zeroed.
+      buffer_.reserve((num_records + 1) * sizeof(bcf1_t*), true);
+      buffer_.append(&dup, sizeof(bcf1_t*));
+    }
+
+    num_records++;
+  }
+
+  buffer_offset_ = 0;
+}
+
+void VCFV2::destroy_buffer() {
+  const size_t num_possible_records = buffer_.alloced_size() / sizeof(bcf1_t*);
+  bcf1_t** record_ptrs = buffer_.data<bcf1_t*>();
+  for (size_t i = 0; i < num_possible_records; i++) {
+    auto* r = record_ptrs[i];
+    if (r != nullptr)
+      bcf_destroy(r);
+  }
+  std::memset(record_ptrs, 0, buffer_.alloced_size());
+  reset_buffer();
+}
+
+void VCFV2::reset_buffer() {
+  buffer_.clear();
+  buffer_offset_ = 0;
+}
+
+void VCFV2::swap(VCFV2& other) {
+  std::swap(open_, other.open_);
+  std::swap(path_, other.path_);
+  std::swap(index_path_, other.index_path_);
+  buffer_.swap(other.buffer_);
+  std::swap(buffer_offset_, other.buffer_offset_);
+  record_iter_.swap(other.record_iter_);
+  std::swap(hdr_, other.hdr_);
+  std::swap(index_tbx_, other.index_tbx_);
+  std::swap(index_hts_, other.index_hts_);
+}
+
+/* ****************************** */
+/*              Iter              */
+/* ****************************** */
+
+VCFV2::Iter::Iter()
+    : fh_(nullptr, hts_close)
+    , hts_iter_(nullptr)
+    , tbx_(nullptr) {
+}
+
+VCFV2::Iter::~Iter() {
+  reset();
+}
+
+bool VCFV2::Iter::init_bcf(
+    SafeBCFFh&& fh,
+    bcf_hdr_t* hdr,
+    hts_idx_t* index,
+    const std::string& contig_name,
+    uint32_t pos) {
+  fh_ = std::move(fh);
+  hdr_ = hdr;
+
+  if (contig_name.empty())
+    throw std::runtime_error(
+        "Failed to init BCF iterator; contig name cannot be empty.");
+
+  int region_id = bcf_hdr_name2id(hdr, contig_name.c_str());
+  if (region_id == -1)
+    return false;
+
+  int region_min = pos;
+  int region_max = std::numeric_limits<int>::max();
+
+  hts_iter_ = bcf_itr_queryi(index, region_id, region_min, region_max);
+  if (hts_iter_ == nullptr)
+    return false;
+
+  return true;
+}
+
+bool VCFV2::Iter::init_tbx(
+    SafeBCFFh&& fh,
+    bcf_hdr_t* hdr,
+    tbx_t* index,
+    const std::string& contig_name,
+    uint32_t pos) {
+  fh_ = std::move(fh);
+  hdr_ = hdr;
+
+  if (contig_name.empty())
+    throw std::runtime_error(
+        "Failed to init TBX iterator; contig name cannot be empty.");
+
+  int region_id = tbx_name2id(index, contig_name.c_str());
+  if (region_id == -1)
+    return false;
+
+  int region_min = pos;
+  int region_max = std::numeric_limits<int>::max();
+
+  tbx_ = index;
+  hts_iter_ = tbx_itr_queryi(index, region_id, region_min, region_max);
+  if (hts_iter_ == nullptr)
+    return false;
+
+  return true;
+}
+
+void VCFV2::Iter::reset() {
+  fh_.reset();
+  hdr_ = nullptr;
+
+  if (hts_iter_ != nullptr) {
+    hts_itr_destroy(hts_iter_);
+    hts_iter_ = nullptr;
+  }
+
+  tbx_ = nullptr;
+
+  if (tmps_.m) {
+    free(tmps_.s);
+    tmps_ = {0, 0, nullptr};
+  }
+}
+
+void VCFV2::Iter::swap(VCFV2::Iter& other) {
+  std::swap(fh_, other.fh_);
+  std::swap(hdr_, other.hdr_);
+  std::swap(hts_iter_, other.hts_iter_);
+  std::swap(tbx_, other.tbx_);
+  std::swap(tmps_, other.tmps_);
+}
+
+bool VCFV2::Iter::next(bcf1_t* rec) {
+  int ret;
+
+  if (tbx_ == nullptr) {
+    ret = bcf_itr_next(fh_.get(), hts_iter_, rec);
+  } else {
+    ret = tbx_itr_next(fh_.get(), tbx_, hts_iter_, &tmps_);
+    vcf_parse1(&tmps_, hdr_, rec);
+  }
+
+  return ret >= 0;
+}
+
+}  // namespace vcf
+}  // namespace tiledb

--- a/libtiledbvcf/src/vcf/vcf_v2.h
+++ b/libtiledbvcf/src/vcf/vcf_v2.h
@@ -1,0 +1,200 @@
+/**
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TILEDB_VCFV2_VCFV2_V2_H
+#define TILEDB_VCFV2_VCFV2_V2_H
+
+#include <htslib/hts.h>
+#include <htslib/synced_bcf_reader.h>
+#include <htslib/vcf.h>
+#include <htslib/vcfutils.h>
+#include <algorithm>
+#include <cstdio>
+#include <iostream>
+#include <map>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "utils/utils.h"
+#include "vcf/htslib_value.h"
+#include "vcf/region.h"
+#include "vcf/vcf_utils.h"
+
+namespace tiledb {
+namespace vcf {
+
+/**
+ * Class wrapping a BCF/VCF file to allow iteration over records.
+ */
+class VCFV2 {
+ public:
+  VCFV2();
+  ~VCFV2();
+
+  VCFV2(VCFV2&& other) = delete;
+  VCFV2(const VCFV2&) = delete;
+  VCFV2& operator=(const VCFV2&) = delete;
+  VCFV2& operator=(VCFV2&&) = delete;
+
+  /**
+   * Opens the specified VCF or BCF file and load the header.
+   *
+   * @param file Path to VCF file.
+   * @param index_file Path to VCF index file. If empty, HTSlib will attempt
+   *   to locate the index file automatically.
+   */
+  void open(const std::string& file, const std::string& index_file = "");
+
+  /** Closes the VCF file and invalidates the iterator. */
+  void close();
+
+  /** Returns true if the file is open. */
+  bool is_open() const;
+
+  /**
+   * Sets the current iterator position to the first record at or after the
+   * given region. Getting `curr_rec` after seek will return the first record in
+   * the region.
+   *
+   * @param contig_name Name of contig to seek to
+   * @param pos 0-based starting position within contig to seek to
+   * @return True if there is at least one record in the given region.
+   */
+  bool seek(const std::string& contig_name, uint32_t pos);
+
+  /**
+   * Returns true if the given contig has any records in the VCF file.
+   */
+  bool contig_has_records(const std::string& contig_name) const;
+
+  /**
+   * Returns the record at the current iterator position. Note you must first
+   * call seek() to initialize the iterator position.
+   */
+  bcf1_t* curr_rec() const;
+
+  /** Returns the header instance of the currently open file. */
+  bcf_hdr_t* hdr() const;
+
+  /**
+   * Advances the current iterator position to the next record. Note you must
+   * first call seek() to initialize the iterator position.
+   *
+   * @return false on read error or if the file has no more records.
+   */
+  bool next();
+
+  /** Returns the name of the contig of the current record. */
+  std::string contig_name() const;
+
+  /** Returns the normalized name of the sample in the currently open file. */
+  std::string sample_name() const;
+
+  /** Sets the max number of records that can be buffered in memory. */
+  void set_max_record_buff_size(uint64_t max_record_buffer_size);
+
+ private:
+  /** BCF/VCF iterator wrapper. */
+  class Iter {
+   public:
+    Iter();
+    ~Iter();
+    bool init_bcf(
+        SafeBCFFh&& fh,
+        bcf_hdr_t* hdr,
+        hts_idx_t* index,
+        const std::string& contig_name,
+        uint32_t pos);
+    bool init_tbx(
+        SafeBCFFh&& fh,
+        bcf_hdr_t* hdr,
+        tbx_t* index,
+        const std::string& contig_name,
+        uint32_t pos);
+    void reset();
+    void swap(Iter& other);
+    bool next(bcf1_t* rec);
+
+   private:
+    SafeBCFFh fh_;
+    bcf_hdr_t* hdr_;
+    hts_itr_t* hts_iter_;
+    tbx_t* tbx_;
+    kstring_t tmps_ = {0, 0, nullptr};
+  };
+
+  /** True if the file is open. */
+  bool open_;
+
+  /** Full path of the VCF file being read. */
+  std::string path_;
+
+  /** Full path of the index file (may be empty). */
+  std::string index_path_;
+
+  /** Record buffer. */
+  Buffer buffer_;
+
+  /** Record buffer offset. */
+  uint64_t buffer_offset_;
+
+  /** The BCF/TBX record iterator. */
+  Iter record_iter_;
+
+  /** Number of records to buffer in memory. */
+  unsigned max_record_buffer_size_;
+
+  /** The HTSlib file header handle. */
+  bcf_hdr_t* hdr_;
+
+  /** The TBX index handle, if the index format is TBX. */
+  tbx_t* index_tbx_;
+
+  /** The HTS index handle, if the index format is HTS. */
+  hts_idx_t* index_hts_;
+
+  /** Frees all buffered records and then resets the record buffer. */
+  void destroy_buffer();
+
+  /**
+   * Resets the record buffer size to 0, but does not free the buffered records
+   * themselves.
+   */
+  void reset_buffer();
+
+  /** Reads records into the record buffer using `iter_`. */
+  void read_records();
+
+  /** Swap all fields with the given VCFV2 instance. */
+  void swap(VCFV2& other);
+};
+
+}  // namespace vcf
+}  // namespace tiledb
+
+#endif  // TILEDB_VCFV2_VCFV2_V2_H

--- a/libtiledbvcf/src/write/record_heap_v2.cc
+++ b/libtiledbvcf/src/write/record_heap_v2.cc
@@ -25,6 +25,7 @@
  */
 
 #include "write/record_heap_v2.h"
+#include "vcf/vcf_utils.h"
 
 namespace tiledb {
 namespace vcf {
@@ -39,7 +40,7 @@ bool RecordHeapV2::empty() const {
 }
 
 void RecordHeapV2::insert(
-    VCF* vcf,
+    VCFV2* vcf,
     NodeType type,
     bcf1_t* record,
     uint32_t sort_end_pos,
@@ -52,7 +53,7 @@ void RecordHeapV2::insert(
     throw std::runtime_error(
         "Error inserting " + str_type + " '" + contig + ":" +
         std::to_string(record->pos + 1) + "-" +
-        std::to_string(VCF::get_end_pos(vcf->hdr(), record, &val) + 1) +
+        std::to_string(VCFUtils::get_end_pos(vcf->hdr(), record, &val) + 1) +
         "' into ingestion heap from sample ID " + std::to_string(sample_id) +
         "; sort end position " + std::to_string(sort_end_pos + 1) +
         " cannot be less than start.");

--- a/libtiledbvcf/src/write/record_heap_v2.h
+++ b/libtiledbvcf/src/write/record_heap_v2.h
@@ -30,7 +30,7 @@
 #include <htslib/vcf.h>
 #include <queue>
 
-#include "vcf/vcf.h"
+#include "vcf/vcf_v2.h"
 
 namespace tiledb {
 namespace vcf {
@@ -47,7 +47,7 @@ class RecordHeapV2 {
         , sample_id(std::numeric_limits<uint32_t>::max()) {
     }
 
-    VCF* vcf;
+    VCFV2* vcf;
     NodeType type;
     bcf1_t* record;
     uint32_t sort_end_pos;
@@ -59,7 +59,7 @@ class RecordHeapV2 {
   bool empty() const;
 
   void insert(
-      VCF* vcf,
+      VCFV2* vcf,
       NodeType type,
       bcf1_t* record,
       uint32_t sort_end_pos,

--- a/libtiledbvcf/src/write/record_heap_v3.h
+++ b/libtiledbvcf/src/write/record_heap_v3.h
@@ -30,7 +30,7 @@
 #include <htslib/vcf.h>
 #include <queue>
 
-#include "vcf/vcf.h"
+#include "vcf/vcf_v3.h"
 
 namespace tiledb {
 namespace vcf {
@@ -48,9 +48,9 @@ class RecordHeapV3 {
         , end_node(false) {
     }
 
-    VCF* vcf;
+    VCFV3* vcf;
     NodeType type;
-    bcf1_t* record;
+    SafeSharedBCFRec record;
     uint32_t sort_start_pos;
     uint32_t sample_id;
     bool end_node;
@@ -61,9 +61,9 @@ class RecordHeapV3 {
   bool empty() const;
 
   void insert(
-      VCF* vcf,
+      VCFV3* vcf,
       NodeType type,
-      bcf1_t* record,
+      SafeSharedBCFRec record,
       uint32_t sort_start_pos,
       uint32_t sample_id,
       bool end_node);

--- a/libtiledbvcf/src/write/writer_worker_v2.h
+++ b/libtiledbvcf/src/write/writer_worker_v2.h
@@ -105,7 +105,7 @@ class WriterWorkerV2 : public WriterWorker {
   const TileDBVCFDataset* dataset_;
 
   /** Vector of VCF files being parsed. */
-  std::vector<std::unique_ptr<VCF>> vcfs_;
+  std::vector<std::unique_ptr<VCFV2>> vcfs_;
 
   /** Reusable memory allocation for getting record field values from htslib. */
   HtslibValueMem val_;

--- a/libtiledbvcf/src/write/writer_worker_v3.h
+++ b/libtiledbvcf/src/write/writer_worker_v3.h
@@ -39,6 +39,7 @@
 #include "dataset/attribute_buffer_set.h"
 #include "dataset/tiledbvcfdataset.h"
 #include "vcf/htslib_value.h"
+#include "vcf/vcf_utils.h"
 #include "write/record_heap_v3.h"
 #include "write/writer.h"
 #include "write/writer_worker.h"
@@ -105,7 +106,7 @@ class WriterWorkerV3 : public WriterWorker {
   const TileDBVCFDataset* dataset_;
 
   /** Vector of VCF files being parsed. */
-  std::vector<std::unique_ptr<VCF>> vcfs_;
+  std::vector<std::unique_ptr<VCFV3>> vcfs_;
 
   /** Reusable memory allocation for getting record field values from htslib. */
   HtslibValueMem val_;

--- a/libtiledbvcf/test/src/unit-vcf-iter.cc
+++ b/libtiledbvcf/test/src/unit-vcf-iter.cc
@@ -32,7 +32,9 @@
 
 #include "catch.hpp"
 
-#include "vcf/vcf.h"
+#include "vcf/vcf_utils.h"
+#include "vcf/vcf_v2.h"
+#include "vcf/vcf_v3.h"
 
 #include <cstring>
 #include <iostream>
@@ -42,8 +44,10 @@ using namespace tiledb::vcf;
 static const std::string input_dir = TILEDB_VCF_TEST_INPUT_DIR;
 
 namespace {
-void check_iter(
-    VCF* vcf, const std::vector<std::tuple<std::string, int, int>>& expected) {
+
+void check_iter_v2(
+    VCFV2* vcf,
+    const std::vector<std::tuple<std::string, int, int>>& expected) {
   HtslibValueMem val;
   for (unsigned i = 0; i < expected.size(); i++) {
     const auto& tup = expected[i];
@@ -51,7 +55,7 @@ void check_iter(
     REQUIRE(r != nullptr);
     REQUIRE(bcf_seqname(vcf->hdr(), r) == std::get<0>(tup));
     REQUIRE(r->pos == std::get<1>(tup));
-    REQUIRE(VCF::get_end_pos(vcf->hdr(), r, &val) == std::get<2>(tup));
+    REQUIRE(VCFUtils::get_end_pos(vcf->hdr(), r, &val) == std::get<2>(tup));
 
     bool b = vcf->next();
     if (i < expected.size() - 1)
@@ -60,10 +64,28 @@ void check_iter(
       REQUIRE(!b);  // should not be more records in vcf
   }
 }
+
+void check_iter_v3(
+    VCFV3* vcf,
+    const std::vector<std::tuple<std::string, int, int>>& expected) {
+  HtslibValueMem val;
+  for (unsigned i = 0; i < expected.size(); i++) {
+    const auto& tup = expected[i];
+    SafeSharedBCFRec r = vcf->next();
+    REQUIRE(r != nullptr);
+    REQUIRE(bcf_seqname(vcf->hdr(), r.get()) == std::get<0>(tup));
+    REQUIRE(r->pos == std::get<1>(tup));
+    REQUIRE(
+        VCFUtils::get_end_pos(vcf->hdr(), r.get(), &val) == std::get<2>(tup));
+  }
+
+  REQUIRE(vcf->next() == nullptr);
+}
+
 }  // namespace
 
-TEST_CASE("VCF: Test basic iterator", "[tiledbvcf][iter]") {
-  VCF vcf;
+TEST_CASE("VCF: Test basic V2 iterator", "[tiledbvcf][iter][v2]") {
+  VCFV2 vcf;
   REQUIRE(!vcf.is_open());
 
   vcf.open(input_dir + "/small.bcf");
@@ -74,7 +96,7 @@ TEST_CASE("VCF: Test basic iterator", "[tiledbvcf][iter]") {
 
   // Work around some compilers complaining about brace-init
   using Tup = std::tuple<std::string, int, int>;
-  check_iter(
+  check_iter_v2(
       &vcf,
       {{
           Tup{"1", 12140, 12276},
@@ -84,7 +106,7 @@ TEST_CASE("VCF: Test basic iterator", "[tiledbvcf][iter]") {
   REQUIRE(!vcf.next());
 
   REQUIRE(vcf.seek("1", 12140));
-  check_iter(
+  check_iter_v2(
       &vcf,
       {{
           Tup{"1", 12140, 12276},
@@ -94,7 +116,7 @@ TEST_CASE("VCF: Test basic iterator", "[tiledbvcf][iter]") {
   REQUIRE(!vcf.next());
 
   REQUIRE(vcf.seek("1", 12500));
-  check_iter(
+  check_iter_v2(
       &vcf,
       {{
           Tup{"1", 12545, 12770},
@@ -103,7 +125,7 @@ TEST_CASE("VCF: Test basic iterator", "[tiledbvcf][iter]") {
   REQUIRE(!vcf.next());
 
   REQUIRE(vcf.seek("1", 12600));
-  check_iter(
+  check_iter_v2(
       &vcf,
       {{
           Tup{"1", 12545, 12770},
@@ -112,7 +134,7 @@ TEST_CASE("VCF: Test basic iterator", "[tiledbvcf][iter]") {
   REQUIRE(!vcf.next());
 
   REQUIRE(vcf.seek("1", 13388));
-  check_iter(
+  check_iter_v2(
       &vcf,
       {{
           Tup{"1", 13353, 13388},
@@ -129,8 +151,8 @@ TEST_CASE("VCF: Test basic iterator", "[tiledbvcf][iter]") {
   REQUIRE(!vcf.seek("1", 0));
 }
 
-TEST_CASE("VCF: Test iterator", "[tiledbvcf][iter]") {
-  VCF vcf;
+TEST_CASE("VCF: Test V2 iterator", "[tiledbvcf][iter][v2]") {
+  VCFV2 vcf;
   vcf.open(input_dir + "/random_synthetic/G1.bcf");
   REQUIRE(vcf.is_open());
   REQUIRE(vcf.curr_rec() == nullptr);
@@ -138,7 +160,90 @@ TEST_CASE("VCF: Test iterator", "[tiledbvcf][iter]") {
 
   // Work around some compilers complaining about brace-init
   using Tup = std::tuple<std::string, int, int>;
-  check_iter(
+  check_iter_v2(
+      &vcf,
+      {{
+          Tup{"7", 11989, 70061},
+          Tup{"7", 77583, 107339},
+          Tup{"7", 111162, 165905},
+      }});
+  // Check iterator doesn't span to the next contig
+  REQUIRE(!vcf.next());
+}
+
+TEST_CASE("VCF: Test basic V3 iterator", "[tiledbvcf][iter][v3]") {
+  VCFV3 vcf;
+  REQUIRE(!vcf.is_open());
+
+  vcf.open(input_dir + "/small.bcf");
+  REQUIRE(vcf.is_open());
+  REQUIRE(vcf.seek("1", 0));
+
+  // Work around some compilers complaining about brace-init
+  using Tup = std::tuple<std::string, int, int>;
+  check_iter_v3(
+      &vcf,
+      {{
+          Tup{"1", 12140, 12276},
+          Tup{"1", 12545, 12770},
+          Tup{"1", 13353, 13388},
+      }});
+  REQUIRE(!vcf.next());
+
+  REQUIRE(vcf.seek("1", 12140));
+  check_iter_v3(
+      &vcf,
+      {{
+          Tup{"1", 12140, 12276},
+          Tup{"1", 12545, 12770},
+          Tup{"1", 13353, 13388},
+      }});
+  REQUIRE(!vcf.next());
+
+  REQUIRE(vcf.seek("1", 12500));
+  check_iter_v3(
+      &vcf,
+      {{
+          Tup{"1", 12545, 12770},
+          Tup{"1", 13353, 13388},
+      }});
+  REQUIRE(!vcf.next());
+
+  REQUIRE(vcf.seek("1", 12600));
+  check_iter_v3(
+      &vcf,
+      {{
+          Tup{"1", 12545, 12770},
+          Tup{"1", 13353, 13388},
+      }});
+  REQUIRE(!vcf.next());
+
+  REQUIRE(vcf.seek("1", 13388));
+  check_iter_v3(
+      &vcf,
+      {{
+          Tup{"1", 13353, 13388},
+      }});
+  REQUIRE(!vcf.next());
+
+  REQUIRE(!vcf.seek("1", 14000));
+  REQUIRE(!vcf.next());
+
+  vcf.close();
+  REQUIRE(!vcf.is_open());
+  REQUIRE(!vcf.next());
+  REQUIRE(!vcf.seek("1", 0));
+}
+
+TEST_CASE("VCF: Test V3 iterator", "[tiledbvcf][iter][v3]") {
+  VCFV3 vcf;
+  vcf.open(input_dir + "/random_synthetic/G1.bcf");
+  REQUIRE(vcf.is_open());
+  REQUIRE(vcf.seek("7", 0));
+
+  // Work around some compilers complaining about brace-init
+  using Tup = std::tuple<std::string, int, int>;
+  check_iter_v3(
       &vcf,
       {{
           Tup{"7", 11989, 70061},


### PR DESCRIPTION
This is a prerequisite to ingesting overlapping records.

Currently, the `VCF` class iterates through a VCF file with a readahead that
buffers multiple records into a single buffer. When the last record in the
buffer is read, the buffer is cleared and populated with the next set of
records. This is OK because we currently enforce that all records are ordered
and without overlap.

To support overlapping records, records may be processed out-of-order. We can
not safely clear the single buffer because nodes on the heap may still point
to them. This change moves ownership of the records from the `VCF` instance
to the individual nodes on the heap.

The `VCF` still performs a readahead, but places each record onto a queue. The
writer worker will pop the next record and place it into the heap. When the
queue is empty, the `VCF` instance will perform the next readahead. There is
no additional copying and the read IO is unchanged. As an optimization,
when the end node on a heap is popped, the allocated record is returned to the
`VCF` instance for re-use.

This patch is verbose because the `VCF` instance had to be split into a V2
and V3 variant to support backwards compatibility. Shared static utilities
have been placed into a `vcf/vcf_utils.h` file.