### PR TITLE
Switch to using point ranges for all sample ids

### DIFF
--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -198,8 +198,7 @@ class TileDBVCFDataset {
 
   std::vector<SafeBCFHdr> fetch_vcf_headers(
       const tiledb::Context& ctx,
-      uint32_t sample_id_min,
-      uint32_t sample_id_max) const;
+      const std::vector<SampleAndId>& samples) const;
 
   std::string first_contig() const;
 

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -196,7 +196,7 @@ class TileDBVCFDataset {
 
   std::string data_uri() const;
 
-  std::vector<SafeBCFHdr> fetch_vcf_headers(
+  std::unordered_map<uint32_t, SafeBCFHdr> fetch_vcf_headers(
       const tiledb::Context& ctx,
       const std::vector<SampleAndId>& samples) const;
 

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -550,8 +550,7 @@ bool Reader::read_current_batch() {
   // Batch complete; finalize the export (if applicable).
   if (exporter_ != nullptr) {
     for (const auto& s : read_state_.sample_batches[read_state_.batch_idx]) {
-      SafeBCFHdr& hdr =
-          read_state_.current_hdrs[s.sample_id - read_state_.sample_min];
+      SafeBCFHdr& hdr = read_state_.current_hdrs.at(s.sample_id);
       exporter_->finalize_export(s, hdr.get());
     }
   }
@@ -986,7 +985,7 @@ bool Reader::report_cell(
   }
 
   const auto& sample = read_state_.current_samples[samp_idx];
-  const auto& hdr = read_state_.current_hdrs[samp_idx];
+  const auto& hdr = read_state_.current_hdrs.at(samp_idx);
 
   if (!exporter_->export_record(
           sample, hdr.get(), region, contig_offset, results, cell_idx))

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -399,7 +399,7 @@ bool Reader::next_read_batch() {
   // Sample handles
   read_state_.current_samples.clear();
   for (const auto& s : read_state_.current_sample_batches) {
-    read_state_.current_samples[s.sample_id - read_state_.sample_min] = s;
+    read_state_.current_samples[s.sample_id] = s;
   }
 
   // Reopen the array so that irrelevant fragment metadata is unloaded.
@@ -976,8 +976,7 @@ bool Reader::report_cell(
   }
 
   const auto& results = read_state_.query_results;
-  uint32_t samp_idx = results.buffers()->sample().value<uint32_t>(cell_idx) -
-                      read_state_.sample_min;
+  uint32_t samp_idx = results.buffers()->sample().value<uint32_t>(cell_idx);
 
   // Skip this cell if we are not reporting its sample.
   if (read_state_.current_samples.count(samp_idx) == 0) {

--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -388,6 +388,9 @@ class Reader {
     /** The samples being exported, batched by space tile. */
     std::vector<std::vector<SampleAndId>> sample_batches;
 
+    /** current sample batch list */
+    std::vector<SampleAndId> current_sample_batches;
+
     /** Total number of records exported across all incomplete reads. */
     uint64_t total_num_records_exported = 0;
 

--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -356,7 +356,7 @@ class Reader {
     std::unordered_map<uint32_t, SampleAndId> current_samples;
 
     /** Map of current relative sample ID -> VCF header instance. */
-    std::vector<SafeBCFHdr> current_hdrs;
+    std::unordered_map<uint32_t, SafeBCFHdr> current_hdrs;
 
     /**
      * Stores the index to a region that was unsuccessfully reported

--- a/libtiledbvcf/test/src/unit-vcf-store.cc
+++ b/libtiledbvcf/test/src/unit-vcf-store.cc
@@ -250,7 +250,7 @@ TEST_CASE("TileDB-VCF: Test register 100", "[tiledbvcf][ingest]") {
     auto hdrs =
         ds.fetch_vcf_headers(ctx, {{"G10", 9}, {"G11", 10}, {"G12", 11}});
     REQUIRE(hdrs.size() == 3);
-    REQUIRE(bcf_hdr_nsamples(hdrs.at(0)) == 1);
+    REQUIRE(bcf_hdr_nsamples(hdrs.at(9)) == 1);
     std::vector<std::string> samples = {
         hdrs.at(9)->samples[0],
         hdrs.at(10)->samples[0],

--- a/libtiledbvcf/test/src/unit-vcf-store.cc
+++ b/libtiledbvcf/test/src/unit-vcf-store.cc
@@ -112,8 +112,8 @@ TEST_CASE("TileDB-VCF: Test register", "[tiledbvcf][ingest]") {
 
     auto hdrs = ds.fetch_vcf_headers(ctx, {{"HG01762", 0}});
     REQUIRE(hdrs.size() == 1);
-    REQUIRE(bcf_hdr_nsamples(hdrs[0]) == 1);
-    REQUIRE(hdrs[0]->samples[0] == std::string("HG01762"));
+    REQUIRE(bcf_hdr_nsamples(hdrs.at(0)) == 1);
+    REQUIRE(hdrs.at(0)->samples[0] == std::string("HG01762"));
 
     REQUIRE(ds.fmt_field_type("GQ") == BCF_HT_INT);
     REQUIRE(ds.info_field_type("BaseQRankSum") == BCF_HT_REAL);
@@ -146,10 +146,10 @@ TEST_CASE("TileDB-VCF: Test register", "[tiledbvcf][ingest]") {
 
     auto hdrs = ds.fetch_vcf_headers(ctx, {{"HG01762", 0}, {"HG00280", 1}});
     REQUIRE(hdrs.size() == 2);
-    REQUIRE(bcf_hdr_nsamples(hdrs[0]) == 1);
-    REQUIRE(hdrs[0]->samples[0] == std::string("HG01762"));
-    REQUIRE(bcf_hdr_nsamples(hdrs[1]) == 1);
-    REQUIRE(hdrs[1]->samples[0] == std::string("HG00280"));
+    REQUIRE(bcf_hdr_nsamples(hdrs.at(0)) == 1);
+    REQUIRE(hdrs.at(0)->samples[0] == std::string("HG01762"));
+    REQUIRE(bcf_hdr_nsamples(hdrs.at(1)) == 1);
+    REQUIRE(hdrs.at(1)->samples[0] == std::string("HG00280"));
   }
 
   if (vfs.is_dir(dataset_uri))
@@ -250,9 +250,11 @@ TEST_CASE("TileDB-VCF: Test register 100", "[tiledbvcf][ingest]") {
     auto hdrs =
         ds.fetch_vcf_headers(ctx, {{"G10", 9}, {"G11", 10}, {"G12", 11}});
     REQUIRE(hdrs.size() == 3);
-    REQUIRE(bcf_hdr_nsamples(hdrs[0]) == 1);
+    REQUIRE(bcf_hdr_nsamples(hdrs.at(0)) == 1);
     std::vector<std::string> samples = {
-        hdrs[0]->samples[0], hdrs[1]->samples[0], hdrs[2]->samples[0]};
+        hdrs.at(9)->samples[0],
+        hdrs.at(10)->samples[0],
+        hdrs.at(11)->samples[0]};
     std::vector<std::string> expected_samples = {"G10", "G11", "G12"};
     REQUIRE_THAT(expected_samples, Catch::Matchers::UnorderedEquals(samples));
   }

--- a/libtiledbvcf/test/src/unit-vcf-store.cc
+++ b/libtiledbvcf/test/src/unit-vcf-store.cc
@@ -110,7 +110,7 @@ TEST_CASE("TileDB-VCF: Test register", "[tiledbvcf][ingest]") {
     REQUIRE(ds.metadata().contig_offsets.at("2") == 249250621);
     REQUIRE(ds.metadata().contig_offsets.at("3") == 249250621 + 243199373);
 
-    auto hdrs = ds.fetch_vcf_headers(ctx, 0, 0);
+    auto hdrs = ds.fetch_vcf_headers(ctx, {{"HG01762", 0}});
     REQUIRE(hdrs.size() == 1);
     REQUIRE(bcf_hdr_nsamples(hdrs[0]) == 1);
     REQUIRE(hdrs[0]->samples[0] == std::string("HG01762"));
@@ -144,7 +144,7 @@ TEST_CASE("TileDB-VCF: Test register", "[tiledbvcf][ingest]") {
     REQUIRE(ds.metadata().contig_offsets.at("2") == 249250621);
     REQUIRE(ds.metadata().contig_offsets.at("3") == 249250621 + 243199373);
 
-    auto hdrs = ds.fetch_vcf_headers(ctx, 0, 1);
+    auto hdrs = ds.fetch_vcf_headers(ctx, {{"HG01762", 0}, {"HG00280", 1}});
     REQUIRE(hdrs.size() == 2);
     REQUIRE(bcf_hdr_nsamples(hdrs[0]) == 1);
     REQUIRE(hdrs[0]->samples[0] == std::string("HG01762"));
@@ -247,12 +247,14 @@ TEST_CASE("TileDB-VCF: Test register 100", "[tiledbvcf][ingest]") {
     REQUIRE(ds.metadata().sample_ids.at("G17") == 16);
     REQUIRE(ds.metadata().sample_names.at(16) == "G17");
 
-    auto hdrs = ds.fetch_vcf_headers(ctx, 9, 11);
+    auto hdrs =
+        ds.fetch_vcf_headers(ctx, {{"G10", 9}, {"G11", 10}, {"G12", 11}});
     REQUIRE(hdrs.size() == 3);
     REQUIRE(bcf_hdr_nsamples(hdrs[0]) == 1);
-    REQUIRE(hdrs[0]->samples[0] == std::string("G10"));
-    REQUIRE(hdrs[1]->samples[0] == std::string("G11"));
-    REQUIRE(hdrs[2]->samples[0] == std::string("G12"));
+    std::vector<std::string> samples = {
+        hdrs[0]->samples[0], hdrs[1]->samples[0], hdrs[2]->samples[0]};
+    std::vector<std::string> expected_samples = {"G10", "G11", "G12"};
+    REQUIRE_THAT(expected_samples, Catch::Matchers::UnorderedEquals(samples));
   }
 
   if (vfs.is_dir(dataset_uri))


### PR DESCRIPTION
Instead of issueing a range query for all samples between the min id and max id, we instead will issue points for all samples. In TileDB 2.1 point ranges can be coalesced automatically. In the worst case before if a user issues a query for 2 samples, the first and last TileDB-VCF would being in the entire dataset. Now it will just be the two samples needed.

This depends on the unmerged #169 .