### PR TITLE
Don't take reference to query in reader futures

### DIFF
--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -487,7 +487,7 @@ bool Reader::read_current_batch() {
   } else {
     buffers_a->set_buffers(query, dataset_->metadata().version);
     read_state_.async_query =
-        std::async(std::launch::async, [&query]() { return query->submit(); });
+        std::async(std::launch::async, [query]() { return query->submit(); });
   }
 
   do {
@@ -509,8 +509,8 @@ bool Reader::read_current_batch() {
     // current results.
     if (query_status == tiledb::Query::Status::INCOMPLETE) {
       buffers_b->set_buffers(query, dataset_->metadata().version);
-      read_state_.async_query = std::async(
-          std::launch::async, [&query]() { return query->submit(); });
+      read_state_.async_query =
+          std::async(std::launch::async, [query]() { return query->submit(); });
     }
 
     // Process the query results.


### PR DESCRIPTION
There is no need to take a reference as the query object is already stored as a pointer. Taking a reference causes crashes as the pointer to pointer becomes invalid when the function goes out of scope.