### PR TITLE
Delay creating contexts for read

### DIFF
--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -69,7 +69,6 @@ void Reader::reset_buffers() {
 
 void Reader::set_all_params(const ExportParams& params) {
   params_ = params;
-  init_tiledb();
 }
 
 void Reader::set_samples(const std::string& samples) {
@@ -155,7 +154,6 @@ InMemoryExporter* Reader::set_in_memory_exporter() {
 
 void Reader::set_memory_budget(unsigned mb) {
   params_.memory_budget_mb = mb;
-  init_tiledb();
 }
 
 void Reader::set_record_limit(uint64_t max_num_records) {
@@ -164,7 +162,11 @@ void Reader::set_record_limit(uint64_t max_num_records) {
 
 void Reader::set_tiledb_config(const std::string& config_str) {
   params_.tiledb_config = utils::split(config_str, ',');
-  init_tiledb();
+  // Attempt to set config to check validity
+  // cfg object will be discarded as a later call to tiledb_init will properly
+  // create config/context
+  tiledb::Config cfg;
+  utils::set_tiledb_config(params_.tiledb_config, &cfg);
 }
 
 ReadStatus Reader::read_status() const {

--- a/libtiledbvcf/test/src/unit-c-api-reader.cc
+++ b/libtiledbvcf/test/src/unit-c-api-reader.cc
@@ -241,6 +241,25 @@ TEST_CASE("C API: Reader set config", "[capi][query]") {
         tiledb_vcf_reader_set_tiledb_config(reader, config2) == TILEDB_VCF_ERR);
   }
 
+  SECTION("- TBB options") {
+    const char* config = "sm.num_tbb_threads=4";
+    REQUIRE(
+        tiledb_vcf_reader_set_tiledb_config(reader, config) == TILEDB_VCF_OK);
+  }
+
+  tiledb_vcf_reader_free(&reader);
+}
+
+TEST_CASE("C API: Reader set tbb and memory", "[capi][query]") {
+  tiledb_vcf_reader_t* reader = nullptr;
+  REQUIRE(tiledb_vcf_reader_alloc(&reader) == TILEDB_VCF_OK);
+
+  // Setting the memory budget first should not cause any error
+  REQUIRE(tiledb_vcf_reader_set_memory_budget(reader, 100) == TILEDB_VCF_OK);
+
+  const char* config = "sm.num_tbb_threads=4";
+  REQUIRE(tiledb_vcf_reader_set_tiledb_config(reader, config) == TILEDB_VCF_OK);
+
   tiledb_vcf_reader_free(&reader);
 }
 


### PR DESCRIPTION
There is no need to call `init_tiledb()` and recreate the context for all possibly parameter change functions. These calls will be done before the dataset is opened and a reader returned. Avoiding these calls avoids a problem of initializing TBB twice with different thread counts.

`init_tiledb()` is left for the bed_file and sample_file setters as those need VFS enabled to validate the files exist. These functions should only be called after the dataset is opened and a reader object is returned, so the code paths should never hit in normal api usage.