### PR TITLE
Fix segfault in InMemoryExporter::get_info_fmt_value

### DIFF
--- a/libtiledbvcf/src/read/in_memory_exporter.cc
+++ b/libtiledbvcf/src/read/in_memory_exporter.cc
@@ -928,7 +928,7 @@ void InMemoryExporter::get_info_fmt_value(
     tot_nbytes -= sizeof(uint32_t);
     ptr += sizeof(uint32_t);
 
-    const char* end = ptr + tot_nbytes + 1;
+    const char* end = ptr + tot_nbytes;
     while (ptr < end) {
       size_t keylen = strlen(ptr);
       bool match = strcmp(field_name.c_str(), ptr) == 0;


### PR DESCRIPTION
We encode and store INFO values in a buffer as: keystr,type,nvalues,values

This fixes an off-by-one where we read an extra INFO value from the query
result. If the overread memory is zeroed, the behavior works as expected. If
the memory is not-zeroed, we end up with a segfault. I could also envision
corrupt/false values being read, but I have not explicitly observed that
scenario.