### PR TITLE
New C/Python APIs for retrieving dataset schema version and sample names

### DIFF
--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -38,7 +38,7 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("result_num_records", &Reader::result_num_records)
       .def("get_tiledb_stats_enabled", &Reader::get_tiledb_stats_enabled)
       .def("get_tiledb_stats", &Reader::get_tiledb_stats)
-      .def("get_dataset_version", &Reader::get_dataset_version)
+      .def("get_schema_version", &Reader::get_schema_version)
       .def("get_fmt_attributes", &Reader::get_fmt_attributes)
       .def("get_info_attributes", &Reader::get_info_attributes)
       .def("get_queryable_attributes", &Reader::get_queryable_attributes)

--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -38,6 +38,7 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("result_num_records", &Reader::result_num_records)
       .def("get_tiledb_stats_enabled", &Reader::get_tiledb_stats_enabled)
       .def("get_tiledb_stats", &Reader::get_tiledb_stats)
+      .def("get_dataset_version", &Reader::get_dataset_version)
       .def("get_fmt_attributes", &Reader::get_fmt_attributes)
       .def("get_info_attributes", &Reader::get_info_attributes)
       .def("get_queryable_attributes", &Reader::get_queryable_attributes);

--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -41,7 +41,8 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("get_dataset_version", &Reader::get_dataset_version)
       .def("get_fmt_attributes", &Reader::get_fmt_attributes)
       .def("get_info_attributes", &Reader::get_info_attributes)
-      .def("get_queryable_attributes", &Reader::get_queryable_attributes);
+      .def("get_queryable_attributes", &Reader::get_queryable_attributes)
+      .def("get_sample_count", &Reader::get_sample_count);
 
   py::class_<Writer>(m, "Writer")
       .def(py::init())

--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -42,7 +42,8 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("get_fmt_attributes", &Reader::get_fmt_attributes)
       .def("get_info_attributes", &Reader::get_info_attributes)
       .def("get_queryable_attributes", &Reader::get_queryable_attributes)
-      .def("get_sample_count", &Reader::get_sample_count);
+      .def("get_sample_count", &Reader::get_sample_count)
+      .def("get_sample_names", &Reader::get_sample_names);
 
   py::class_<Writer>(m, "Writer")
       .def(py::init())

--- a/apis/python/src/tiledbvcf/binding/reader.cc
+++ b/apis/python/src/tiledbvcf/binding/reader.cc
@@ -356,6 +356,13 @@ int32_t Reader::get_dataset_version() {
   return version;
 }
 
+int32_t Reader::get_sample_count() {
+  auto reader = ptr.get();
+  int32_t count;
+  check_error(reader, tiledb_vcf_reader_get_sample_count(reader, &count));
+  return count;
+}
+
 std::vector<std::string> Reader::get_fmt_attributes() {
   auto reader = ptr.get();
   int32_t count;

--- a/apis/python/src/tiledbvcf/binding/reader.cc
+++ b/apis/python/src/tiledbvcf/binding/reader.cc
@@ -349,7 +349,7 @@ std::string Reader::get_tiledb_stats() {
   return std::string(stats);
 }
 
-int32_t Reader::get_dataset_version() {
+int32_t Reader::get_schema_version() {
   auto reader = ptr.get();
   int32_t version;
   check_error(reader, tiledb_vcf_reader_get_dataset_version(reader, &version));

--- a/apis/python/src/tiledbvcf/binding/reader.cc
+++ b/apis/python/src/tiledbvcf/binding/reader.cc
@@ -356,30 +356,6 @@ int32_t Reader::get_dataset_version() {
   return version;
 }
 
-int32_t Reader::get_sample_count() {
-  auto reader = ptr.get();
-  int32_t count;
-  check_error(reader, tiledb_vcf_reader_get_sample_count(reader, &count));
-  return count;
-}
-
-std::vector<std::string> Reader::get_sample_names() {
-  auto reader = ptr.get();
-  int32_t count;
-  std::vector<std::string> names;
-  check_error(
-      reader, tiledb_vcf_reader_get_sample_count(reader, &count));
-
-  for (int32_t i = 0; i < count; i++) {
-    char* name;
-    check_error(
-        reader, tiledb_vcf_reader_get_sample_name(reader, i, &name));
-    names.emplace_back(name);
-  }
-
-  return names;
-}
-
 std::vector<std::string> Reader::get_fmt_attributes() {
   auto reader = ptr.get();
   int32_t count;
@@ -430,6 +406,28 @@ std::vector<std::string> Reader::get_queryable_attributes() {
   }
 
   return attrs;
+}
+
+int32_t Reader::get_sample_count() {
+  auto reader = ptr.get();
+  int32_t count;
+  check_error(reader, tiledb_vcf_reader_get_sample_count(reader, &count));
+  return count;
+}
+
+std::vector<std::string> Reader::get_sample_names() {
+  auto reader = ptr.get();
+  int32_t count;
+  std::vector<std::string> names;
+  check_error(reader, tiledb_vcf_reader_get_sample_count(reader, &count));
+
+  for (int32_t i = 0; i < count; i++) {
+    char* name;
+    check_error(reader, tiledb_vcf_reader_get_sample_name(reader, i, &name));
+    names.emplace_back(name);
+  }
+
+  return names;
 }
 
 py::dtype Reader::to_numpy_dtype(tiledb_vcf_attr_datatype_t datatype) {

--- a/apis/python/src/tiledbvcf/binding/reader.cc
+++ b/apis/python/src/tiledbvcf/binding/reader.cc
@@ -349,6 +349,13 @@ std::string Reader::get_tiledb_stats() {
   return std::string(stats);
 }
 
+int32_t Reader::get_dataset_version() {
+  auto reader = ptr.get();
+  int32_t version;
+  check_error(reader, tiledb_vcf_reader_get_dataset_version(reader, &version));
+  return version;
+}
+
 std::vector<std::string> Reader::get_fmt_attributes() {
   auto reader = ptr.get();
   int32_t count;

--- a/apis/python/src/tiledbvcf/binding/reader.cc
+++ b/apis/python/src/tiledbvcf/binding/reader.cc
@@ -363,6 +363,23 @@ int32_t Reader::get_sample_count() {
   return count;
 }
 
+std::vector<std::string> Reader::get_sample_names() {
+  auto reader = ptr.get();
+  int32_t count;
+  std::vector<std::string> names;
+  check_error(
+      reader, tiledb_vcf_reader_get_sample_count(reader, &count));
+
+  for (int32_t i = 0; i < count; i++) {
+    char* name;
+    check_error(
+        reader, tiledb_vcf_reader_get_sample_name(reader, i, &name));
+    names.emplace_back(name);
+  }
+
+  return names;
+}
+
 std::vector<std::string> Reader::get_fmt_attributes() {
   auto reader = ptr.get();
   int32_t count;

--- a/apis/python/src/tiledbvcf/binding/reader.cc
+++ b/apis/python/src/tiledbvcf/binding/reader.cc
@@ -422,7 +422,7 @@ std::vector<std::string> Reader::get_sample_names() {
   check_error(reader, tiledb_vcf_reader_get_sample_count(reader, &count));
 
   for (int32_t i = 0; i < count; i++) {
-    char* name;
+    const char* name;
     check_error(reader, tiledb_vcf_reader_get_sample_name(reader, i, &name));
     names.emplace_back(name);
   }

--- a/apis/python/src/tiledbvcf/binding/reader.cc
+++ b/apis/python/src/tiledbvcf/binding/reader.cc
@@ -421,6 +421,7 @@ std::vector<std::string> Reader::get_sample_names() {
   std::vector<std::string> names;
   check_error(reader, tiledb_vcf_reader_get_sample_count(reader, &count));
 
+  names.reserve(count);
   for (int32_t i = 0; i < count; i++) {
     const char* name;
     check_error(reader, tiledb_vcf_reader_get_sample_name(reader, i, &name));

--- a/apis/python/src/tiledbvcf/binding/reader.h
+++ b/apis/python/src/tiledbvcf/binding/reader.h
@@ -115,8 +115,8 @@ class Reader {
   /** Fetches TileDB statistics */
   std::string get_tiledb_stats();
 
-  /** Returns version number of the TileDB VCF dataset */
-  int32_t get_dataset_version();
+  /** Returns schema version number of the TileDB VCF dataset */
+  int32_t get_schema_version();
 
   /** Returns fmt attribute names */
   std::vector<std::string> get_fmt_attributes();

--- a/apis/python/src/tiledbvcf/binding/reader.h
+++ b/apis/python/src/tiledbvcf/binding/reader.h
@@ -118,12 +118,6 @@ class Reader {
   /** Returns version number of the TileDB VCF dataset */
   int32_t get_dataset_version();
 
-  /** Returns number of samples in the dataset */
-  int32_t get_sample_count();
-
-  /** Retrieve list of samples from dataset metadata */
-  std::vector<std::string> get_sample_names();
-
   /** Returns fmt attribute names */
   std::vector<std::string> get_fmt_attributes();
 
@@ -132,6 +126,12 @@ class Reader {
 
   /** Returns all queryable attribute names */
   std::vector<std::string> get_queryable_attributes();
+
+  /** Returns number of registered samples in the dataset */
+  int32_t get_sample_count();
+
+  /** Retrieve list of registered samples names */
+  std::vector<std::string> get_sample_names();
 
   /**
    * Set reader verbose output mode

--- a/apis/python/src/tiledbvcf/binding/reader.h
+++ b/apis/python/src/tiledbvcf/binding/reader.h
@@ -115,6 +115,9 @@ class Reader {
   /** Fetches TileDB statistics */
   std::string get_tiledb_stats();
 
+  /** Returns version number of the TileDB VCF dataset */
+  int32_t get_dataset_version();
+
   /** Returns fmt attribute names */
   std::vector<std::string> get_fmt_attributes();
 

--- a/apis/python/src/tiledbvcf/binding/reader.h
+++ b/apis/python/src/tiledbvcf/binding/reader.h
@@ -118,8 +118,11 @@ class Reader {
   /** Returns version number of the TileDB VCF dataset */
   int32_t get_dataset_version();
 
-  /** Retrieve list of samples from dataset */
+  /** Returns number of samples in the dataset */
   int32_t get_sample_count();
+
+  /** Retrieve list of samples from dataset metadata */
+  std::vector<std::string> get_sample_names();
 
   /** Returns fmt attribute names */
   std::vector<std::string> get_fmt_attributes();

--- a/apis/python/src/tiledbvcf/binding/reader.h
+++ b/apis/python/src/tiledbvcf/binding/reader.h
@@ -118,6 +118,9 @@ class Reader {
   /** Returns version number of the TileDB VCF dataset */
   int32_t get_dataset_version();
 
+  /** Retrieve list of samples from dataset */
+  int32_t get_sample_count();
+
   /** Returns fmt attribute names */
   std::vector<std::string> get_fmt_attributes();
 

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -223,6 +223,11 @@ class Dataset(object):
 
         return self.reader.get_tiledb_stats();
 
+    def dataset_version(self):
+        if self.mode != 'r':
+            raise Exception('Dataset version can only be called for reader')
+        return self.reader.get_dataset_version()
+
     def attributes(self, attr_type = "all"):
         """List queryable attributes available in the VCF dataset
 

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -233,6 +233,11 @@ class Dataset(object):
             raise Exception('Samples can only be retrieved for reader')
         return self.reader.get_sample_count()
 
+    def samples(self):
+        if self.mode != 'r':
+            raise Exception('Samples can only be retrieved for reader')
+        return self.reader.get_sample_names()
+
     def attributes(self, attr_type = "all"):
         """List queryable attributes available in the VCF dataset
 

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -223,10 +223,12 @@ class Dataset(object):
 
         return self.reader.get_tiledb_stats();
 
-    def dataset_version(self):
+    def schema_version(self):
+        """Retrieve the VCF dataset's schema version
+        """
         if self.mode != 'r':
-            raise Exception('Dataset version can only be called for reader')
-        return self.reader.get_dataset_version()
+            raise Exception('Schema version can only be called for reader')
+        return self.reader.get_schema_version()
 
     def sample_count(self):
         if self.mode != 'r':

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -228,6 +228,11 @@ class Dataset(object):
             raise Exception('Dataset version can only be called for reader')
         return self.reader.get_dataset_version()
 
+    def sample_count(self):
+        if self.mode != 'r':
+            raise Exception('Samples can only be retrieved for reader')
+        return self.reader.get_sample_count()
+
     def attributes(self, attr_type = "all"):
         """List queryable attributes available in the VCF dataset
 

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -234,9 +234,12 @@ class Dataset(object):
         return self.reader.get_sample_count()
 
     def samples(self):
+        """Retrieve list of sample names registered in the VCF dataset
+        """
         if self.mode != 'r':
-            raise Exception('Samples can only be retrieved for reader')
+            raise Exception('Sample names can only be retrieved for reader')
         return self.reader.get_sample_names()
+
 
     def attributes(self, attr_type = "all"):
         """List queryable attributes available in the VCF dataset

--- a/apis/python/tests/test_tiledbvcf.py
+++ b/apis/python/tests/test_tiledbvcf.py
@@ -88,6 +88,9 @@ def test_retrieve_attributes(test_ds):
     ]
     assert test_ds.attributes(attr_type = "fmt") == fmt_attrs
 
+def test_retrieve_samples(test_ds):
+    assert test_ds.samples() == ['HG00280', 'HG01762']
+
 def test_read_attrs(test_ds_attrs):
     attrs = ['sample_name']
     df = test_ds_attrs.read(attrs = attrs)

--- a/libtiledbvcf/src/c_api/tiledbvcf.cc
+++ b/libtiledbvcf/src/c_api/tiledbvcf.cc
@@ -667,6 +667,18 @@ int32_t tiledb_vcf_reader_get_sample_count(
   return TILEDB_VCF_OK;
 }
 
+int32_t tiledb_vcf_reader_get_sample_name(
+    tiledb_vcf_reader_t* reader, int32_t index, char** name) {
+  if (sanity_check(reader) == TILEDB_VCF_ERR || name == nullptr)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          reader, reader->reader_->sample_name(index, name)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
 
 int32_t tiledb_vcf_reader_set_verbose(
     tiledb_vcf_reader_t* reader, const bool verbose) {

--- a/libtiledbvcf/src/c_api/tiledbvcf.cc
+++ b/libtiledbvcf/src/c_api/tiledbvcf.cc
@@ -656,6 +656,18 @@ int32_t tiledb_vcf_reader_get_info_attribute_name(
   return TILEDB_VCF_OK;
 }
 
+int32_t tiledb_vcf_reader_get_sample_count(
+    tiledb_vcf_reader_t* reader, int32_t* count) {
+  if (sanity_check(reader) == TILEDB_VCF_ERR || count == nullptr)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(reader, reader->reader_->sample_count(count)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
+
 int32_t tiledb_vcf_reader_set_verbose(
     tiledb_vcf_reader_t* reader, const bool verbose) {
   if (sanity_check(reader) == TILEDB_VCF_ERR)

--- a/libtiledbvcf/src/c_api/tiledbvcf.cc
+++ b/libtiledbvcf/src/c_api/tiledbvcf.cc
@@ -668,7 +668,7 @@ int32_t tiledb_vcf_reader_get_sample_count(
 }
 
 int32_t tiledb_vcf_reader_get_sample_name(
-    tiledb_vcf_reader_t* reader, int32_t index, char** name) {
+    tiledb_vcf_reader_t* reader, int32_t index, const char** name) {
   if (sanity_check(reader) == TILEDB_VCF_ERR || name == nullptr)
     return TILEDB_VCF_ERR;
 

--- a/libtiledbvcf/src/c_api/tiledbvcf.cc
+++ b/libtiledbvcf/src/c_api/tiledbvcf.cc
@@ -672,13 +672,11 @@ int32_t tiledb_vcf_reader_get_sample_name(
   if (sanity_check(reader) == TILEDB_VCF_ERR || name == nullptr)
     return TILEDB_VCF_ERR;
 
-  if (SAVE_ERROR_CATCH(
-          reader, reader->reader_->sample_name(index, name)))
+  if (SAVE_ERROR_CATCH(reader, reader->reader_->sample_name(index, name)))
     return TILEDB_VCF_ERR;
 
   return TILEDB_VCF_OK;
 }
-
 
 int32_t tiledb_vcf_reader_set_verbose(
     tiledb_vcf_reader_t* reader, const bool verbose) {

--- a/libtiledbvcf/src/c_api/tiledbvcf.h
+++ b/libtiledbvcf/src/c_api/tiledbvcf.h
@@ -784,6 +784,9 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_info_attribute_name(
 TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_sample_count(
     tiledb_vcf_reader_t* reader, int32_t* count);
 
+TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_sample_name(
+    tiledb_vcf_reader_t* reader, int32_t index, char** name);
+
 /**
  * Sets verbose mode on or off
  * @param reader VCF reader object

--- a/libtiledbvcf/src/c_api/tiledbvcf.h
+++ b/libtiledbvcf/src/c_api/tiledbvcf.h
@@ -781,9 +781,22 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_info_attribute_count(
 TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_info_attribute_name(
     tiledb_vcf_reader_t* reader, int32_t index, char** name);
 
-TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_sample_count(
-    tiledb_vcf_reader_t* reader, int32_t* count);
+/**
+ * Get the number of registered samples
+ * @param reader VCF reader object
+ * @param count number of samples registered in the dataset
+ * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.*
+ */
+TILEDBVCF_EXPORT int32_t
+tiledb_vcf_reader_get_sample_count(tiledb_vcf_reader_t* reader, int32_t* count);
 
+/**
+ * Retrieve sample name for a given index
+ * @param reader VCF reader object
+ * @param index the sample name to retrieve
+ * @param name char* sample name
+ * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.*
+ */
 TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_sample_name(
     tiledb_vcf_reader_t* reader, int32_t index, char** name);
 

--- a/libtiledbvcf/src/c_api/tiledbvcf.h
+++ b/libtiledbvcf/src/c_api/tiledbvcf.h
@@ -798,7 +798,7 @@ tiledb_vcf_reader_get_sample_count(tiledb_vcf_reader_t* reader, int32_t* count);
  * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.*
  */
 TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_sample_name(
-    tiledb_vcf_reader_t* reader, int32_t index, char** name);
+    tiledb_vcf_reader_t* reader, int32_t index, const char** name);
 
 /**
  * Sets verbose mode on or off

--- a/libtiledbvcf/src/c_api/tiledbvcf.h
+++ b/libtiledbvcf/src/c_api/tiledbvcf.h
@@ -575,6 +575,9 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_tiledb_stats_enabled(
 TILEDBVCF_EXPORT int32_t
 tiledb_vcf_reader_get_tiledb_stats(tiledb_vcf_reader_t* reader, char** stats);
 
+TILEDBVCF_EXPORT int32_t
+tiledb_vcf_reader_get_samples(tiledb_vcf_reader_t* reader, const char* samples);
+
 /**
  * Performs a blocking read operation. This reads data from the dataset into the
  * buffers that have been set on the reader.
@@ -777,6 +780,9 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_info_attribute_count(
  */
 TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_info_attribute_name(
     tiledb_vcf_reader_t* reader, int32_t index, char** name);
+
+TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_sample_count(
+    tiledb_vcf_reader_t* reader, int32_t* count);
 
 /**
  * Sets verbose mode on or off

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -302,7 +302,7 @@ void TileDBVCFDataset::open(
 
   open_ = true;
 
-  // Build queryable attribute list
+  // Build queryable attribute and sample lists
   std::set<std::string> unique_queryable_attributes{
       "sample_name", "query_bed_start", "query_bed_end", "contig"};
   for (auto s : this->all_attributes()) {
@@ -328,6 +328,12 @@ void TileDBVCFDataset::open(
     std::vector<char> name(key.begin(), key.end());
     name.emplace_back('\0');
     vcf_attributes_.push_back(name);
+  }
+
+  for (const auto& s : metadata_.sample_names) {
+    std::vector<char> sample(s.begin(), s.end());
+    sample.emplace_back('\0');
+    sample_names_.push_back(sample);
   }
 }
 
@@ -960,6 +966,10 @@ int32_t TileDBVCFDataset::queryable_attribute_count() const {
 const char* TileDBVCFDataset::queryable_attribute_name(
     const int32_t index) const {
   return this->vcf_attributes_[index].data();
+}
+
+const char* TileDBVCFDataset::sample_name(const int32_t index) const {
+  return this->sample_names_[index].data();
 }
 
 std::string TileDBVCFDataset::data_array_uri(

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -266,6 +266,13 @@ class TileDBVCFDataset {
    */
   const char* queryable_attribute_name(int32_t index) const;
 
+  /**
+   * Get sample name by index
+   * @param index
+   * @return
+   */
+  const char* sample_name(int32_t index) const;
+
  private:
   /* ********************************* */
   /*          PRIVATE ATTRIBUTES       */
@@ -288,6 +295,9 @@ class TileDBVCFDataset {
 
   /** List of all attributes of vcf for querying */
   std::vector<std::vector<char>> vcf_attributes_;
+
+  /** List of sample names for exporting */
+  std::vector<std::vector<char>> sample_names_;
 
   /* ********************************* */
   /*          STATIC METHODS           */

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -756,7 +756,7 @@ std::pair<size_t, size_t> Reader::get_intersecting_regions_v3(
   size_t last = nil;
   for (size_t i = region_idx; i < regions.size(); i++) {
     // Regions are sorted on END, so stop searching early if possible.
-    if (end < regions[i].seq_offset + regions[i].min)
+     if (end < regions[i].seq_offset + regions[i].min)
       break;
 
     bool intersects = intersects_p(regions[i], start, end);
@@ -779,7 +779,7 @@ std::pair<size_t, size_t> Reader::get_intersecting_regions_v3(
   size_t original_last = last;
 
   // Next find the index of the last region that intersects the cell's
-  // REAL_START position. This is used as the actual interval of intersection.
+  // REAL_START position. This is used as the actual interval of intersection
   for (size_t i = original_last; i < regions.size(); i++) {
     bool intersects = intersects_p(regions[i], real_start, end);
     if (i < regions.size() - 1) {

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -1427,6 +1427,13 @@ void Reader::info_attribute_count(int32_t* count) {
   *count = this->dataset_->info_field_types().size();
 }
 
+void Reader::sample_count(int32_t* count) {
+  if (count == nullptr)
+    throw std::runtime_error(
+        "Error getting sample count; dataset is not open.");
+  *count = dataset_->metadata().sample_names.size();
+}
+
 void Reader::info_attribute_name(int32_t index, char** name) {
   auto info_attributes = this->dataset_->info_field_types();
   auto iter = info_attributes.begin();

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -1432,8 +1432,8 @@ void Reader::sample_count(int32_t* count) {
   *count = dataset_->metadata().sample_names.size();
 }
 
-void Reader::sample_name(int32_t index, char** name) {
-  *name = const_cast<char*>(dataset_->metadata().sample_names[index].c_str());
+void Reader::sample_name(int32_t index, const char** name) {
+  *name = dataset_->metadata().sample_names[index].c_str();
 }
 
 void Reader::info_attribute_name(int32_t index, char** name) {

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -193,8 +193,7 @@ void Reader::tiledb_stats(char** stats) {
 
 void Reader::dataset_version(int32_t* version) const {
   if (dataset_ == nullptr)
-    throw std::runtime_error(
-        "Error getting dataset version; dataset is not open.");
+    throw std::runtime_error("Error getting dataset version");
   *version = dataset_->metadata().version;
 }
 
@@ -779,7 +778,7 @@ std::pair<size_t, size_t> Reader::get_intersecting_regions_v3(
   size_t original_last = last;
 
   // Next find the index of the last region that intersects the cell's
-  // REAL_START position. This is used as the actual interval of intersection
+  // REAL_START position. This is used as the actual interval of intersection.
   for (size_t i = original_last; i < regions.size(); i++) {
     bool intersects = intersects_p(regions[i], real_start, end);
     if (i < regions.size() - 1) {
@@ -1429,8 +1428,7 @@ void Reader::info_attribute_count(int32_t* count) {
 
 void Reader::sample_count(int32_t* count) {
   if (count == nullptr)
-    throw std::runtime_error(
-        "Error getting sample count; dataset is not open.");
+    throw std::runtime_error("Error getting sample count");
   *count = dataset_->metadata().sample_names.size();
 }
 

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -1433,7 +1433,7 @@ void Reader::sample_count(int32_t* count) {
 }
 
 void Reader::sample_name(int32_t index, const char** name) {
-  *name = dataset_->metadata().sample_names[index].c_str();
+  *name = dataset_->sample_name(index);
 }
 
 void Reader::info_attribute_name(int32_t index, char** name) {

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -756,7 +756,7 @@ std::pair<size_t, size_t> Reader::get_intersecting_regions_v3(
   size_t last = nil;
   for (size_t i = region_idx; i < regions.size(); i++) {
     // Regions are sorted on END, so stop searching early if possible.
-     if (end < regions[i].seq_offset + regions[i].min)
+    if (end < regions[i].seq_offset + regions[i].min)
       break;
 
     bool intersects = intersects_p(regions[i], start, end);

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -1434,6 +1434,10 @@ void Reader::sample_count(int32_t* count) {
   *count = dataset_->metadata().sample_names.size();
 }
 
+void Reader::sample_name(int32_t index, char** name) {
+  *name = const_cast<char*>(dataset_->metadata().sample_names[index].c_str());
+}
+
 void Reader::info_attribute_name(int32_t index, char** name) {
   auto info_attributes = this->dataset_->info_field_types();
   auto iter = info_attributes.begin();

--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -308,6 +308,8 @@ class Reader {
 
   void sample_count(int32_t* count);
 
+  void sample_name(int32_t index, char** name);
+
   /**
    * Sets verbose mode on or off
    * @param verbose setting

--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -215,6 +215,9 @@ class Reader {
   /** Gets the version number of the open dataset. */
   void dataset_version(int32_t* version) const;
 
+  /** Retrieve list of sample names. */
+  void get_samples(std::string* samples) const;
+
   /** Returns the size of the result last exported for the given attribute. */
   void result_size(
       const std::string& attribute,
@@ -302,6 +305,8 @@ class Reader {
    * @param name of attribute
    */
   void info_attribute_name(int32_t index, char** name);
+
+  void sample_count(int32_t* count);
 
   /**
    * Sets verbose mode on or off

--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -306,8 +306,17 @@ class Reader {
    */
   void info_attribute_name(int32_t index, char** name);
 
+  /**
+   * Get the number of registered samples
+   * @param sample count
+   */
   void sample_count(int32_t* count);
 
+  /**
+   * Retrieve sample name by index
+   * @param index of sample
+   * @param name of sample
+   */
   void sample_name(int32_t index, char** name);
 
   /**

--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -317,7 +317,7 @@ class Reader {
    * @param index of sample
    * @param name of sample
    */
-  void sample_name(int32_t index, char** name);
+  void sample_name(int32_t index, const char** name);
 
   /**
    * Sets verbose mode on or off


### PR DESCRIPTION
Adds the following python methods (as well as the requisite C APIs):
- `dataset.samples()`
- `dataset.schema_version()`

Retrieving the dataset's schema version may not be all that useful on its own but I plan on using it in a higher-level `describe()` function.