### PR TITLE
Multi-stage build for CLI docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 temp
 docker
 dist
+temp
 libtiledbvcf/build
 apis/python/build
 apis/python/.eggs

--- a/docker/Dockerfile-cli
+++ b/docker/Dockerfile-cli
@@ -4,7 +4,7 @@ ENV AWS_EC2_METADATA_DISABLED true
 
 # Install some dependencies
 RUN yum -y install which wget git tar gzip unzip gcc-c++ zlib-devel \
-       openssl-devel bzip2-devel tbb-devel libcurl-devel xz-devel make \
+       openssl-devel bzip2-devel libcurl-devel xz-devel make \
        automake autoconf \
     && yum clean all
 
@@ -29,7 +29,6 @@ FROM amazonlinux:latest
 COPY --from=builder /usr/local/bin/* /usr/local/bin/
 COPY --from=builder /usr/local/include/* /usr/local/include/
 COPY --from=builder /usr/local/lib/* /usr/local/lib/
-COPY --from=builder /usr/lib64/libtbb.so.2 /usr/lib64/libtbb.so.2
 
 WORKDIR /data
 ENTRYPOINT ["/usr/local/bin/tiledbvcf"]

--- a/docker/Dockerfile-cli
+++ b/docker/Dockerfile-cli
@@ -1,4 +1,4 @@
-FROM amazonlinux:latest
+FROM amazonlinux:latest as builder
 
 ENV AWS_EC2_METADATA_DISABLED true
 
@@ -23,7 +23,12 @@ RUN cmake .. -DCMAKE_BUILD_TYPE=Release \
              -DOVERRIDE_INSTALL_PREFIX=OFF \
     && make -j4 \
     && make install-libtiledbvcf
-RUN rm -rf /tmp/libtiledbvcf
+
+FROM amazonlinux:latest
+COPY --from=builder /usr/local/bin/* /usr/local/bin/
+COPY --from=builder /usr/local/include/* /usr/local/include/
+COPY --from=builder /usr/local/lib/* /usr/local/lib/
+COPY --from=builder /usr/lib64/libtbb.so.2 /usr/lib64/libtbb.so.2
 
 WORKDIR /data
 ENTRYPOINT ["/usr/local/bin/tiledbvcf"]

--- a/docker/Dockerfile-cli
+++ b/docker/Dockerfile-cli
@@ -16,6 +16,7 @@ RUN wget https://cmake.org/files/v3.12/cmake-3.12.3-Linux-x86_64.sh \
 # Copy the TileDB-VCF directory and build it.
 WORKDIR /tmp
 COPY libtiledbvcf libtiledbvcf
+COPY .git .git
 
 WORKDIR /tmp/libtiledbvcf/build
 RUN cmake .. -DCMAKE_BUILD_TYPE=Release \

--- a/docker/Dockerfile-cli
+++ b/docker/Dockerfile-cli
@@ -3,23 +3,18 @@ FROM amazonlinux:latest as builder
 ENV AWS_EC2_METADATA_DISABLED true
 
 # Install some dependencies
-RUN yum -y install which wget git tar gzip unzip gcc-c++ zlib-devel \
+RUN yum -y install cmake3 which wget git tar gzip unzip gcc-c++ zlib-devel \
        openssl-devel bzip2-devel libcurl-devel xz-devel make \
        automake autoconf \
     && yum clean all
 
-# Install a newer version of CMake (TileDB requires >= 3.3)
-RUN wget https://cmake.org/files/v3.12/cmake-3.12.3-Linux-x86_64.sh \
-    && sh cmake-3.12.3-Linux-x86_64.sh --skip-license --prefix=/usr/ \
-    && rm cmake-3.12.3-Linux-x86_64.sh
-
-# Copy the TileDB-VCF directory and build it.
 WORKDIR /tmp
 COPY libtiledbvcf libtiledbvcf
+# Needed to properly detect TileDB-VCF version
 COPY .git .git
 
 WORKDIR /tmp/libtiledbvcf/build
-RUN cmake .. -DCMAKE_BUILD_TYPE=Release \
+RUN cmake3 .. -DCMAKE_BUILD_TYPE=Release \
              -DCMAKE_INSTALL_PREFIX=/usr/local \
              -DOVERRIDE_INSTALL_PREFIX=OFF \
     && make -j4 \

--- a/docker/README.md
+++ b/docker/README.md
@@ -69,6 +69,29 @@ docker run --rm -v $PWD:/data tiledb/tiledbvcf-cli export \
   --sample-names v2-WpXCYApL
 ```
 
+To avoid permission issues when creating TileDB-VCF datasets with Docker you need to provide the current user ID and group ID to the container:
+
+```sh
+docker run --rm \
+  -v $PWD:/data \
+  -u "$(id -u):$(id -g)" \
+  tiledb/tiledbvcf-cli \
+  create -u test-array
+```
+
+User and group IDs should also be specified when ingesting data:
+
+```sh
+# create a sample file with S3 URIs for 10 example BCF files
+printf "s3://tiledb-inc-demo-data/examples/notebooks/vcfs/G%i.bcf\n" $(seq 10) > samples.txt
+
+docker run --rm \
+  -v $PWD:/data \
+  -u "$(id -u):$(id -g)" \
+  tiledb/tiledbvcf-cli \
+  store -u test-array -f samples.txt --scratch-mb 10 --verbose
+```
+
 ### Python
 
 You can use the `tiledbvcf-py` container to execute an external script or launch an interactive Python session.


### PR DESCRIPTION
- updates the CLI Dockerfile to utilize multi-stage builds significantly shrinking the size of the final image (860Mb -> 187Mb)
- copies over `.git` so TileDB-VCF's version is now recorded at build time
- adds an example of creating an array with Docker, highlighting the need to specify user/group IDs to avoid permission issues
