### PR TITLE
V3 Arrays should move regions based on start_pos

### DIFF
--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -776,12 +776,11 @@ std::pair<size_t, size_t> Reader::get_intersecting_regions_v3(
   if (last == nil)
     return {nil, nil};
 
-  // Set the new region index to the last intersecting region index.
-  *new_region_idx = last;
+  size_t original_last = last;
 
-  // Next find the index of the last region that intersects the cell's REAL_END
-  // position. This is used as the actual interval of intersection.
-  for (size_t i = *new_region_idx; i < regions.size(); i++) {
+  // Next find the index of the last region that intersects the cell's
+  // REAL_START position. This is used as the actual interval of intersection.
+  for (size_t i = original_last; i < regions.size(); i++) {
     bool intersects = intersects_p(regions[i], real_start, end);
     if (i < regions.size() - 1) {
       bool next_intersects = intersects_p(regions[i + 1], real_start, end);
@@ -797,7 +796,7 @@ std::pair<size_t, size_t> Reader::get_intersecting_regions_v3(
 
   // Search backwards to find the first region that intersects the cell.
   size_t first = nil;
-  for (size_t i = *new_region_idx;; i--) {
+  for (size_t i = original_last;; i--) {
     bool intersects = intersects_p(regions[i], real_start, end);
     if (i > 0) {
       bool prev_intersects = intersects_p(regions[i - 1], real_start, end);
@@ -813,6 +812,11 @@ std::pair<size_t, size_t> Reader::get_intersecting_regions_v3(
     if (i == 0)
       break;
   }
+
+  // Set the new region index to the first intersecting region index.
+  // Since we sort on start position, we must wait for the start to cross to a
+  // new region to move
+  *new_region_idx = first;
 
   // If we're here then we must have a valid interval.
   if (first == nil || last == nil)

--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -511,7 +511,7 @@ class Reader {
 
   /**
    * Finds the interval of indexes in the sorted regions vector that intersect
-   * a record with the given start/end/real_end coordinates.
+   * a record with the given start/end/real_start coordinates.
    *
    * This performs a linear search starting at the given index to find the first
    * intersecting index, and then iterates forward to find the last index.


### PR DESCRIPTION
In v3 arrays the sort on the start instead of end means that we can't use the end position crossing to a new region to bump the minimum region checked for intersection. We need to instead wait for the start position to move to a new minimum region before shifting.

Limiting the regions we check for intersections is an optimization to limit the search domain as we move through the results of the query.