### PR TITLE
Add python options to assist dask dataframe

### DIFF
--- a/apis/python/src/tiledbvcf/binding/reader.cc
+++ b/apis/python/src/tiledbvcf/binding/reader.cc
@@ -152,9 +152,9 @@ void Reader::set_verbose(bool verbose) {
   check_error(reader, tiledb_vcf_reader_set_verbose(reader, verbose));
 }
 
-void Reader::read() {
+void Reader::read(const bool release_buffers) {
   auto reader = ptr.get();
-  alloc_buffers();
+  alloc_buffers(release_buffers);
   set_buffers();
 
   check_error(reader, tiledb_vcf_reader_read(reader));
@@ -165,11 +165,12 @@ void Reader::read() {
         "TileDB-VCF-Py: Error submitting read; unhandled read status.");
 }
 
-void Reader::alloc_buffers() {
+void Reader::alloc_buffers(const bool release_buffs) {
   auto reader = ptr.get();
 
   // Release old buffers. TODO: reuse when possible
-  release_buffers();
+  if (release_buffs)
+      release_buffers();
 
   // Get a count of the number of buffers required.
   int num_buffers = 0;

--- a/apis/python/src/tiledbvcf/binding/reader.h
+++ b/apis/python/src/tiledbvcf/binding/reader.h
@@ -89,7 +89,7 @@ class Reader {
   void set_tiledb_stats_enabled(const bool stats_enabled);
 
   /** Performs a blocking read operation. */
-  void read();
+  void read(const bool release_buffers);
 
   /**
    * Returns a map of attribute name -> (offsets_buff, data_buff) containing the
@@ -174,7 +174,7 @@ class Reader {
   std::vector<BufferInfo> buffers_;
 
   /** Allocate buffers for the read. */
-  void alloc_buffers();
+  void alloc_buffers(const bool release_buffers);
 
   /** Sets the allocated buffers on the reader object. */
   void set_buffers();

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -121,7 +121,15 @@ class Dataset(object):
                     pass
             self.writer.set_tiledb_config(",".join(tiledb_config_list))
 
-    def read(self, attrs, samples=None, regions=None, samples_file=None, bed_file=None):
+    def read(
+        self,
+        attrs,
+        samples=None,
+        regions=None,
+        samples_file=None,
+        bed_file=None,
+        return_type="pandas",
+    ):
 
         """Reads data from a TileDB-VCF dataset.
 
@@ -138,6 +146,7 @@ class Dataset(object):
         :param str samples_file: URI of file containing sample names to be read,
             one per line.
         :param str bed_file: URI of a BED file of genomic regions to be read.
+        :param return_type: Type to return, 'pandas' for pandas dataframe or 'arrow' for raw arrow table
         :return: Pandas DataFrame containing results.
         """
         if self.mode != "r":
@@ -153,7 +162,7 @@ class Dataset(object):
         if bed_file is not None:
             self.reader.set_bed_file(bed_file)
 
-        return self.continue_read()
+        return self.continue_read(return_type=return_type)
 
     def read_iter(
         self, attrs, samples=None, regions=None, samples_file=None, bed_file=None
@@ -166,12 +175,20 @@ class Dataset(object):
         while not self.read_completed():
             yield self.continue_read()
 
-    def continue_read(self):
+    def continue_read(self, release_buffers=True, return_type="pandas"):
+        """
+        Continue an incomplete read
+        :param release_buffers: Release previous result buffers before reallocating new buffers for cotinued read, set to false if you have grabbed a arrow reference
+        :param return_type: Type to return, 'pandas' for pandas dataframe or 'arrow' for raw arrow table
+        :return: pandas dataframe
+        """
         if self.mode != "r":
             raise Exception("Dataset not open in read mode")
 
-        self.reader.read()
+        self.reader.read(release_buffers)
         table = self.reader.get_results_arrow()
+        if return_type == "arrow":
+            return table
         return table.to_pandas()
 
     def read_completed(self):


### PR DESCRIPTION
Two new options were added to read/continue_read to specify if we should return a pandas dataframe or the arrow table. Also added was an option for if the previous results should be freed before continuing the read.

This will allow for the dask dataframe to more efficiently build from the arrow table.