### PR TITLE
Add python method for retrieving attributes from a dataset

### DIFF
--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -41,7 +41,10 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("get_fmt_attribute_count", &Reader::get_fmt_attribute_count)
       .def("get_fmt_attribute_name", &Reader::get_fmt_attribute_name)
       .def("get_info_attribute_count", &Reader::get_info_attribute_count)
-      .def("get_info_attribute_name", &Reader::get_info_attribute_name);
+      .def("get_info_attribute_name", &Reader::get_info_attribute_name)
+      .def("get_queryable_attribute_count", &Reader::get_queryable_attribute_count)
+      .def("get_queryable_attribute_name", &Reader::get_queryable_attribute_name);
+
 
   py::class_<Writer>(m, "Writer")
       .def(py::init())

--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -37,7 +37,11 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("completed", &Reader::completed)
       .def("result_num_records", &Reader::result_num_records)
       .def("get_tiledb_stats_enabled", &Reader::get_tiledb_stats_enabled)
-      .def("get_tiledb_stats", &Reader::get_tiledb_stats);
+      .def("get_tiledb_stats", &Reader::get_tiledb_stats)
+      .def("get_fmt_attribute_count", &Reader::get_fmt_attribute_count)
+      .def("get_fmt_attribute_name", &Reader::get_fmt_attribute_name)
+      .def("get_info_attribute_count", &Reader::get_info_attribute_count)
+      .def("get_info_attribute_name", &Reader::get_info_attribute_name);
 
   py::class_<Writer>(m, "Writer")
       .def(py::init())

--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -38,12 +38,9 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("result_num_records", &Reader::result_num_records)
       .def("get_tiledb_stats_enabled", &Reader::get_tiledb_stats_enabled)
       .def("get_tiledb_stats", &Reader::get_tiledb_stats)
-      .def("get_fmt_attribute_count", &Reader::get_fmt_attribute_count)
-      .def("get_fmt_attribute_name", &Reader::get_fmt_attribute_name)
-      .def("get_info_attribute_count", &Reader::get_info_attribute_count)
-      .def("get_info_attribute_name", &Reader::get_info_attribute_name)
-      .def("get_queryable_attribute_count", &Reader::get_queryable_attribute_count)
-      .def("get_queryable_attribute_name", &Reader::get_queryable_attribute_name);
+      .def("get_fmt_attributes", &Reader::get_fmt_attributes)
+      .def("get_info_attributes", &Reader::get_info_attributes)
+      .def("get_queryable_attributes", &Reader::get_queryable_attributes);
 
 
   py::class_<Writer>(m, "Writer")

--- a/apis/python/src/tiledbvcf/binding/reader.cc
+++ b/apis/python/src/tiledbvcf/binding/reader.cc
@@ -353,6 +353,34 @@ std::string Reader::get_tiledb_stats() {
   return std::string(stats);
 }
 
+int32_t Reader::get_fmt_attribute_count() {
+  auto reader = ptr.get();
+  int32_t count;
+  check_error(reader, tiledb_vcf_reader_get_fmt_attribute_count(reader, &count));
+  return (count);
+}
+
+std::string Reader::get_fmt_attribute_name(int32_t index) {
+  auto reader = ptr.get();
+  char* name;
+  check_error(reader, tiledb_vcf_reader_get_fmt_attribute_name(reader, index, &name));
+  return std::string(name);
+}
+
+int32_t Reader::get_info_attribute_count() {
+  auto reader = ptr.get();
+  int32_t count;
+  check_error(reader, tiledb_vcf_reader_get_info_attribute_count(reader, &count));
+  return (count);
+}
+
+std::string Reader::get_info_attribute_name(int32_t index) {
+  auto reader = ptr.get();
+  char* name;
+  check_error(reader, tiledb_vcf_reader_get_info_attribute_name(reader, index, &name));
+  return std::string(name);
+}
+
 py::dtype Reader::to_numpy_dtype(tiledb_vcf_attr_datatype_t datatype) {
   switch (datatype) {
     case TILEDB_VCF_CHAR:

--- a/apis/python/src/tiledbvcf/binding/reader.cc
+++ b/apis/python/src/tiledbvcf/binding/reader.cc
@@ -381,6 +381,20 @@ std::string Reader::get_info_attribute_name(int32_t index) {
   return std::string(name);
 }
 
+int32_t Reader::get_queryable_attribute_count() {
+  auto reader = ptr.get();
+  int32_t count;
+  check_error(reader, tiledb_vcf_reader_get_queryable_attribute_count(reader, &count));
+  return (count);
+}
+
+std::string Reader::get_queryable_attribute_name(int32_t index) {
+  auto reader = ptr.get();
+  char* name;
+  check_error(reader, tiledb_vcf_reader_get_queryable_attribute_name(reader, index, &name));
+  return std::string(name);
+}
+
 py::dtype Reader::to_numpy_dtype(tiledb_vcf_attr_datatype_t datatype) {
   switch (datatype) {
     case TILEDB_VCF_CHAR:

--- a/apis/python/src/tiledbvcf/binding/reader.cc
+++ b/apis/python/src/tiledbvcf/binding/reader.cc
@@ -353,46 +353,49 @@ std::string Reader::get_tiledb_stats() {
   return std::string(stats);
 }
 
-int32_t Reader::get_fmt_attribute_count() {
+std::vector<std::string> Reader::get_fmt_attributes() {
   auto reader = ptr.get();
   int32_t count;
+  std::vector<std::string> attrs;
   check_error(reader, tiledb_vcf_reader_get_fmt_attribute_count(reader, &count));
-  return (count);
+
+  for(int32_t i = 0; i < count; i++) {
+    char* name;
+    check_error(reader, tiledb_vcf_reader_get_fmt_attribute_name(reader, i, &name));
+    attrs.emplace_back(name);
+  }
+
+  return attrs;
 }
 
-std::string Reader::get_fmt_attribute_name(int32_t index) {
-  auto reader = ptr.get();
-  char* name;
-  check_error(reader, tiledb_vcf_reader_get_fmt_attribute_name(reader, index, &name));
-  return std::string(name);
-}
-
-int32_t Reader::get_info_attribute_count() {
+std::vector<std::string> Reader::get_info_attributes() {
   auto reader = ptr.get();
   int32_t count;
+  std::vector<std::string> attrs;
   check_error(reader, tiledb_vcf_reader_get_info_attribute_count(reader, &count));
-  return (count);
+
+  for(int32_t i = 0; i < count; i++) {
+    char* name;
+    check_error(reader, tiledb_vcf_reader_get_info_attribute_name(reader, i, &name));
+    attrs.emplace_back(name);
+  }
+
+  return attrs;
 }
 
-std::string Reader::get_info_attribute_name(int32_t index) {
-  auto reader = ptr.get();
-  char* name;
-  check_error(reader, tiledb_vcf_reader_get_info_attribute_name(reader, index, &name));
-  return std::string(name);
-}
-
-int32_t Reader::get_queryable_attribute_count() {
+std::vector<std::string> Reader::get_queryable_attributes() {
   auto reader = ptr.get();
   int32_t count;
+  std::vector<std::string> attrs;
   check_error(reader, tiledb_vcf_reader_get_queryable_attribute_count(reader, &count));
-  return (count);
-}
 
-std::string Reader::get_queryable_attribute_name(int32_t index) {
-  auto reader = ptr.get();
-  char* name;
-  check_error(reader, tiledb_vcf_reader_get_queryable_attribute_name(reader, index, &name));
-  return std::string(name);
+  for(int32_t i = 0; i < count; i++) {
+    char* name;
+    check_error(reader, tiledb_vcf_reader_get_queryable_attribute_name(reader, i, &name));
+    attrs.emplace_back(name);
+  }
+
+  return attrs;
 }
 
 py::dtype Reader::to_numpy_dtype(tiledb_vcf_attr_datatype_t datatype) {

--- a/apis/python/src/tiledbvcf/binding/reader.h
+++ b/apis/python/src/tiledbvcf/binding/reader.h
@@ -127,6 +127,12 @@ class Reader {
   /** Returns info attribute name */
   std::string get_info_attribute_name(int32_t index);
 
+  /** Returns number of queryable attributes */
+  int32_t get_queryable_attribute_count();
+
+  /** Returns queryable attribute name */
+  std::string get_queryable_attribute_name(int32_t index);
+
   /**
    * Set reader verbose output mode
    *

--- a/apis/python/src/tiledbvcf/binding/reader.h
+++ b/apis/python/src/tiledbvcf/binding/reader.h
@@ -115,6 +115,18 @@ class Reader {
   /** Fetches TileDB statistics */
   std::string get_tiledb_stats();
 
+  /** Returns number of queryable fmt attributes */
+  int32_t get_fmt_attribute_count();
+
+  /** Returns fmt attribute name */
+  std::string get_fmt_attribute_name(int32_t index);
+
+  /** Returns number of queryable info attributes */
+  int32_t get_info_attribute_count();
+
+  /** Returns info attribute name */
+  std::string get_info_attribute_name(int32_t index);
+
   /**
    * Set reader verbose output mode
    *

--- a/apis/python/src/tiledbvcf/binding/reader.h
+++ b/apis/python/src/tiledbvcf/binding/reader.h
@@ -115,23 +115,14 @@ class Reader {
   /** Fetches TileDB statistics */
   std::string get_tiledb_stats();
 
-  /** Returns number of queryable fmt attributes */
-  int32_t get_fmt_attribute_count();
+  /** Returns fmt attribute names */
+  std::vector<std::string> get_fmt_attributes();
 
-  /** Returns fmt attribute name */
-  std::string get_fmt_attribute_name(int32_t index);
+  /** Returns info attribute names */
+  std::vector<std::string> get_info_attributes();
 
-  /** Returns number of queryable info attributes */
-  int32_t get_info_attribute_count();
-
-  /** Returns info attribute name */
-  std::string get_info_attribute_name(int32_t index);
-
-  /** Returns number of queryable attributes */
-  int32_t get_queryable_attribute_count();
-
-  /** Returns queryable attribute name */
-  std::string get_queryable_attribute_name(int32_t index);
+  /** Returns all queryable attribute names */
+  std::vector<std::string> get_queryable_attributes();
 
   /**
    * Set reader verbose output mode

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -246,6 +246,23 @@ class Dataset(object):
 
         return attrs
 
+    def queryable_attributes(self):
+            """List queryable available attributes ingested from the VCF INFO and FORMAT fields
+
+            :returns: a list of strings representing the attribute names
+            """
+
+            if self.mode != 'r':
+                raise Exception("Attributes can only be retrieved in read mode")
+
+            n_attrs = self.reader.get_queryable_attribute_count();
+
+            attrs = []
+            for i in range(n_attrs):
+                attrs.append(self.reader.get_queryable_attribute_name(i))
+
+            return attrs
+
     def fmt_attr_count(self):
         if self.mode != 'r':
             raise Exception('Attributes can only be counted for in read mode')

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -226,6 +226,30 @@ class Dataset(object):
 
         return self.reader.get_tiledb_stats();
 
+    def fmt_attr_count(self):
+        if self.mode != 'r':
+            raise Exception('Attributes can only be counted for in read mode')
+
+        return self.reader.get_fmt_attribute_count();
+
+    def fmt_attr_name(self, index):
+        if self.mode != 'r':
+            raise Exception('Attributes can only be retrieved in read mode')
+
+        return self.reader.get_fmt_attribute_name(index);
+
+    def info_attr_count(self):
+        if self.mode != 'r':
+            raise Exception('Attributes can only be counted for in read mode')
+
+        return self.reader.get_info_attribute_count();
+
+    def info_attr_name(self, index):
+        if self.mode != 'r':
+            raise Exception('Attributes can only be retrieved in read mode')
+
+        return self.reader.get_info_attribute_name(index);
+
 class TileDBVCFDataset(Dataset):
     """A handle on a TileDB-VCF dataset."""
 

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -226,6 +226,26 @@ class Dataset(object):
 
         return self.reader.get_tiledb_stats();
 
+    def attributes(self):
+        """List available attributes ingested from the VCF INFO and FORMAT fields
+
+        :returns: a list of strings representing the attribute names
+        """
+
+        if self.mode != 'r':
+            raise Exception("Attributes can only be retrieved in read mode")
+
+        n_info = self.reader.get_info_attribute_count();
+        n_fmt = self.reader.get_fmt_attribute_count();
+
+        attrs = []
+        for i in range(n_info):
+            attrs.append(self.reader.get_info_attribute_name(i))
+        for i in range(n_fmt):
+            attrs.append(self.reader.get_fmt_attribute_name(i))
+
+        return attrs
+
     def fmt_attr_count(self):
         if self.mode != 'r':
             raise Exception('Attributes can only be counted for in read mode')

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -260,22 +260,13 @@ class Dataset(object):
             return sorted(list(attrs))
 
     def __queryable_attrs(self):
-        attrs = []
-        for i in range(self.reader.get_queryable_attribute_count()):
-            attrs.append(self.reader.get_queryable_attribute_name(i))
-        return attrs
+        return self.reader.get_queryable_attributes()
 
     def __fmt_attrs(self):
-        attrs = []
-        for i in range(self.reader.get_fmt_attribute_count()):
-            attrs.append(self.reader.get_fmt_attribute_name(i))
-        return attrs
+        return self.reader.get_fmt_attributes()
 
     def __info_attrs(self):
-        attrs = []
-        for i in range(self.reader.get_info_attribute_count()):
-            attrs.append(self.reader.get_info_attribute_name(i))
-        return attrs
+        return self.reader.get_info_attributes()
 
 class TileDBVCFDataset(Dataset):
     """A handle on a TileDB-VCF dataset."""

--- a/apis/python/tests/test_tiledbvcf.py
+++ b/apis/python/tests/test_tiledbvcf.py
@@ -42,6 +42,48 @@ def test_read_must_specify_attrs(test_ds):
     with pytest.raises(Exception):
         df = test_ds.read()
 
+def test_retrieve_attributes(test_ds):
+    builtin_attrs = [
+        "sample_name",
+        "contig",
+        "pos_start",
+        "pos_end",
+        "query_bed_start",
+        "query_bed_end",
+        "alleles",
+        "id",
+        "filters",
+        "qual"
+    ]
+    assert test_ds.attributes(attr_type = "builtin") == sorted(builtin_attrs)
+
+    info_attrs = [
+        "info_BaseQRankSum",
+        "info_ClippingRankSum",
+        "info_DP",
+        "info_DS",
+        "info_END",
+        "info_HaplotypeScore",
+        "info_InbreedingCoeff",
+        "info_MLEAC",
+        "info_MLEAF",
+        "info_MQ",
+        "info_MQ0",
+        "info_MQRankSum",
+        "info_ReadPosRankSum"
+    ]
+    assert test_ds.attributes(attr_type = "info") == info_attrs
+
+    fmt_attrs = [
+        "fmt_AD",
+        "fmt_DP",
+        "fmt_GQ",
+        "fmt_GT",
+        "fmt_MIN_DP",
+        "fmt_PL",
+        "fmt_SB"
+    ]
+    assert test_ds.attributes(attr_type = "fmt") == fmt_attrs
 
 def test_basic_reads(test_ds):
     expected_df = pd.DataFrame(


### PR DESCRIPTION
New `attributes()` method for `tiledbvcf.Dataset` that allows users to retrieve attributes available in a dataset. 

* by default all attributes are returned (with the exception of the aggregated `info` and `fmt` attributes)
* specific subsets of attributes can be selected with the `attr_type` argument