### PR TITLE
Validate region has same contig as record

### DIFF
--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -656,10 +656,11 @@ std::list<Region> TileDBVCFDataset::all_contigs_list() const {
   return result;
 }
 
-std::pair<uint32_t, uint32_t> TileDBVCFDataset::contig_from_column(
-    uint32_t col) const {
+std::tuple<uint32_t, uint32_t, std::string>
+TileDBVCFDataset::contig_from_column(uint32_t col) const {
   bool found = false;
   uint32_t contig_offset = 0, contig_length = 0;
+  std::string contig;
   for (const auto& it : metadata_.contig_offsets) {
     uint32_t offset = it.second;
     if (col >= offset) {
@@ -667,6 +668,7 @@ std::pair<uint32_t, uint32_t> TileDBVCFDataset::contig_from_column(
       if (col < offset + length) {
         contig_offset = offset;
         contig_length = length;
+        contig = it.first;
         found = true;
         break;
       }
@@ -677,7 +679,7 @@ std::pair<uint32_t, uint32_t> TileDBVCFDataset::contig_from_column(
     throw std::runtime_error(
         "Error finding contig containing column " + std::to_string(col));
 
-  return {contig_offset, contig_length};
+  return {contig_offset, contig_length, contig};
 }
 
 TileDBVCFDataset::Metadata TileDBVCFDataset::read_metadata(

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -218,7 +218,8 @@ class TileDBVCFDataset {
    * Returns a pair of (offset, length) for the contig containing the given
    * global column coordinate value.
    */
-  std::pair<uint32_t, uint32_t> contig_from_column(uint32_t col) const;
+  std::tuple<uint32_t, uint32_t, std::string> contig_from_column(
+      uint32_t col) const;
 
   /**
    * Splits an attribute name like 'info_X' or 'fmt_Y' into a pair ('info', 'X')

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -595,9 +595,9 @@ bool Reader::process_query_results_v3() {
     const uint32_t anchor_gap = dataset_->metadata().anchor_gap;
 
     // If we've passed into a new contig, get the new info for it.
-    if (end >= contig_info.first + contig_info.second)
+    if (end >= std::get<0>(contig_info) + std::get<1>(contig_info))
       contig_info = dataset_->contig_from_column(end);
-    const uint32_t contig_offset = contig_info.first;
+    const uint32_t contig_offset = std::get<0>(contig_info);
 
     // Perform a binary search to find first region we can intersection
     // This is an optimization to avoid a linear scan over all regions for
@@ -624,6 +624,11 @@ bool Reader::process_query_results_v3() {
                    read_state_.region_idx;
     for (; j < read_state_.regions.size(); j++) {
       const auto& reg = read_state_.regions[j];
+
+      // If the region does not match the contig skip
+      if (reg.seq_name != std::get<2>(contig_info))
+        continue;
+
       const uint32_t reg_min = reg.seq_offset + reg.min;
       const uint32_t reg_max = reg.seq_offset + reg.max;
 
@@ -693,9 +698,9 @@ bool Reader::process_query_results_v2() {
     const uint32_t anchor_gap = dataset_->metadata().anchor_gap;
 
     // If we've passed into a new contig, get the new info for it.
-    if (end >= contig_info.first + contig_info.second)
+    if (end >= std::get<0>(contig_info) + std::get<1>(contig_info))
       contig_info = dataset_->contig_from_column(end);
-    const uint32_t contig_offset = contig_info.first;
+    const uint32_t contig_offset = std::get<0>(contig_info);
 
     // Perform a binary search to find first region we can intersection
     // This is an optimization to avoid a linear scan over all regions for


### PR DESCRIPTION
For v2/v3 arrays we need to validate region is same contig as record by checking the names. Even with global ordering in v2/v3 arrays its possible for a region to incorrectly overlap because a record extends before or after a contigs boundaries. Contig offsets are not guaranteed to be unique so we use a string comparison of the contig name.