### PR TITLE
Error in spark for sample option and filter

### DIFF
--- a/apis/spark/src/main/java/io/tiledb/vcf/VCFDataSourceReader.java
+++ b/apis/spark/src/main/java/io/tiledb/vcf/VCFDataSourceReader.java
@@ -56,6 +56,10 @@ public class VCFDataSourceReader
       boolean pushed = false;
       if (f instanceof EqualTo) {
         if (((EqualTo) f).attribute().equals("sampleName")) {
+          if (options.getSamples().isPresent() || options.getSampleURI().isPresent()) {
+            throw new UnsupportedOperationException(
+                "Cannot have a sampleName in where clause while also having samples or sampleFile in options list");
+          }
           String value = (String) ((EqualTo) f).value();
           pushedSampleNames.add(value);
           pushed = true;

--- a/apis/spark/src/test/java/io/tiledb/vcf/VCFDatasourceTest.java
+++ b/apis/spark/src/test/java/io/tiledb/vcf/VCFDatasourceTest.java
@@ -163,7 +163,6 @@ public class VCFDatasourceTest extends SharedJavaSparkSession {
 
   @Test
   public void testBedFile() {
-    System.out.println("BED: " + testSampleFile());
     Dataset<Row> dfRead =
         session()
             .read()
@@ -201,6 +200,42 @@ public class VCFDatasourceTest extends SharedJavaSparkSession {
     Assert.assertEquals(rows.get(0).getString(0), "HG01762");
     Assert.assertEquals(rows.get(1).getString(0), "HG01762");
     Assert.assertEquals(rows.get(2).getString(0), "HG01762");
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testSchemaPushDownSamplesError() {
+    Dataset<Row> dfRead =
+        session()
+            .read()
+            .format("io.tiledb.vcf")
+            .option("uri", testSampleGroupURI("ingested_2samples"))
+            .option("ranges", "1:12100-13360,1:13500-17350")
+            .option("samples", "HG01762")
+            .option("tiledb.vfs.num_threads", 1)
+            .load();
+    dfRead.createOrReplaceTempView("vcf");
+    List<Row> rows =
+        sparkSession
+            .sql("SELECT sampleName FROM vcf WHERE vcf.sampleName='HG01762'")
+            .collectAsList();
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testSchemaPushDownSamplesError2() {
+    Dataset<Row> dfRead =
+        session()
+            .read()
+            .format("io.tiledb.vcf")
+            .option("uri", testSampleGroupURI("ingested_2samples"))
+            .option("ranges", "1:12100-13360,1:13500-17350")
+            .option("samplefile", testSampleFile())
+            .option("tiledb.vfs.num_threads", 1)
+            .load();
+    dfRead.createOrReplaceTempView("vcf");
+    List<Row> rows =
+        sparkSession
+            .sql("SELECT sampleName FROM vcf WHERE vcf.sampleName='HG01762'")
+            .collectAsList();
   }
 
   @Test


### PR DESCRIPTION
If a user passes both a sample option (`sampleFile` or `samples`) and then they try to add a predicated filter in a where clause return an error to the user. When both a sample option and a predicate are passed we can't know which (or all) of the samples the user was trying to access. The safest option is to error and force the user to set either a where clause or an option only.