### PR TITLE
Reduce Number of Time Array Is Opened

### DIFF
--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -301,7 +301,9 @@ void TileDBVCFDataset::open(
   utils::set_tiledb_config(tiledb_config, &cfg);
   Context ctx(cfg);
 
-  metadata_ = read_metadata(ctx, root_uri_);
+  data_array_ = open_data_array(ctx, TILEDB_READ);
+  vcf_header_array_ = open_vcf_array(ctx, TILEDB_READ);
+  read_metadata(ctx, root_uri_);
 
   // We support V2, V3 and V4 (current) formats.
   if (metadata_.version != Version::V2 && metadata_.version != Version::V3 &&
@@ -534,17 +536,14 @@ std::string TileDBVCFDataset::root_uri() const {
   return root_uri_;
 }
 
-std::unordered_map<uint32_t, SafeBCFHdr> TileDBVCFDataset::fetch_vcf_headers_v4(
-    const tiledb::Context& ctx,
-    const std::vector<SampleAndId>& samples,
-    std::unordered_map<std::string, size_t>* lookup_map) const {
-  std::unordered_map<uint32_t, SafeBCFHdr> result;
-  std::unique_ptr<Array> array;
+std::unique_ptr<tiledb::Array> TileDBVCFDataset::open_vcf_array(
+    const tiledb::Context& ctx, tiledb_query_type_t query_type) {
+  std::unique_ptr<Array> array = nullptr;
   try {
     // First let's try to open the metadata using proper cloud detection
     std::string array_uri = vcf_headers_uri(root_uri_, true);
     // Set up and submit query
-    array.reset(new Array(ctx, array_uri, TILEDB_READ));
+    array.reset(new Array(ctx, array_uri, query_type));
   } catch (const tiledb::TileDBError& ex) {
     try {
       // Fall back to use s3 style paths, this handle datasets that are
@@ -553,7 +552,7 @@ std::unordered_map<uint32_t, SafeBCFHdr> TileDBVCFDataset::fetch_vcf_headers_v4(
       std::string array_uri = vcf_headers_uri(root_uri_, false);
 
       // Set up and submit query
-      array = std::unique_ptr<Array>(new Array(ctx, array_uri, TILEDB_READ));
+      array = std::unique_ptr<Array>(new Array(ctx, array_uri, query_type));
     } catch (const tiledb::TileDBError& ex) {
       throw std::runtime_error(
           "Cannot open TileDB-VCF vcf headers; dataset '" + root_uri_ +
@@ -562,7 +561,48 @@ std::unordered_map<uint32_t, SafeBCFHdr> TileDBVCFDataset::fetch_vcf_headers_v4(
     }
   }
 
-  Query query(ctx, *array);
+  return array;
+}
+
+std::unique_ptr<tiledb::Array> TileDBVCFDataset::open_data_array(
+    const tiledb::Context& ctx, tiledb_query_type_t query_type) {
+  std::unique_ptr<Array> array = nullptr;
+  try {
+    // First let's try to open the metadata using proper cloud detection
+    std::string array_uri = data_array_uri(root_uri_, true);
+    // Set up and submit query
+    array.reset(new Array(ctx, array_uri, query_type));
+  } catch (const tiledb::TileDBError& ex) {
+    try {
+      // Fall back to use s3 style paths, this handle datasets that are
+      // registered on the cloud but not with the proper naming scheme. Allows
+      // tiledb://namespace/s3://bucket/tiledbvcf_array style access
+      std::string array_uri = data_array_uri(root_uri_, false);
+
+      // Set up and submit query
+      array = std::unique_ptr<Array>(new Array(ctx, array_uri, query_type));
+    } catch (const tiledb::TileDBError& ex) {
+      throw std::runtime_error(
+          "Cannot open TileDB-VCF vcf headers; dataset '" + root_uri_ +
+          "' or its metadata does not exist. TileDB error message: " +
+          std::string(ex.what()));
+    }
+  }
+
+  return array;
+}
+
+std::unordered_map<uint32_t, SafeBCFHdr> TileDBVCFDataset::fetch_vcf_headers_v4(
+    const tiledb::Context& ctx,
+    const std::vector<SampleAndId>& samples,
+    std::unordered_map<std::string, size_t>* lookup_map) const {
+  std::unordered_map<uint32_t, SafeBCFHdr> result;
+
+  if (vcf_header_array_ == nullptr)
+    throw std::runtime_error(
+        "Cannot fetch TileDB-VCF vcf headers; Array object unexpectedly null");
+
+  Query query(ctx, *vcf_header_array_);
 
   if (samples.size() > 0) {
     for (const auto& sample : samples) {
@@ -570,7 +610,7 @@ std::unordered_map<uint32_t, SafeBCFHdr> TileDBVCFDataset::fetch_vcf_headers_v4(
     }
   } else {
     // When no samples are passed grab the first one
-    auto non_empty_domain = array->non_empty_domain_var(0);
+    auto non_empty_domain = vcf_header_array_->non_empty_domain_var(0);
     if (!non_empty_domain.first.empty())
       query.add_range(0, non_empty_domain.first, non_empty_domain.first);
   }
@@ -671,30 +711,12 @@ std::unordered_map<uint32_t, SafeBCFHdr> TileDBVCFDataset::fetch_vcf_headers_v4(
 std::unordered_map<uint32_t, SafeBCFHdr> TileDBVCFDataset::fetch_vcf_headers(
     const tiledb::Context& ctx, const std::vector<SampleAndId>& samples) const {
   std::unordered_map<uint32_t, SafeBCFHdr> result;
-  std::unique_ptr<Array> array;
-  try {
-    // First let's try to open the metadata using proper cloud detection
-    std::string array_uri = vcf_headers_uri(root_uri_, true);
-    // Set up and submit query
-    array = std::unique_ptr<Array>(new Array(ctx, array_uri, TILEDB_READ));
-  } catch (const tiledb::TileDBError& ex) {
-    try {
-      // Fall back to use s3 style paths, this handle datasets that are
-      // registered on the cloud but not with the proper naming scheme. Allows
-      // tiledb://namespace/s3://bucket/tiledbvcf_array style access
-      std::string array_uri = vcf_headers_uri(root_uri_, false);
 
-      // Set up and submit query
-      array = std::unique_ptr<Array>(new Array(ctx, array_uri, TILEDB_READ));
-    } catch (const tiledb::TileDBError& ex) {
-      throw std::runtime_error(
-          "Cannot open TileDB-VCF vcf headers; dataset '" + root_uri_ +
-          "' or its metadata does not exist. TileDB error message: " +
-          std::string(ex.what()));
-    }
-  }
+  if (vcf_header_array_ == nullptr)
+    throw std::runtime_error(
+        "Cannot fetch TileDB-VCF vcf headers; Array object unexpectedly null");
 
-  Query query(ctx, *array);
+  Query query(ctx, *vcf_header_array_);
 
   std::unordered_map<uint32_t, std::string> sample_name_mapping;
   for (const auto& sample : samples) {
@@ -901,27 +923,10 @@ TileDBVCFDataset::contig_from_column(uint32_t col) const {
   return {contig_offset, contig_length, contig};
 }
 
-TileDBVCFDataset::Metadata TileDBVCFDataset::read_metadata_v4(
+void TileDBVCFDataset::read_metadata_v4(
     const Context& ctx, const std::string& root_uri) {
-  std::unique_ptr<Array> data_array;
-  try {
-    // First let's try to open the metadata using proper cloud detection
-    data_array.reset(
-        new Array(ctx, data_array_uri(root_uri, true), TILEDB_READ));
-  } catch (const tiledb::TileDBError& ex) {
-    try {
-      // Fall back to use s3 style paths, this handle datasets that are
-      // registered on the cloud but not with the proper naming scheme. Allows
-      // tiledb://namespace/s3://bucket/tiledbvcf_array style access
-      data_array.reset(
-          new Array(ctx, data_array_uri(root_uri, false), TILEDB_READ));
-    } catch (const tiledb::TileDBError& ex) {
-      throw std::runtime_error(
-          "Cannot open TileDB-VCF dataset; dataset '" + root_uri +
-          "' or its metadata does not exist. TileDB error message: " +
-          std::string(ex.what()));
-    }
-  }
+  if (data_array_ == nullptr)
+    throw std::runtime_error( "Cannot open TileDB-VCF dataset; dataset '" + root_uri + "' or its metadata does not exist.);
 
   Metadata metadata;
 
@@ -930,31 +935,32 @@ TileDBVCFDataset::Metadata TileDBVCFDataset::read_metadata_v4(
                                 const std::string& name,
                                 tiledb_datatype_t expected_dtype,
                                 void* dest) {
-    const void* ptr = nullptr;
-    tiledb_datatype_t dtype;
-    uint32_t value_num = 0;
-    data_array->get_metadata(name, &dtype, &value_num, &ptr);
-    if (dtype != expected_dtype || ptr == nullptr)
-      throw std::runtime_error(
-          "Error loading metadata; '" + name + "' field has invalid value.");
-    std::memcpy(dest, ptr, tiledb_datatype_size(dtype) * value_num);
+      const void* ptr = nullptr;
+      tiledb_datatype_t dtype;
+      uint32_t value_num = 0;
+      data_array->get_metadata(name, &dtype, &value_num, &ptr);
+      if (dtype != expected_dtype || ptr == nullptr)
+        throw std::runtime_error(
+            "Error loading metadata; '" + name + "' field has invalid value.");
+      std::memcpy(dest, ptr, tiledb_datatype_size(dtype) * value_num);
   };
 
   /** Helper function to read a CSV string metadata value. */
   const auto get_csv_md_value = [&data_array](
                                     const std::string& name,
                                     std::vector<std::string>* result) {
-    const void* ptr = nullptr;
-    tiledb_datatype_t dtype;
-    uint32_t value_num = 0;
-    data_array->get_metadata(name, &dtype, &value_num, &ptr);
-    if (ptr != nullptr) {
-      if (dtype != TILEDB_CHAR)
-        throw std::runtime_error(
-            "Error loading metadata; '" + name + "' field has invalid value.");
-      std::string b64_str(static_cast<const char*>(ptr), value_num);
-      *result = utils::split(base64_decode(b64_str), ',');
-    }
+      const void* ptr = nullptr;
+      tiledb_datatype_t dtype;
+      uint32_t value_num = 0;
+      data_array->get_metadata(name, &dtype, &value_num, &ptr);
+      if (ptr != nullptr) {
+        if (dtype != TILEDB_CHAR)
+          throw std::runtime_error(
+              "Error loading metadata; '" + name +
+              "' field has invalid value.");
+        std::string b64_str(static_cast<const char*>(ptr), value_num);
+        *result = utils::split(base64_decode(b64_str), ',');
+      }
   };
 
   get_md_value("version", TILEDB_UINT32, &metadata.version);
@@ -969,14 +975,15 @@ TileDBVCFDataset::Metadata TileDBVCFDataset::read_metadata_v4(
   // Derive the sample id -> name map.
   metadata.sample_names.resize(metadata.all_samples.size());
   for (size_t i = 0; i < metadata.all_samples.size(); i++) {
-    metadata.sample_names[i] = metadata.all_samples[i];
-    metadata.sample_ids[metadata.all_samples[i]] = i;
+      metadata.sample_names[i] = metadata.all_samples[i];
+      metadata.sample_ids[metadata.all_samples[i]] = i;
   }
 
-  return metadata;
+  metadata_ = metadata;
+  return;
 }
 
-TileDBVCFDataset::Metadata TileDBVCFDataset::read_metadata(
+void TileDBVCFDataset::read_metadata(
     const Context& ctx, const std::string& root_uri) {
   std::unique_ptr<Array> data_array;
   try {
@@ -1078,7 +1085,7 @@ TileDBVCFDataset::Metadata TileDBVCFDataset::read_metadata(
   for (const auto& pair : metadata.sample_ids)
     metadata.sample_names[pair.second] = pair.first;
 
-  return metadata;
+  metadata_ = metadata;
 }
 
 void TileDBVCFDataset::write_metadata(
@@ -1444,32 +1451,14 @@ std::vector<std::string> TileDBVCFDataset::get_all_samples_from_vcf_headers(
     const Context& ctx, const std::string& root_uri) {
   std::vector<std::string> result;
 
-  std::unique_ptr<Array> array;
-  try {
-    // First let's try to open the metadata using proper cloud detection
-    std::string array_uri = vcf_headers_uri(root_uri, true);
-    // Set up and submit query
-    array.reset(new Array(ctx, array_uri, TILEDB_READ));
-  } catch (const tiledb::TileDBError& ex) {
-    try {
-      // Fall back to use s3 style paths, this handle datasets that are
-      // registered on the cloud but not with the proper naming scheme. Allows
-      // tiledb://namespace/s3://bucket/tiledbvcf_array style access
-      std::string array_uri = vcf_headers_uri(root_uri, false);
+  if (vcf_header_array_ == nullptr)
+    throw std::runtime_error(
+        "Cannot fetch TileDB-VCF samples from vcf header array; Array object "
+        "unexpectedly null");
 
-      // Set up and submit query
-      array.reset(new Array(ctx, array_uri, TILEDB_READ));
-    } catch (const tiledb::TileDBError& ex) {
-      throw std::runtime_error(
-          "Cannot open TileDB-VCF vcf headers; dataset '" + root_uri +
-          "' or its metadata does not exist. TileDB error message: " +
-          std::string(ex.what()));
-    }
-  }
+  Query query(ctx, *vcf_header_array_);
 
-  Query query(ctx, *array);
-
-  auto non_empty_domain = array->non_empty_domain_var(0);
+  auto non_empty_domain = vcf_header_array_->non_empty_domain_var(0);
   if (non_empty_domain.first.empty() && non_empty_domain.second.empty())
     return {};
   query.add_range(0, non_empty_domain.first, non_empty_domain.second);

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -217,18 +217,15 @@ class TileDBVCFDataset {
   std::string root_uri() const;
 
   std::unordered_map<uint32_t, SafeBCFHdr> fetch_vcf_headers(
-      const tiledb::Context& ctx,
       const std::vector<SampleAndId>& samples) const;
 
   /**
    * Fetch VCF headers
-   * @param ctx TileDB context
    * @param samples List of samples, if list is empty then we'll fetch just one
    * @param lookup_map
    * @return
    */
   std::unordered_map<uint32_t, SafeBCFHdr> fetch_vcf_headers_v4(
-      const tiledb::Context& ctx,
       const std::vector<SampleAndId>& samples,
       std::unordered_map<std::string, size_t>* lookup_map) const;
 
@@ -248,7 +245,7 @@ class TileDBVCFDataset {
    * @param Context contex
    * @return List of all regions and contigs
    */
-  std::vector<Region> all_contigs_v4(const tiledb::Context& ctx) const;
+  std::vector<Region> all_contigs_v4() const;
 
   /**
    * Returns a list of regions, one per contig (spanning the entire contig),
@@ -263,7 +260,7 @@ class TileDBVCFDataset {
    * @param Context contex
    * @return List of all regions and contigs
    */
-  std::list<Region> all_contigs_list_v4(const tiledb::Context& ctx) const;
+  std::list<Region> all_contigs_list_v4() const;
 
   /**
    * Returns a pair of (offset, length) for the contig containing the given
@@ -341,11 +338,9 @@ class TileDBVCFDataset {
   /**
    * Fetch all sample ids from the vcf header array
    *
-   * @param ctx contex
    * @return vector of all sample names
    */
-  std::vector<std::string> get_all_samples_from_vcf_headers(
-      const Context& ctx, const std::string& root_uri);
+  std::vector<std::string> get_all_samples_from_vcf_headers();
 
   std::shared_ptr<tiledb::Array> data_array() const;
 
@@ -527,50 +522,45 @@ class TileDBVCFDataset {
   /**
    * Populate the metadata maps of info/fmt field name -> htslib types.
    */
-  void load_field_type_maps(const tiledb::Context& ctx);
+  void load_field_type_maps();
 
   /**
    * Populate the metadata maps of info/fmt field name -> htslib types.
    */
-  void load_field_type_maps_v4(const tiledb::Context& ctx);
+  void load_field_type_maps_v4();
 
   /**
    * Open the VCF header array
    *
-   * @param ctx tiledb contex
    * @param query_type query type
    * @return Unique ptr to open array
    */
-  std::unique_ptr<tiledb::Array> open_vcf_array(
-      const tiledb::Context& ctx, tiledb_query_type_t query_type);
+  std::unique_ptr<tiledb::Array> open_vcf_array(tiledb_query_type_t query_type);
 
   /**
    * Open the data array
    *
-   * @param ctx tiledb contex
    * @param query_type query type
    * @return Unique ptr to open array
    */
   std::shared_ptr<tiledb::Array> open_data_array(
-      const tiledb::Context& ctx, tiledb_query_type_t query_type);
+      tiledb_query_type_t query_type);
 
   /**
    * Reads the Metadata from a given dataset.
    *
-   * @param ctx TileDB context
    * @param root_uri Root URI of the dataset
    * @return The dataset's Metadata.
    */
-  void read_metadata(const Context& ctx, const std::string& root_uri);
+  void read_metadata();
 
   /**
    * Reads the Metadata from a given dataset.
    *
-   * @param ctx TileDB context
    * @param root_uri Root URI of the dataset
    * @return The dataset's Metadata.
    */
-  void read_metadata_v4(const Context& ctx, const std::string& root_uri);
+  void read_metadata_v4();
 };
 
 }  // namespace vcf

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -343,7 +343,7 @@ class TileDBVCFDataset {
    * @param ctx contex
    * @return vector of all sample names
    */
-  static std::vector<std::string> get_all_samples_from_vcf_headers(
+  std::vector<std::string> get_all_samples_from_vcf_headers(
       const Context& ctx, const std::string& root_uri);
 
  private:
@@ -371,6 +371,14 @@ class TileDBVCFDataset {
 
   /** List of sample names for exporting */
   std::vector<std::vector<char>> sample_names_;
+
+  /** Pointer to hold an open vcf header array. This avoid opening the array
+   * multiple times in multiple places */
+  std::unique_ptr<tiledb::Array> vcf_header_array_;
+
+  /** Pointer to hold an open data array. This avoid opening the array multiple
+   * times in multiple places */
+  std::unique_ptr<tiledb::Array> data_array_;
 
   /* ********************************* */
   /*          STATIC METHODS           */
@@ -452,26 +460,6 @@ class TileDBVCFDataset {
       const Metadata& metadata);
 
   /**
-   * Reads the Metadata from a given dataset.
-   *
-   * @param ctx TileDB context
-   * @param root_uri Root URI of the dataset
-   * @return The dataset's Metadata.
-   */
-  static Metadata read_metadata(
-      const Context& ctx, const std::string& root_uri);
-
-  /**
-   * Reads the Metadata from a given dataset.
-   *
-   * @param ctx TileDB context
-   * @param root_uri Root URI of the dataset
-   * @return The dataset's Metadata.
-   */
-  static Metadata read_metadata_v4(
-      const Context& ctx, const std::string& root_uri);
-
-  /**
    * Writes the given sample header data to the separate sample header array in
    * the dataset.
    *
@@ -536,6 +524,44 @@ class TileDBVCFDataset {
    * Populate the metadata maps of info/fmt field name -> htslib types.
    */
   void load_field_type_maps_v4(const tiledb::Context& ctx);
+
+  /**
+   * Open the VCF header array
+   *
+   * @param ctx tiledb contex
+   * @param query_type query type
+   * @return Unique ptr to open array
+   */
+  std::unique_ptr<tiledb::Array> open_vcf_array(
+      const tiledb::Context& ctx, tiledb_query_type_t query_type);
+
+  /**
+   * Open the data array
+   *
+   * @param ctx tiledb contex
+   * @param query_type query type
+   * @return Unique ptr to open array
+   */
+  std::unique_ptr<tiledb::Array> open_data_array(
+      const tiledb::Context& ctx, tiledb_query_type_t query_type);
+
+  /**
+   * Reads the Metadata from a given dataset.
+   *
+   * @param ctx TileDB context
+   * @param root_uri Root URI of the dataset
+   * @return The dataset's Metadata.
+   */
+  void read_metadata(const Context& ctx, const std::string& root_uri);
+
+  /**
+   * Reads the Metadata from a given dataset.
+   *
+   * @param ctx TileDB context
+   * @param root_uri Root URI of the dataset
+   * @return The dataset's Metadata.
+   */
+  void read_metadata_v4(const Context& ctx, const std::string& root_uri);
 };
 
 }  // namespace vcf

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -196,6 +196,7 @@ class TileDBVCFDataset {
   /* ********************************* */
 
   TileDBVCFDataset();
+  ~TileDBVCFDataset();
 
   static void create(const CreationParams& params);
 
@@ -346,6 +347,8 @@ class TileDBVCFDataset {
   std::vector<std::string> get_all_samples_from_vcf_headers(
       const Context& ctx, const std::string& root_uri);
 
+  std::shared_ptr<tiledb::Array> data_array() const;
+
  private:
   /* ********************************* */
   /*          PRIVATE ATTRIBUTES       */
@@ -378,7 +381,13 @@ class TileDBVCFDataset {
 
   /** Pointer to hold an open data array. This avoid opening the array multiple
    * times in multiple places */
-  std::unique_ptr<tiledb::Array> data_array_;
+  std::shared_ptr<tiledb::Array> data_array_;
+
+  /** TileDB config used for open dataset */
+  tiledb::Config cfg_;
+
+  /** TileDB Context for dataset */
+  tiledb::Context ctx_;
 
   /* ********************************* */
   /*          STATIC METHODS           */
@@ -542,7 +551,7 @@ class TileDBVCFDataset {
    * @param query_type query type
    * @return Unique ptr to open array
    */
-  std::unique_ptr<tiledb::Array> open_data_array(
+  std::shared_ptr<tiledb::Array> open_data_array(
       const tiledb::Context& ctx, tiledb_query_type_t query_type);
 
   /**

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -441,10 +441,6 @@ bool Reader::next_read_batch() {
         &read_state_.current_hdrs_lookup);
   }
 
-  // Reopen the array so that irrelevant fragment metadata is unloaded.
-  read_state_.array.reset(nullptr);
-  read_state_.array.reset(new Array(*ctx_, dataset_->data_uri(), TILEDB_READ));
-
   // Set up the TileDB query
   read_state_.query.reset(new Query(*ctx_, *read_state_.array));
 

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -434,13 +434,11 @@ bool Reader::next_read_batch() {
   if (dataset_->metadata().version == TileDBVCFDataset::Version::V2 ||
       dataset_->metadata().version == TileDBVCFDataset::Version::V3) {
     read_state_.current_hdrs =
-        dataset_->fetch_vcf_headers(*ctx_, read_state_.current_sample_batches);
+        dataset_->fetch_vcf_headers(read_state_.current_sample_batches);
   } else {
     assert(dataset_->metadata().version == TileDBVCFDataset::Version::V4);
     read_state_.current_hdrs = dataset_->fetch_vcf_headers_v4(
-        *ctx_,
-        read_state_.current_sample_batches,
-        &read_state_.current_hdrs_lookup);
+        read_state_.current_sample_batches, &read_state_.current_hdrs_lookup);
   }
 
   // Set up the TileDB query
@@ -1231,8 +1229,7 @@ std::vector<SampleAndId> Reader::prepare_sample_names_v4() const {
 
   // No specified samples means all samples.
   if (result.empty()) {
-    const auto& samples =
-        dataset_->get_all_samples_from_vcf_headers(*ctx_, dataset_->root_uri());
+    const auto& samples = dataset_->get_all_samples_from_vcf_headers();
     for (const auto& s : samples) {
       result.push_back({.sample_name = s, .sample_id = 0});
     }
@@ -1285,7 +1282,7 @@ void Reader::prepare_regions_v4(
         dataset_->metadata().version == TileDBVCFDataset::Version::V3)
       pre_partition_regions_list = dataset_->all_contigs_list();
     else {
-      pre_partition_regions_list = dataset_->all_contigs_list_v4(*ctx_);
+      pre_partition_regions_list = dataset_->all_contigs_list_v4();
     }
   }
 

--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -408,7 +408,7 @@ class Reader {
     uint64_t last_num_records_exported = 0;
 
     /** Underlying TileDB array. */
-    std::unique_ptr<Array> array;
+    std::shared_ptr<Array> array;
 
     /** TileDB query object. */
     std::unique_ptr<Query> query;

--- a/libtiledbvcf/test/src/unit-vcf-store.cc
+++ b/libtiledbvcf/test/src/unit-vcf-store.cc
@@ -107,7 +107,7 @@ TEST_CASE("TileDB-VCF: Test register", "[tiledbvcf][ingest]") {
         ds.metadata().sample_names,
         Catch::Matchers::VectorContains(std::string("HG01762")));
 
-    auto hdrs = ds.fetch_vcf_headers_v4(ctx, {{"HG01762", 0}}, nullptr);
+    auto hdrs = ds.fetch_vcf_headers_v4({{"HG01762", 0}}, nullptr);
     REQUIRE(hdrs.size() == 1);
     REQUIRE(bcf_hdr_nsamples(hdrs.at(0)) == 1);
     REQUIRE(hdrs.at(0)->samples[0] == std::string("HG01762"));
@@ -141,7 +141,7 @@ TEST_CASE("TileDB-VCF: Test register", "[tiledbvcf][ingest]") {
         ds.metadata().sample_names, Catch::Matchers::Contains(samples));
 
     auto hdrs =
-        ds.fetch_vcf_headers_v4(ctx, {{"HG01762", 0}, {"HG00280", 1}}, nullptr);
+        ds.fetch_vcf_headers_v4({{"HG01762", 0}, {"HG00280", 1}}, nullptr);
     REQUIRE(hdrs.size() == 2);
     std::vector<std::string> expected_samples = {"HG01762", "HG00280"};
     std::vector<std::string> result_samples = {


### PR DESCRIPTION
This PR reduces the number of times we open an array. First we stop reopening the array for every TileDB query (read partition). Next we create TileDBVCFDataset class members to hold the open VCF header and data arrays so we don't have to open those in multiple places.

If the user has a lot of fragment and not consolidated the fragment metadata opening the array can be costly. While the user should consolidate the fragment metadata, we can also avoid opening the array so many times to help.