### PR TITLE
Add CLI flag to skip region sorting

### DIFF
--- a/libtiledbvcf/src/cli/tiledbvcf.cc
+++ b/libtiledbvcf/src/cli/tiledbvcf.cc
@@ -378,6 +378,9 @@ int main(int argc, char** argv) {
         (option("-R", "--regions-file") %
              "File containing regions (BED format)" &
          value("path", export_args.regions_file_uri))),
+       option("--sorted")
+           .set(export_args.sort_regions, false) %
+               "Do not sort regions or regions file if they are pre-sorted",
        option("-n", "--limit") %
                "Only export the first N intersecting records." &
            value("N", export_args.max_num_records),

--- a/libtiledbvcf/src/cli/tiledbvcf.cc
+++ b/libtiledbvcf/src/cli/tiledbvcf.cc
@@ -256,7 +256,7 @@ int main(int argc, char** argv) {
            }),
        option("-n", "--no-duplicates")
                .set(create_args.allow_duplicates, false) %
-           "Do not allow records with duplicate end positions to be written to "
+           "Do not allow records with duplicate start positions to be written to "
            "the array.");
 
   RegistrationParams register_args;

--- a/libtiledbvcf/src/cli/tiledbvcf.cc
+++ b/libtiledbvcf/src/cli/tiledbvcf.cc
@@ -256,8 +256,8 @@ int main(int argc, char** argv) {
            }),
        option("-n", "--no-duplicates")
                .set(create_args.allow_duplicates, false) %
-           "Do not allow records with duplicate start positions to be written to "
-           "the array.");
+           "Do not allow records with duplicate start positions to be written "
+           "to the array.");
 
   RegistrationParams register_args;
   auto register_mode =
@@ -378,9 +378,8 @@ int main(int argc, char** argv) {
         (option("-R", "--regions-file") %
              "File containing regions (BED format)" &
          value("path", export_args.regions_file_uri))),
-       option("--sorted")
-           .set(export_args.sort_regions, false) %
-               "Do not sort regions or regions file if they are pre-sorted",
+       option("--sorted").set(export_args.sort_regions, false) %
+           "Do not sort regions or regions file if they are pre-sorted",
        option("-n", "--limit") %
                "Only export the first N intersecting records." &
            value("N", export_args.max_num_records),


### PR DESCRIPTION
I took a page from bedtools and named the flag `--sorted`, indicating the user-provided regions are already sorted. But I'm open to other suggestions.

Also updated the docs for `--no-duplicates` w/ start-based indexing.