### PR TITLE
Update v2/v3 reads to use new intersection algorithm

### DIFF
--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -364,9 +364,6 @@ class Reader {
      */
     size_t last_intersecting_region_idx_;
 
-    /** Map of current relative sample ID -> last real_end reported. */
-    std::vector<uint32_t> last_reported_end;
-
     /**
      * Current index into the `regions` vector, used for finding intersecting
      * regions efficiently.


### PR DESCRIPTION
There is a bug in the existing intersection reads, in that we don't properly limit exporting duplicate records from anchors. The
last_exported_end does not correctly handle anchors, and has problems because TileDB query results are unordered. Instead a new formula for checking intersection which is more generic and guaranteed to not have issue with anchors or duplicates.


Depends on #171 