### PR TITLE
Update C++ tests for unordered vector of results

### DIFF
--- a/libtiledbvcf/cmake/Modules/FindCatch_EP.cmake
+++ b/libtiledbvcf/cmake/Modules/FindCatch_EP.cmake
@@ -32,7 +32,7 @@
 
 # Search the path set during the superbuild for the EP.
 message(STATUS "searching for catch in ${EP_SOURCE_DIR}")
-set(CATCH_PATHS ${EP_SOURCE_DIR}/ep_catch/single_include)
+set(CATCH_PATHS ${EP_SOURCE_DIR}/ep_catch/single_include/catch2)
 
 find_path(CATCH_INCLUDE_DIR
   NAMES catch.hpp
@@ -48,8 +48,8 @@ if (NOT CATCH_FOUND AND SUPERBUILD)
   message(STATUS "Adding Catch as an external project")
   ExternalProject_Add(ep_catch
     PREFIX "externals"
-    URL "https://github.com/catchorg/Catch2/archive/v2.2.1.zip"
-    URL_HASH SHA1=578908c96d67e681a13ea903188a107076a6d1ee
+    URL "https://github.com/catchorg/Catch2/archive/v2.13.1.zip"
+    URL_HASH SHA1=7efd0a2ac05b61649153c6279bfc9554b2c02195
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ""

--- a/libtiledbvcf/test/src/unit-c-api-reader.cc
+++ b/libtiledbvcf/test/src/unit-c-api-reader.cc
@@ -42,139 +42,173 @@ static std::string INPUT_ARRAYS_DIR_V2 =
 /*           HELPER MACROS           */
 /* ********************************* */
 
-#define SET_BUFF_POS_START(r, nr)                               \
-  uint32_t pos_start[(nr)];                                     \
-  REQUIRE(                                                      \
-      tiledb_vcf_reader_set_buffer_values(                      \
-          reader, "pos_start", sizeof(pos_start), pos_start) == \
-      TILEDB_VCF_OK);
+#define SET_BUFF_POS_START(r, nr)              \
+  std::vector<uint32_t> pos_start((nr));       \
+  REQUIRE(                                     \
+      tiledb_vcf_reader_set_buffer_values(     \
+          reader,                              \
+          "pos_start",                         \
+          sizeof(uint32_t) * pos_start.size(), \
+          pos_start.data()) == TILEDB_VCF_OK);
 
-#define SET_BUFF_POS_END(r, nr)            \
-  uint32_t pos_end[(nr)];                  \
-  REQUIRE(                                 \
-      tiledb_vcf_reader_set_buffer_values( \
-          reader, "pos_end", sizeof(pos_end), pos_end) == TILEDB_VCF_OK);
+#define SET_BUFF_POS_END(r, nr)              \
+  std::vector<uint32_t> pos_end((nr));       \
+  REQUIRE(                                   \
+      tiledb_vcf_reader_set_buffer_values(   \
+          reader,                            \
+          "pos_end",                         \
+          sizeof(uint32_t) * pos_end.size(), \
+          pos_end.data()) == TILEDB_VCF_OK);
 
-#define SET_BUFF_QUERY_BED_START(r, nr)    \
-  uint32_t query_bed_start[(nr)];          \
-  REQUIRE(                                 \
-      tiledb_vcf_reader_set_buffer_values( \
-          reader,                          \
-          "query_bed_start",               \
-          sizeof(query_bed_start),         \
-          query_bed_start) == TILEDB_VCF_OK);
+#define SET_BUFF_QUERY_BED_START(r, nr)              \
+  std::vector<uint32_t> query_bed_start((nr));       \
+  REQUIRE(                                           \
+      tiledb_vcf_reader_set_buffer_values(           \
+          reader,                                    \
+          "query_bed_start",                         \
+          sizeof(uint32_t) * query_bed_start.size(), \
+          query_bed_start.data()) == TILEDB_VCF_OK);
 
-#define SET_BUFF_QUERY_BED_END(r, nr)                                       \
-  uint32_t query_bed_end[(nr)];                                             \
-  REQUIRE(                                                                  \
-      tiledb_vcf_reader_set_buffer_values(                                  \
-          reader, "query_bed_end", sizeof(query_bed_end), query_bed_end) == \
-      TILEDB_VCF_OK);
+#define SET_BUFF_QUERY_BED_END(r, nr)              \
+  std::vector<uint32_t> query_bed_end((nr));       \
+  REQUIRE(                                         \
+      tiledb_vcf_reader_set_buffer_values(         \
+          reader,                                  \
+          "query_bed_end",                         \
+          sizeof(uint32_t) * query_bed_end.size(), \
+          query_bed_end.data()) == TILEDB_VCF_OK);
 
-#define SET_BUFF_SAMPLE_NAME(r, nr)                                     \
-  int32_t sample_name_offsets[(nr) + 1];                                \
-  char sample_name[(nr)*10];                                            \
+#define SET_BUFF_SAMPLE_NAME(r, nr)                     \
+  std::vector<int32_t> sample_name_offsets((nr) + 1);   \
+  std::vector<char> sample_name((nr)*10);               \
+  REQUIRE(                                              \
+      tiledb_vcf_reader_set_buffer_values(              \
+          (reader),                                     \
+          "sample_name",                                \
+          sizeof(char) * sample_name.size(),            \
+          sample_name.data()) == TILEDB_VCF_OK);        \
+  REQUIRE(                                              \
+      tiledb_vcf_reader_set_buffer_offsets(             \
+          (reader),                                     \
+          "sample_name",                                \
+          sizeof(int32_t) * sample_name_offsets.size(), \
+          sample_name_offsets.data()) == TILEDB_VCF_OK);
+
+#define SET_BUFF_CONTIG(r, nr)                                                \
+  std::vector<int32_t> contig_offsets((nr) + 1);                              \
+  std::vector<char> contig((nr)*10);                                          \
+  REQUIRE(                                                                    \
+      tiledb_vcf_reader_set_buffer_values(                                    \
+          (reader), "contig", sizeof(char) * contig.size(), contig.data()) == \
+      TILEDB_VCF_OK);                                                         \
+  REQUIRE(                                                                    \
+      tiledb_vcf_reader_set_buffer_offsets(                                   \
+          (reader),                                                           \
+          "contig",                                                           \
+          sizeof(int32_t) * contig_offsets.size(),                            \
+          contig_offsets.data()) == TILEDB_VCF_OK);
+
+#define SET_BUFF_ALLELES(r, nr)                          \
+  std::vector<int32_t> alleles_offsets(2 * (nr) + 1);    \
+  std::vector<int32_t> alleles_list_offsets((nr) + 1);   \
+  std::vector<char> alleles((nr)*20);                    \
+  REQUIRE(                                               \
+      tiledb_vcf_reader_set_buffer_values(               \
+          (reader),                                      \
+          "alleles",                                     \
+          sizeof(char) * alleles.size(),                 \
+          alleles.data()) == TILEDB_VCF_OK);             \
+  REQUIRE(                                               \
+      tiledb_vcf_reader_set_buffer_offsets(              \
+          (reader),                                      \
+          "alleles",                                     \
+          sizeof(int32_t) * alleles_offsets.size(),      \
+          alleles_offsets.data()) == TILEDB_VCF_OK);     \
+  REQUIRE(                                               \
+      tiledb_vcf_reader_set_buffer_list_offsets(         \
+          (reader),                                      \
+          "alleles",                                     \
+          sizeof(int32_t) * alleles_list_offsets.size(), \
+          alleles_list_offsets.data()) == TILEDB_VCF_OK);
+
+#define SET_BUFF_FILTERS(r, nr)                           \
+  std::vector<int32_t> filters_offsets(2 * (nr) + 1);     \
+  std::vector<int32_t> filters_list_offsets((nr) + 1);    \
+  std::vector<uint8_t> filters_bitmap((nr) / 8 + 1);      \
+  std::vector<char> filters((nr)*20);                     \
+  REQUIRE(                                                \
+      tiledb_vcf_reader_set_buffer_values(                \
+          (reader),                                       \
+          "filters",                                      \
+          sizeof(char) * filters.size(),                  \
+          filters.data()) == TILEDB_VCF_OK);              \
+  REQUIRE(                                                \
+      tiledb_vcf_reader_set_buffer_offsets(               \
+          (reader),                                       \
+          "filters",                                      \
+          sizeof(int32_t) * filters_offsets.size(),       \
+          filters_offsets.data()) == TILEDB_VCF_OK);      \
+  REQUIRE(                                                \
+      tiledb_vcf_reader_set_buffer_list_offsets(          \
+          (reader),                                       \
+          "filters",                                      \
+          sizeof(int32_t) * filters_list_offsets.size(),  \
+          filters_list_offsets.data()) == TILEDB_VCF_OK); \
+  REQUIRE(                                                \
+      tiledb_vcf_reader_set_buffer_validity_bitmap(       \
+          reader,                                         \
+          "filters",                                      \
+          sizeof(uint8_t) * filters_bitmap.size(),        \
+          filters_bitmap.data()) == TILEDB_VCF_OK);
+
+#define SET_BUFF_INFO(r, nr)                                            \
+  std::vector<int32_t> info_offsets((nr) + 1);                          \
+  std::vector<char> info((nr)*100);                                     \
   REQUIRE(                                                              \
       tiledb_vcf_reader_set_buffer_values(                              \
-          (reader), "sample_name", sizeof(sample_name), sample_name) == \
+          (reader), "info", sizeof(char) * info.size(), info.data()) == \
       TILEDB_VCF_OK);                                                   \
   REQUIRE(                                                              \
       tiledb_vcf_reader_set_buffer_offsets(                             \
           (reader),                                                     \
-          "sample_name",                                                \
-          sizeof(sample_name_offsets),                                  \
-          sample_name_offsets) == TILEDB_VCF_OK);
+          "info",                                                       \
+          sizeof(int32_t) * info_offsets.size(),                        \
+          info_offsets.data()) == TILEDB_VCF_OK);
 
-#define SET_BUFF_CONTIG(r, nr)                                           \
-  int32_t contig_offsets[(nr) + 1];                                      \
-  char contig[(nr)*10];                                                  \
-  REQUIRE(                                                               \
-      tiledb_vcf_reader_set_buffer_values(                               \
-          (reader), "contig", sizeof(contig), contig) == TILEDB_VCF_OK); \
-  REQUIRE(                                                               \
-      tiledb_vcf_reader_set_buffer_offsets(                              \
-          (reader), "contig", sizeof(contig_offsets), contig_offsets) == \
+#define SET_BUFF_FORMAT(r, nr)                                             \
+  std::vector<int32_t> format_offsets((nr) + 1);                           \
+  std::vector<char> format((nr)*100);                                      \
+  REQUIRE(                                                                 \
+      tiledb_vcf_reader_set_buffer_values(                                 \
+          (reader), "fmt", sizeof(char) * format.size(), format.data()) == \
+      TILEDB_VCF_OK);                                                      \
+  REQUIRE(                                                                 \
+      tiledb_vcf_reader_set_buffer_offsets(                                \
+          (reader),                                                        \
+          "fmt",                                                           \
+          sizeof(int32_t) * format_offsets.size(),                         \
+          format_offsets.data()) == TILEDB_VCF_OK);
+
+#define SET_BUFF_FMT_GT(r, nr)                                               \
+  std::vector<int32_t> fmt_GT_offsets((nr) + 1);                             \
+  std::vector<int> fmt_GT((nr)*2);                                           \
+  REQUIRE(                                                                   \
+      tiledb_vcf_reader_set_buffer_values(                                   \
+          (reader), "fmt_GT", sizeof(int) * fmt_GT.size(), fmt_GT.data()) == \
+      TILEDB_VCF_OK);                                                        \
+  REQUIRE(                                                                   \
+      tiledb_vcf_reader_set_buffer_offsets(                                  \
+          (reader),                                                          \
+          "fmt_GT",                                                          \
+          sizeof(int32_t) * fmt_GT_offsets.size(),                           \
+          fmt_GT_offsets.data()) == TILEDB_VCF_OK);
+
+#define SET_BUFF_FMT_DP(r, nr)                                               \
+  std::vector<int> fmt_DP((nr));                                             \
+  REQUIRE(                                                                   \
+      tiledb_vcf_reader_set_buffer_values(                                   \
+          (reader), "fmt_DP", sizeof(int) * fmt_DP.size(), fmt_DP.data()) == \
       TILEDB_VCF_OK);
-
-#define SET_BUFF_ALLELES(r, nr)                                             \
-  int32_t alleles_offsets[2 * (nr) + 1];                                    \
-  int32_t alleles_list_offsets[(nr) + 1];                                   \
-  char alleles[(nr)*20];                                                    \
-  REQUIRE(                                                                  \
-      tiledb_vcf_reader_set_buffer_values(                                  \
-          (reader), "alleles", sizeof(alleles), alleles) == TILEDB_VCF_OK); \
-  REQUIRE(                                                                  \
-      tiledb_vcf_reader_set_buffer_offsets(                                 \
-          (reader), "alleles", sizeof(alleles_offsets), alleles_offsets) == \
-      TILEDB_VCF_OK);                                                       \
-  REQUIRE(                                                                  \
-      tiledb_vcf_reader_set_buffer_list_offsets(                            \
-          (reader),                                                         \
-          "alleles",                                                        \
-          sizeof(alleles_list_offsets),                                     \
-          alleles_list_offsets) == TILEDB_VCF_OK);
-
-#define SET_BUFF_FILTERS(r, nr)                                             \
-  int32_t filters_offsets[2 * (nr) + 1];                                    \
-  int32_t filters_list_offsets[(nr) + 1];                                   \
-  uint8_t filters_bitmap[(nr) / 8 + 1];                                     \
-  char filters[(nr)*20];                                                    \
-  REQUIRE(                                                                  \
-      tiledb_vcf_reader_set_buffer_values(                                  \
-          (reader), "filters", sizeof(filters), filters) == TILEDB_VCF_OK); \
-  REQUIRE(                                                                  \
-      tiledb_vcf_reader_set_buffer_offsets(                                 \
-          (reader), "filters", sizeof(filters_offsets), filters_offsets) == \
-      TILEDB_VCF_OK);                                                       \
-  REQUIRE(                                                                  \
-      tiledb_vcf_reader_set_buffer_list_offsets(                            \
-          (reader),                                                         \
-          "filters",                                                        \
-          sizeof(filters_list_offsets),                                     \
-          filters_list_offsets) == TILEDB_VCF_OK);                          \
-  REQUIRE(                                                                  \
-      tiledb_vcf_reader_set_buffer_validity_bitmap(                         \
-          reader, "filters", sizeof(filters_bitmap), filters_bitmap) ==     \
-      TILEDB_VCF_OK);
-
-#define SET_BUFF_INFO(r, nr)                                       \
-  int32_t info_offsets[(nr) + 1];                                  \
-  char info[(nr)*100];                                             \
-  REQUIRE(                                                         \
-      tiledb_vcf_reader_set_buffer_values(                         \
-          (reader), "info", sizeof(info), info) == TILEDB_VCF_OK); \
-  REQUIRE(                                                         \
-      tiledb_vcf_reader_set_buffer_offsets(                        \
-          (reader), "info", sizeof(info_offsets), info_offsets) == \
-      TILEDB_VCF_OK);
-
-#define SET_BUFF_FORMAT(r, nr)                                        \
-  int32_t format_offsets[(nr) + 1];                                   \
-  char format[(nr)*100];                                              \
-  REQUIRE(                                                            \
-      tiledb_vcf_reader_set_buffer_values(                            \
-          (reader), "fmt", sizeof(format), format) == TILEDB_VCF_OK); \
-  REQUIRE(                                                            \
-      tiledb_vcf_reader_set_buffer_offsets(                           \
-          (reader), "fmt", sizeof(format_offsets), format_offsets) == \
-      TILEDB_VCF_OK);
-
-#define SET_BUFF_FMT_GT(r, nr)                                           \
-  int32_t fmt_GT_offsets[(nr) + 1];                                      \
-  int fmt_GT[(nr)*2];                                                    \
-  REQUIRE(                                                               \
-      tiledb_vcf_reader_set_buffer_values(                               \
-          (reader), "fmt_GT", sizeof(fmt_GT), fmt_GT) == TILEDB_VCF_OK); \
-  REQUIRE(                                                               \
-      tiledb_vcf_reader_set_buffer_offsets(                              \
-          (reader), "fmt_GT", sizeof(fmt_GT_offsets), fmt_GT_offsets) == \
-      TILEDB_VCF_OK);
-
-#define SET_BUFF_FMT_DP(r, nr)             \
-  int fmt_DP[(nr)];                        \
-  REQUIRE(                                 \
-      tiledb_vcf_reader_set_buffer_values( \
-          (reader), "fmt_DP", sizeof(fmt_DP), fmt_DP) == TILEDB_VCF_OK);
 
 /* ********************************* */
 /*               TESTS               */

--- a/libtiledbvcf/test/src/unit-helpers.h
+++ b/libtiledbvcf/test/src/unit-helpers.h
@@ -1,0 +1,241 @@
+/**
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2020 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef __UNIT_HELPERS
+#define __UNIT_HELPERS
+
+#include <numeric>
+#include <sstream>
+#include <utility>
+#include <vector>
+#include "catch.hpp"
+
+template <typename T, typename Compare>
+std::vector<std::size_t> sort_permutation(
+    const std::vector<T>& vec, const Compare& compare) {
+  std::vector<std::size_t> p(vec.size());
+  std::iota(p.begin(), p.end(), 0);
+  std::sort(p.begin(), p.end(), [&](std::size_t i, std::size_t j) {
+    return compare(vec[i], vec[j]);
+  });
+  return p;
+}
+
+template <typename T>
+std::vector<T> apply_permutation(
+    const std::vector<T>& vec, const std::vector<std::size_t>& p) {
+  std::vector<T> sorted_vec(vec.size());
+  std::transform(p.begin(), p.end(), sorted_vec.begin(), [&](std::size_t i) {
+    return vec[i];
+  });
+  return sorted_vec;
+}
+
+struct record {
+  std::string sample;
+  uint32_t start_pos = 0;
+  uint32_t end_pos = 0;
+  uint32_t query_bed_start = 0;
+  uint32_t query_bed_end = 0;
+  std::string contig;
+  std::vector<std::string> alleles;
+  std::vector<std::string> filters;
+  bool filter_valid;
+  std::string info;
+  std::string fmt;
+  std::vector<int32_t> fmt_GT;
+  int fmt_DP = 0;
+  std::vector<int> fmt_PL;
+
+  explicit record(
+      std::string sample = "",
+      uint32_t start_pos = 0,
+      uint32_t end_pos = 0,
+      uint32_t query_bed_start = 0,
+      uint32_t query_bed_end = 0,
+      std::string contig = "",
+      std::vector<std::string> alleles = {},
+      std::vector<std::string> filters = {},
+      bool filter_valid = false,
+      std::string info = "",
+      std::string fmt = "",
+      std::vector<int32_t> fmt_GT = {},
+      int fmt_DP = 0,
+      std::vector<int> fmt_PL = {})
+      : sample(std::move(sample))
+      , start_pos(start_pos)
+      , end_pos(end_pos)
+      , query_bed_start(query_bed_start)
+      , query_bed_end(query_bed_end)
+      , contig(std::move(contig))
+      , alleles(std::move(alleles))
+      , filters(std::move(filters))
+      , filter_valid(filter_valid)
+      , info(std::move(info))
+      , fmt(std::move(fmt))
+      , fmt_GT(std::move(fmt_GT))
+      , fmt_DP(fmt_DP)
+      , fmt_PL(std::move(fmt_PL)) {
+  }
+
+  bool operator==(const record& b) const {
+    if (sample != b.sample)
+      return false;
+
+    if (start_pos != b.start_pos)
+      return false;
+
+    if (end_pos != b.end_pos)
+      return false;
+
+    if (query_bed_start != b.query_bed_start)
+      return false;
+
+    if (query_bed_end != b.query_bed_end)
+      return false;
+
+    if (contig != b.contig)
+      return false;
+
+    if (info != b.info)
+      return false;
+
+    if (fmt != b.fmt)
+      return false;
+
+    if (fmt_DP != b.fmt_DP)
+      return false;
+
+    if (filter_valid != b.filter_valid)
+      return false;
+
+    if (alleles.size() != b.alleles.size())
+      return false;
+
+    if (filters.size() != b.filters.size())
+      return false;
+
+    if (fmt_GT.size() != b.fmt_GT.size())
+      return false;
+
+    if (fmt_PL.size() != b.fmt_PL.size())
+      return false;
+
+    for (size_t i = 0; i < alleles.size(); i++) {
+      if (alleles[i] != b.alleles[i])
+        return false;
+    }
+
+    for (size_t i = 0; i < filters.size(); i++) {
+      if (filters[i] != b.filters[i])
+        return false;
+    }
+
+    for (size_t i = 0; i < fmt_GT.size(); i++) {
+      if (fmt_GT[i] != b.fmt_GT[i])
+        return false;
+    }
+
+    for (size_t i = 0; i < fmt_PL.size(); i++) {
+      if (fmt_PL[i] != b.fmt_PL[i])
+        return false;
+    }
+
+    return true;
+  }
+
+  bool operator!=(const record& b) const {
+    return !(*this == b);
+  }
+
+  friend std::ostream& operator<<(std::ostream& out, const record& r);
+
+  std::string describe() const {
+    std::stringstream out;
+    out << this->sample << "-" << this->contig << "-" << this->start_pos << "-"
+        << this->end_pos << "-" << this->query_bed_start << "-"
+        << this->query_bed_end << "-";
+    for (size_t i = 0; i < this->alleles.size(); i++) {
+      out << this->alleles[i];
+      if (i < this->alleles.size() - 1)
+        out << ",";
+    }
+    out << "-";
+    for (size_t i = 0; i < this->filters.size(); i++) {
+      out << this->filters[i];
+      if (i < this->filters.size() - 1)
+        out << ",";
+    }
+    return out.str();
+  }
+};
+
+std::ostream& operator<<(std::ostream& out, const record& r) {
+  out << r.describe();
+  return out;
+}
+
+template <typename T>
+std::vector<T> var_value(
+    std::vector<T> data, std::vector<int32_t> offsets, uint64_t index) {
+  // Arrow compatible buffers have one final offset
+  uint64_t start = offsets[index];
+  uint64_t end = offsets[index + 1];
+  return std::vector<T>(data.begin() + start, data.begin() + end);
+}
+
+template <typename T>
+std::vector<std::vector<T>> var_list_value(
+    std::vector<T> data,
+    std::vector<int32_t> offsets,
+    std::vector<int32_t> list_offsets,
+    uint64_t index) {
+  // Arrow compatible buffers have one final offset
+  uint64_t start = offsets[index];
+  uint64_t end = offsets[index + 1];
+  return std::vector<T>(data.begin() + start, data.begin() + end);
+}
+
+std::vector<std::string> var_list_value(
+    std::vector<char> data,
+    std::vector<int32_t> offsets,
+    std::vector<int32_t> list_offsets,
+    uint64_t index) {
+  std::vector<std::string> ret;
+  // Arrow compatible buffers have one final offset
+  uint32_t list_offset_start = list_offsets[index];
+  uint32_t list_offset_end = list_offsets[index + 1];
+
+  for (uint32_t i = list_offset_start; i < list_offset_end; i++) {
+    uint32_t start = offsets[i];
+    uint32_t end = offsets[i + 1];
+    ret.emplace_back(data.begin() + start, data.begin() + end);
+  }
+
+  return ret;
+}
+
+#endif

--- a/libtiledbvcf/test/src/unit-vcf-export.cc
+++ b/libtiledbvcf/test/src/unit-vcf-export.cc
@@ -104,7 +104,7 @@ void check_result(
   for (unsigned i = 0; i < nrec; i++)
     actual.push_back(*(buffer.data<T>() + i));
 
-  REQUIRE(actual == expected);
+  REQUIRE_THAT(expected, Catch::Matchers::UnorderedEquals(actual));
 }
 
 template <typename T>
@@ -136,8 +136,7 @@ void check_var_result(
     }
   }
 
-  for (unsigned i = 0; i < actual.size(); i++)
-    REQUIRE(actual[i] == expected[i]);
+  REQUIRE_THAT(expected, Catch::Matchers::UnorderedEquals(actual));
 }
 
 void check_string_result(
@@ -156,7 +155,7 @@ void check_string_result(
     std::string s(buffer.data<char>() + buffer.offsets()[i], len);
     actual.push_back(s);
   }
-  REQUIRE(actual == expected);
+  REQUIRE_THAT(expected, Catch::Matchers::UnorderedEquals(actual));
 }
 }  // namespace
 
@@ -277,8 +276,8 @@ TEST_CASE("TileDB-VCF: Test export", "[tiledbvcf][export]") {
     check_var_result<int32_t>(
         reader, "fmt_PL", pl, {0,   0, 0, 0,  0, 0, 0,  66, 990, 0, 24,
                                360, 0, 6, 90, 0, 3, 32, 0,  0,   0});
-    check_var_result<int32_t>(reader, "fmt_DP", dp, {0, 0, 64, 15, 6, 2, 0});
-    check_var_result<int32_t>(
+    check_result<int32_t>(reader, "fmt_DP", dp, {0, 0, 64, 15, 6, 2, 0});
+    check_result<int32_t>(
         reader, "fmt_MIN_DP", min_dp, {0, 0, 30, 14, 3, 1, 0});
   }
 
@@ -1528,7 +1527,7 @@ TEST_CASE("TileDB-VCF: Test export with nulls", "[tiledbvcf][export]") {
     check_var_result<float>(
         reader, "info_BaseQRankSum", baseq, {-0.787f, 1.97f});
     check_var_result<int32_t>(reader, "info_DP", info_dp, {89, 24});
-    check_var_result<int32_t>(
+    check_result<int32_t>(
         reader,
         "fmt_DP",
         fmt_dp,


### PR DESCRIPTION
Since there is no ordering of VCF results, we switch to use a struct that represents a VCF record. Then we use Catch2's `UnorderedEquals` matcher to compare expected results to actual ignoring any record ordering differences. We also switch the vcf export tests to handle unordered comparison of results.