### PR TITLE
Change `ranges` to `regions` in the Spark API

### DIFF
--- a/apis/spark/src/main/java/io/tiledb/vcf/VCFDataSourceOptions.java
+++ b/apis/spark/src/main/java/io/tiledb/vcf/VCFDataSourceOptions.java
@@ -44,7 +44,9 @@ public class VCFDataSourceOptions implements Serializable {
 
   /** @return Optional array of contig regions to read */
   public Optional<String[]> getRanges() {
-    if (options.containsKey("ranges")) {
+    if (options.containsKey("regions")) {
+      return Optional.of(options.get("regions").split("\\s*,[,\\s]*"));
+    } else if (options.containsKey("ranges")) {
       return Optional.of(options.get("ranges").split("\\s*,[,\\s]*"));
     }
     return Optional.empty();

--- a/apis/spark/src/test/java/io/tiledb/vcf/VCFDataSourceOptionsTest.java
+++ b/apis/spark/src/test/java/io/tiledb/vcf/VCFDataSourceOptionsTest.java
@@ -59,6 +59,16 @@ public class VCFDataSourceOptionsTest {
   }
 
   @Test
+  public void testRegionsOption() {
+    HashMap<String, String> optionMap = new HashMap<>();
+    optionMap.put("regions", "CHR1:1-100, CHR2:2-200");
+    VCFDataSourceOptions options = new VCFDataSourceOptions(new DataSourceOptions(optionMap));
+    Optional<String[]> ranges = options.getRanges();
+    Assert.assertTrue(ranges.isPresent());
+    Assert.assertArrayEquals(new String[] {"CHR1:1-100", "CHR2:2-200"}, ranges.get());
+  }
+
+  @Test
   public void testMemoryBudgetOptionMissing() {
     VCFDataSourceOptions options = new VCFDataSourceOptions(new DataSourceOptions(new HashMap<>()));
     Assert.assertFalse(options.getMemoryBudget().isPresent());


### PR DESCRIPTION
Previously spark used "ranges" as the option for specifying regions. This was inconsistent with other apis. Now spark accepts both ranges and regions to be inline with other APIs and not break backwards compatibility.