### PR TITLE
Fix buffer memory leak

### DIFF
--- a/apis/python/src/tiledbvcf/binding/reader.cc
+++ b/apis/python/src/tiledbvcf/binding/reader.cc
@@ -291,13 +291,6 @@ void Reader::release_buffers() {
   auto reader = ptr.get();
   check_error(reader, tiledb_vcf_reader_reset_buffers(reader));
 
-  for (auto& b : buffers_) {
-    b.data.release();
-    b.offsets.release();
-    b.list_offsets.release();
-    b.bitmap.release();
-  }
-
   buffers_.clear();
 }
 


### PR DESCRIPTION
Calling `.release()` un-tracks the buffer from the python perspective. Calling `clear` on the
buffer vector will release the python refcount correctly.

[ch3031]