### PR TITLE
Add new function for resetting reader's buffers

### DIFF
--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -42,7 +42,6 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("get_info_attributes", &Reader::get_info_attributes)
       .def("get_queryable_attributes", &Reader::get_queryable_attributes);
 
-
   py::class_<Writer>(m, "Writer")
       .def(py::init())
       .def("init", &Writer::init)

--- a/apis/python/src/tiledbvcf/binding/reader.cc
+++ b/apis/python/src/tiledbvcf/binding/reader.cc
@@ -288,6 +288,9 @@ void Reader::set_buffers() {
 }
 
 void Reader::release_buffers() {
+  auto reader = ptr.get();
+  check_error(reader, tiledb_vcf_reader_reset_buffers(reader));
+
   for (auto& b : buffers_) {
     b.data.release();
     b.offsets.release();
@@ -357,11 +360,13 @@ std::vector<std::string> Reader::get_fmt_attributes() {
   auto reader = ptr.get();
   int32_t count;
   std::vector<std::string> attrs;
-  check_error(reader, tiledb_vcf_reader_get_fmt_attribute_count(reader, &count));
+  check_error(
+      reader, tiledb_vcf_reader_get_fmt_attribute_count(reader, &count));
 
-  for(int32_t i = 0; i < count; i++) {
+  for (int32_t i = 0; i < count; i++) {
     char* name;
-    check_error(reader, tiledb_vcf_reader_get_fmt_attribute_name(reader, i, &name));
+    check_error(
+        reader, tiledb_vcf_reader_get_fmt_attribute_name(reader, i, &name));
     attrs.emplace_back(name);
   }
 
@@ -372,11 +377,13 @@ std::vector<std::string> Reader::get_info_attributes() {
   auto reader = ptr.get();
   int32_t count;
   std::vector<std::string> attrs;
-  check_error(reader, tiledb_vcf_reader_get_info_attribute_count(reader, &count));
+  check_error(
+      reader, tiledb_vcf_reader_get_info_attribute_count(reader, &count));
 
-  for(int32_t i = 0; i < count; i++) {
+  for (int32_t i = 0; i < count; i++) {
     char* name;
-    check_error(reader, tiledb_vcf_reader_get_info_attribute_name(reader, i, &name));
+    check_error(
+        reader, tiledb_vcf_reader_get_info_attribute_name(reader, i, &name));
     attrs.emplace_back(name);
   }
 
@@ -387,11 +394,14 @@ std::vector<std::string> Reader::get_queryable_attributes() {
   auto reader = ptr.get();
   int32_t count;
   std::vector<std::string> attrs;
-  check_error(reader, tiledb_vcf_reader_get_queryable_attribute_count(reader, &count));
+  check_error(
+      reader, tiledb_vcf_reader_get_queryable_attribute_count(reader, &count));
 
-  for(int32_t i = 0; i < count; i++) {
+  for (int32_t i = 0; i < count; i++) {
     char* name;
-    check_error(reader, tiledb_vcf_reader_get_queryable_attribute_name(reader, i, &name));
+    check_error(
+        reader,
+        tiledb_vcf_reader_get_queryable_attribute_name(reader, i, &name));
     attrs.emplace_back(name);
   }
 

--- a/apis/python/tests/test_tiledbvcf.py
+++ b/apis/python/tests/test_tiledbvcf.py
@@ -33,10 +33,13 @@ def test_ds():
     return tiledbvcf.Dataset(
         os.path.join(TESTS_INPUT_DIR, 'arrays/v3/ingested_2samples'))
 
+@pytest.fixture
+def test_ds_attrs():
+    return tiledbvcf.Dataset(
+        os.path.join(TESTS_INPUT_DIR, 'arrays/v3/ingested_2samples_GT_DP_PL'))
 
 def test_basic_count(test_ds):
     assert test_ds.count() == 14
-
 
 def test_read_must_specify_attrs(test_ds):
     with pytest.raises(Exception):
@@ -84,6 +87,19 @@ def test_retrieve_attributes(test_ds):
         "fmt_SB"
     ]
     assert test_ds.attributes(attr_type = "fmt") == fmt_attrs
+
+def test_read_attrs(test_ds_attrs):
+    attrs = ['sample_name']
+    df = test_ds_attrs.read(attrs = attrs)
+    assert df.columns.values.tolist() == attrs
+
+    attrs = ['sample_name', 'fmt_GT']
+    df = test_ds_attrs.read(attrs = attrs)
+    assert df.columns.values.tolist() == attrs
+
+    attrs = ['sample_name']
+    df = test_ds_attrs.read(attrs = attrs)
+    assert df.columns.values.tolist() == attrs
 
 def test_basic_reads(test_ds):
     expected_df = pd.DataFrame(

--- a/libtiledbvcf/src/c_api/tiledbvcf.cc
+++ b/libtiledbvcf/src/c_api/tiledbvcf.cc
@@ -558,6 +558,16 @@ int32_t tiledb_vcf_reader_reset(tiledb_vcf_reader_t* reader) {
   return TILEDB_VCF_OK;
 }
 
+int32_t tiledb_vcf_reader_reset_buffers(tiledb_vcf_reader_t* reader) {
+  if (sanity_check(reader) == TILEDB_VCF_ERR)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(reader, reader->reader_->reset_buffers()))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
 int32_t tiledb_vcf_reader_get_last_error(
     tiledb_vcf_reader_t* reader, tiledb_vcf_error_t** error) {
   if (sanity_check(reader) == TILEDB_VCF_ERR || error == nullptr)

--- a/libtiledbvcf/src/c_api/tiledbvcf.h
+++ b/libtiledbvcf/src/c_api/tiledbvcf.h
@@ -807,6 +807,18 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_dataset_version(
 TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_reset(tiledb_vcf_reader_t* reader);
 
 /**
+ * Resets the reader's buffers This allows the same reader instance to
+ * be used for another read operation, without having to reopen/reinitialize the
+ * dataset. This is used in addition to tiledb_vcf_reader_reset() if the user
+ * wants to change attributes
+ *
+ * @param reader VCF reader object
+ * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
+ */
+TILEDBVCF_EXPORT int32_t
+tiledb_vcf_reader_reset_buffers(tiledb_vcf_reader_t* reader);
+
+/**
  * Gets the last error from the reader object. Don't forget to free the error
  * object.
  *

--- a/libtiledbvcf/src/read/in_memory_exporter.cc
+++ b/libtiledbvcf/src/read/in_memory_exporter.cc
@@ -239,6 +239,11 @@ void InMemoryExporter::reset() {
   reset_current_sizes();
 }
 
+void InMemoryExporter::reset_buffers() {
+  user_buffers_.clear();
+  user_buffers_by_idx_.clear();
+}
+
 void InMemoryExporter::result_size(
     const std::string& attribute,
     int64_t* num_offsets,

--- a/libtiledbvcf/src/read/in_memory_exporter.h
+++ b/libtiledbvcf/src/read/in_memory_exporter.h
@@ -76,6 +76,10 @@ class InMemoryExporter : public Exporter {
   /** Resets any state of the exporter. */
   void reset() override;
 
+  /** Reset user buffers. Used to reuse a reader but for different attributes.
+   */
+  void reset_buffers();
+
   /**
    * Exports a cell by copying to the user's buffers.
    *

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -62,6 +62,11 @@ void Reader::reset() {
     exporter_->reset();
 }
 
+void Reader::reset_buffers() {
+  auto exp = set_in_memory_exporter();
+  exp->reset_buffers();
+}
+
 void Reader::set_all_params(const ExportParams& params) {
   params_ = params;
   init_tiledb();

--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -127,6 +127,10 @@ class Reader {
    */
   void reset();
 
+  /** Reset user buffers. Used to reuse a reader but for different attributes.
+   */
+  void reset_buffers();
+
   /** Convenience function to set all parameters from the given struct. */
   void set_all_params(const ExportParams& params);
 


### PR DESCRIPTION
This is useful when a user is reusing a dataset object from python but wants to change the attributes that are being queried.