### PR TITLE
Use the default HTSLIB read capacity size

### DIFF
--- a/libtiledbvcf/src/htslib_plugin/hfile_tiledb_vfs.c
+++ b/libtiledbvcf/src/htslib_plugin/hfile_tiledb_vfs.c
@@ -161,7 +161,7 @@ hFILE* hopen_tiledb_vfs(const char* uri, const char* modestr) {
 
   // Initialize hFILE_tiledb_vfs
   hFILE_tiledb_vfs* fp =
-      (hFILE_tiledb_vfs*)hfile_init(sizeof(hFILE_tiledb_vfs), modestr, 1024);
+      (hFILE_tiledb_vfs*)hfile_init(sizeof(hFILE_tiledb_vfs), modestr, 0);
   if (fp == NULL) {
     printf("error in fp == NULL");
     return NULL;


### PR DESCRIPTION
Use the default HTSLIB read capacity size. We always should have been signalling to htslib to use the default 32kb capacity.