### PR TITLE
Update READMEs for 0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Check out our [docs][vcf] for installation and usage instructions:
 
 The docs linked above provide more comprehensive examples but here a few quick exercises to get you started.
 
-By the way, we host a publicly accessible version of the `vcf-samples-20` array on S3. If you have TileDB-VCF installed and you'd like to follow along just swap out the `uri`'s below for `s3://tiledb-inc-demo-data/tiledbvcf-arrays/v2/vcf-samples-20`. And if you *don't* have TileDB-VCF installed yet, you can use our [Docker images](docker/README.md) to test things out.
+By the way, we host a publicly accessible version of the `vcf-samples-20` array on S3. If you have TileDB-VCF installed and you'd like to follow along just swap out the `uri`'s below for `s3://tiledb-inc-demo-data/tiledbvcf-arrays/v3/vcf-samples-20`. And if you *don't* have TileDB-VCF installed yet, you can use our [Docker images](docker/README.md) to test things out.
 
 ### CLI
 
@@ -66,7 +66,7 @@ Running the same query in python
 ```py
 import tiledbvcf
 
-ds = tiledbvcf.TileDBVCFDataset(uri="vcf-samples-20", mode="r")
+ds = tiledbvcf.Dataset(uri="vcf-samples-20", mode="r")
 
 ds.read(
     attrs=["sample_name", "pos_start", "fmt_GT"],

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <a href="https://tiledb.com"><img src="https://github.com/TileDB-Inc/TileDB/raw/dev/doc/source/_static/tiledb-logo_color_no_margin_@4x.png" alt="TileDB logo" width="400"></a>
 
-[![Build Status](https://img.shields.io/azure-devops/build/tiledb-inc/836549eb-f74a-4986-a18f-7fbba6bbb5f0/8?label=Azure%20Pipelines&logo=azure-pipelines&style=flat-square)](https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=8&branchName=master)
+[![Build Status](https://img.shields.io/azure-devops/build/tiledb-inc/836549eb-f74a-4986-a18f-7fbba6bbb5f0/8/master?label=Azure%20Pipelines&logo=azure-pipelines&style=flat-square)](https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=8&branchName=master)
 [![Docker-CLI](https://img.shields.io/static/v1?label=Docker&message=tiledbvcf-cli&color=099cec&logo=docker&style=flat-square)](https://hub.docker.com/repository/docker/tiledb/tiledbvcf-cli)
 [![Docker-Py](https://img.shields.io/static/v1?label=Docker&message=tiledbvcf-py&color=099cec&logo=docker&style=flat-square)](https://hub.docker.com/repository/docker/tiledb/tiledbvcf-py)
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Check out our [docs][vcf] for installation and usage instructions:
 
 The docs linked above provide more comprehensive examples but here a few quick exercises to get you started.
 
-By the way, we host a publicly accessible version of the `vcf-samples-20` array on S3. If you have TileDB-VCF installed and you'd like to follow along just swap out the `uri`'s below for `s3://tiledb-inc-demo-data/tiledb-arrays/2.0/vcf-samples-20`. And if you *don't* have TileDB-VCF installed yet, you can use our [Docker images](docker/README.md) to test things out.
+By the way, we host a publicly accessible version of the `vcf-samples-20` array on S3. If you have TileDB-VCF installed and you'd like to follow along just swap out the `uri`'s below for `s3://tiledb-inc-demo-data/tiledbvcf-arrays/v2/vcf-samples-20`. And if you *don't* have TileDB-VCF installed yet, you can use our [Docker images](docker/README.md) to test things out.
 
 ### CLI
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -56,16 +56,15 @@ List all samples in the dataset:
 
 ```sh
 docker run --rm tiledb/tiledbvcf-cli list \
-  --uri s3://tiledb-inc-demo-data/tiledb-arrays/2.0/vcf-samples-20
+  --uri s3://tiledb-inc-demo-data/tiledbvcf-arrays/v3/vcf-samples-20
 ```
 
-Create a table of all variants within a region of interest for sample `v2-WpXCYApL` and save the results in `./exported-vars.tsv`.
+Create a table of all variants within a region of interest for sample `v2-WpXCYApL`
 
 ```sh
 docker run --rm -v $PWD:/data tiledb/tiledbvcf-cli export \
-  --uri s3://tiledb-inc-demo-data/tiledb-arrays/2.0/vcf-samples-20 \
-  -Ot --tsv-fields "CHR,POS,REF,S:GT" \
-  --output-path exported-vars.tsv \
+  --uri s3://tiledb-inc-demo-data/tiledbvcf-arrays/v3/vcf-samples-20 \
+  -Ot --tsv-fields "CHR,POS,REF,S:GT"
   --regions chr7:144000320-144008793 \
   --sample-names v2-WpXCYApL
 ```
@@ -83,7 +82,7 @@ The following script performs the same query as above but returns a pandas `Data
 ```py
 import tiledbvcf
 
-uri = "s3://tiledb-inc-demo-data/tiledb-arrays/2.0/vcf-samples-20"
+uri = "s3://tiledb-inc-demo-data/tiledbvcf-arrays/v3/vcf-samples-20"
 
 # open the array in 'read' mode
 ds = tiledbvcf.TileDBVCFDataset(uri, mode = "r")

--- a/docker/README.md
+++ b/docker/README.md
@@ -85,7 +85,7 @@ import tiledbvcf
 uri = "s3://tiledb-inc-demo-data/tiledbvcf-arrays/v3/vcf-samples-20"
 
 # open the array in 'read' mode
-ds = tiledbvcf.TileDBVCFDataset(uri, mode = "r")
+ds = tiledbvcf.Dataset(uri, mode = "r")
 
 ds.read(
   attrs=['sample_name', 'pos_start', 'pos_end', 'alleles'],


### PR DESCRIPTION
- update references to `vcf-samples-20` with the new v3 URI
- swap deprecated `TileDBVCFDataset` class for `Dataset` in READMEs
