### PR TITLE
Always placehold a spot for null values in buffer

### DIFF
--- a/libtiledbvcf/src/enums/attr_datatype.h
+++ b/libtiledbvcf/src/enums/attr_datatype.h
@@ -74,6 +74,22 @@ inline void attr_datatype_enum(
     throw std::runtime_error("Error converting string AttrDatatype to enum.");
 }
 
+/** Returns the byte size of the input attribute datatype. */
+inline uint64_t attr_datatype_size(AttrDatatype attr_datatype) {
+  switch (attr_datatype) {
+    case AttrDatatype::CHAR:
+      return sizeof(char);
+    case AttrDatatype::UINT8:
+      return sizeof(uint8_t);
+    case AttrDatatype::INT32:
+      return sizeof(int32_t);
+    case AttrDatatype::FLOAT32:
+      return sizeof(float);
+    default:
+      throw std::runtime_error("Error converting AttrDatatype to size.");
+  }
+}
+
 inline std::ostream& operator<<(
     std::ostream& os, const AttrDatatype& datatype) {
   os << attr_datatype_str(datatype);

--- a/libtiledbvcf/src/read/in_memory_exporter.cc
+++ b/libtiledbvcf/src/read/in_memory_exporter.cc
@@ -671,11 +671,19 @@ bool InMemoryExporter::copy_cell_data(
     return false;
 
   // Copy data
-  if (data != nullptr)
+  if (data != nullptr) {
     std::memcpy(
         static_cast<char*>(dest->data) + dest->curr_sizes.data_bytes,
         data,
         nbytes);
+  } else if (dest->bitmap_buff != nullptr && !var_len) {
+    // Handle null by setting the bytes and elements to 1
+    // Arrow expects null values to have 1 value which is ignored for fixed
+    // length fields
+    nbytes = attr_datatype_size(
+        get_info_fmt_datatype(this->dataset_, dest->attr_name));
+    nelts = 1;
+  }
 
   // Update offsets
   if (var_len) {


### PR DESCRIPTION
Arrow expects that null values will have a 1 element place still held in the buffer for the index position. Make sure this happens in all cases.

Previously fmt/info fields might not properly set the element or byte count to 1 value. This caused these fields to be shifted in spark by however many nulls were present.