### PR TITLE
Define minimum version of htslib from conda in python dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .vscode*
+temp
 docker
 dist
 libtiledbvcf/build

--- a/docker/Dockerfile-py
+++ b/docker/Dockerfile-py
@@ -15,8 +15,8 @@ RUN apt-get update \
 # Copy the TileDB-VCF Python directory and build it.
 COPY apis/python/conda-env.yml .
 RUN conda env update -n base -f conda-env.yml \
-    && conda install -y -c bioconda htslib \
-    && conda install -y cmake \
+    && conda install -y -c bioconda 'htslib>=1.8' \
+    && conda install -y 'cmake>=3' \
     && conda clean -a -y \
     && rm conda-env.yml
 


### PR DESCRIPTION
Builds were failing because conda started installing an older version of htslib (v1.3) that lacks some of the logging features we use. This sets the minimum version to 1.8, which is what use in the superbuild. 