### PR TITLE
Add option for enable/disable of vcf header stats

### DIFF
--- a/libtiledbvcf/src/c_api/tiledbvcf.cc
+++ b/libtiledbvcf/src/c_api/tiledbvcf.cc
@@ -377,6 +377,33 @@ int32_t tiledb_vcf_reader_get_tiledb_stats_enabled(
   return TILEDB_VCF_OK;
 }
 
+int32_t tiledb_vcf_reader_set_tiledb_stats_enabled_vcf_header_array(
+    tiledb_vcf_reader_t* reader, const bool stats_enabled) {
+  if (sanity_check(reader) == TILEDB_VCF_ERR)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          reader,
+          reader->reader_->set_tiledb_stats_enabled_vcf_header_array(
+              stats_enabled)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
+int32_t tiledb_vcf_reader_get_tiledb_stats_enabled_vcf_header_array(
+    tiledb_vcf_reader_t* reader, bool* enabled) {
+  if (sanity_check(reader) == TILEDB_VCF_ERR)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          reader,
+          reader->reader_->tiledb_stats_enabled_vcf_header_array(enabled)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
 int32_t tiledb_vcf_reader_get_tiledb_stats(
     tiledb_vcf_reader_t* reader, char** stats) {
   if (sanity_check(reader) == TILEDB_VCF_ERR)
@@ -879,6 +906,33 @@ int32_t tiledb_vcf_writer_get_tiledb_stats_enabled(
     return TILEDB_VCF_ERR;
 
   if (SAVE_ERROR_CATCH(writer, writer->writer_->tiledb_stats_enabled(enabled)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
+int32_t tiledb_vcf_writer_set_tiledb_stats_enabled_vcf_header_array(
+    tiledb_vcf_writer_t* writer, const bool stats_enabled) {
+  if (sanity_check(writer) == TILEDB_VCF_ERR)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          writer,
+          writer->writer_->set_tiledb_stats_enabled_vcf_header_array(
+              stats_enabled)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
+int32_t tiledb_vcf_writer_get_tiledb_stats_enabled_vcf_header_array(
+    tiledb_vcf_writer_t* writer, bool* enabled) {
+  if (sanity_check(writer) == TILEDB_VCF_ERR)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          writer,
+          writer->writer_->tiledb_stats_enabled_vcf_header_array(enabled)))
     return TILEDB_VCF_ERR;
 
   return TILEDB_VCF_OK;

--- a/libtiledbvcf/src/c_api/tiledbvcf.h
+++ b/libtiledbvcf/src/c_api/tiledbvcf.h
@@ -566,6 +566,30 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_tiledb_stats_enabled(
     tiledb_vcf_reader_t* reader, bool* stats_enabled);
 
 /**
+ * Sets whether TileDB internal statistics should be enabled or not for vcf
+ * header array.
+ *
+ * @param reader VCF reader object
+ * @param tiledb_stats_enabled whether to enable stats or not, default is false
+ * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
+ */
+TILEDBVCF_EXPORT int32_t
+tiledb_vcf_reader_set_tiledb_stats_enabled_vcf_header_array(
+    tiledb_vcf_reader_t* reader, const bool stats_enabled);
+
+/**
+ * Gets whether TileDB internal statistics should be enabled or not for vcf
+ * header array.
+ *
+ * @param reader VCF reader object
+ * @param tiledb_stats_enabled whether to enable stats or not
+ * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
+ */
+TILEDBVCF_EXPORT int32_t
+tiledb_vcf_reader_get_tiledb_stats_enabled_vcf_header_array(
+    tiledb_vcf_reader_t* reader, bool* stats_enabled);
+
+/**
  * Gets TileDB internal statistics as a string
  *
  * @param reader VCF reader object
@@ -1018,6 +1042,30 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_get_tiledb_stats_enabled(
  */
 TILEDBVCF_EXPORT int32_t
 tiledb_vcf_writer_get_tiledb_stats(tiledb_vcf_writer_t* writer, char** stats);
+
+/**
+ * Sets whether TileDB internal statistics should be enabled or not for vcf
+ * header array access.
+ *
+ * @param writer VCF writer object
+ * @param tiledb_stats_enabled whether to enable stats or not, default is false
+ * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
+ */
+TILEDBVCF_EXPORT int32_t
+tiledb_vcf_writer_set_tiledb_stats_enabled_vcf_header_array(
+    tiledb_vcf_writer_t* writer, const bool stats_enabled);
+
+/**
+ * Gets whether TileDB internal statistics should be enabled or not for vcf
+ * header array access.
+ *
+ * @param writer VCF writer object
+ * @param tiledb_stats_enabled whether to enable stats or not
+ * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
+ */
+TILEDBVCF_EXPORT int32_t
+tiledb_vcf_writer_get_tiledb_stats_enabled_vcf_header_array(
+    tiledb_vcf_writer_t* writer, bool* stats_enabled);
 
 /**
  * Returns the version number of the TileDB VCF dataset.

--- a/libtiledbvcf/src/cli/tiledbvcf.cc
+++ b/libtiledbvcf/src/cli/tiledbvcf.cc
@@ -360,7 +360,10 @@ int main(int argc, char** argv) {
            (values("paths", store_args.sample_uris) %
             "Argument list of VCF files to ingest"),
        option("--stats").set(store_args.tiledb_stats_enabled) %
-           "Enable TileDB stats");
+           "Enable TileDB stats",
+       option("--stats-vcf-header-array")
+               .set(store_args.tiledb_stats_enabled_vcf_header_array) %
+           "Enable TileDB stats for vcf header array usage");
 
   ExportParams export_args;
   export_args.export_to_disk = true;
@@ -459,7 +462,10 @@ int main(int argc, char** argv) {
            export_args.sample_names = utils::split(s, ',');
          }))),
        option("--stats").set(export_args.tiledb_stats_enabled) %
-           "Enable TileDB stats");
+           "Enable TileDB stats",
+       option("--stats-vcf-header-array")
+               .set(export_args.tiledb_stats_enabled_vcf_header_array) %
+           "Enable TileDB stats for vcf header array usage");
 
   ListParams list_args;
   auto list_mode =

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -344,6 +344,31 @@ class TileDBVCFDataset {
 
   std::shared_ptr<tiledb::Array> data_array() const;
 
+  /**
+   * Returns if the core tiledb stats are enabled or not
+   * @return tiledb stats enabled
+   */
+  const bool tiledb_stats_enabled() const;
+
+  /**
+   * Sets whether the core tiledb stats are enabled or not
+   * @param stats_enabled
+   */
+  void set_tiledb_stats_enabled(const bool stats_enabled);
+
+  /**
+   * Retuns if core tiledb stats are enabled or not for the vcf header array
+   * @return stats enabled for vcf header array
+   */
+  const bool tiledb_stats_enabled_vcf_header() const;
+
+  /**
+   * Sets whether the core tiledb stats are enabled or not for the vcf header
+   * array
+   * @param stats_enabled
+   */
+  void set_tiledb_stats_enabled_vcf_header(const bool stats_enabled);
+
  private:
   /* ********************************* */
   /*          PRIVATE ATTRIBUTES       */
@@ -383,6 +408,12 @@ class TileDBVCFDataset {
 
   /** TileDB Context for dataset */
   tiledb::Context ctx_;
+
+  /** TileDB stats enablement */
+  bool tiledb_stats_enabled_;
+
+  /** TileDB stats enablement for vcf header array */
+  bool tiledb_stats_enabled_vcf_header_;
 
   /* ********************************* */
   /*          STATIC METHODS           */

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -185,8 +185,16 @@ void Reader::set_tiledb_stats_enabled(bool stats_enabled) {
   params_.tiledb_stats_enabled = stats_enabled;
 }
 
-void Reader::tiledb_stats_enabled(bool* enabled) {
+void Reader::tiledb_stats_enabled(bool* enabled) const {
   *enabled = params_.tiledb_stats_enabled;
+}
+
+void Reader::set_tiledb_stats_enabled_vcf_header_array(bool stats_enabled) {
+  params_.tiledb_stats_enabled_vcf_header_array = stats_enabled;
+}
+
+void Reader::tiledb_stats_enabled_vcf_header_array(bool* enabled) const {
+  *enabled = params_.tiledb_stats_enabled_vcf_header_array;
 }
 
 void Reader::tiledb_stats(char** stats) {
@@ -270,6 +278,9 @@ void Reader::get_buffer_validity_bitmap(
 }
 
 void Reader::read() {
+  dataset_->set_tiledb_stats_enabled(params_.tiledb_stats_enabled);
+  dataset_->set_tiledb_stats_enabled_vcf_header(
+      params_.tiledb_stats_enabled_vcf_header_array);
   // If the user requests stats, enable them on read
   // Multiple calls to enable stats has no effect
   if (params_.tiledb_stats_enabled) {
@@ -465,7 +476,8 @@ bool Reader::next_read_batch_v2_v3() {
   read_state_.query->set_layout(TILEDB_UNORDERED);
   if (params_.verbose) {
     std::cout << "Initialized TileDB query with "
-              << read_state_.query_regions.size() << " column ranges."
+              << read_state_.query_regions.size() << " start_pos ranges, "
+              << read_state_.current_sample_batches.size() << " sample ranges."
               << std::endl;
   }
 
@@ -549,14 +561,16 @@ bool Reader::next_read_batch_v4() {
               << read_state_
                      .query_regions_v4[read_state_.query_contig_batch_idx]
                      .second.size()
-              << " column ranges"
+              << " start_pos ranges,"
+              << read_state_.current_sample_batches.size() << " samples"
               << " for contig "
               << read_state_
                      .query_regions_v4[read_state_.query_contig_batch_idx]
                      .first
               << " (contig batch " << read_state_.query_contig_batch_idx + 1
-              << "/" << read_state_.query_regions_v4.size() << ")."
-              << std::endl;
+              << "/" << read_state_.query_regions_v4.size() << ", sample batch "
+              << read_state_.batch_idx + 1 << "/"
+              << read_state_.sample_batches.size() << ")." << std::endl;
   }
 
   return true;

--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -81,6 +81,7 @@ struct ExportParams {
   uint64_t max_num_records = std::numeric_limits<uint64_t>::max();
   std::vector<std::string> tiledb_config;
   bool tiledb_stats_enabled = false;
+  bool tiledb_stats_enabled_vcf_header_array = false;
 
   // Memory/performance params:
   unsigned memory_budget_mb = 2 * 1024;
@@ -202,7 +203,13 @@ class Reader {
   void set_tiledb_stats_enabled(bool stats_enabled);
 
   /** Returns if tiledb stats are enabled */
-  void tiledb_stats_enabled(bool* enabled);
+  void tiledb_stats_enabled(bool* enabled) const;
+
+  /** Enable tiledb stats for the vcf header array */
+  void set_tiledb_stats_enabled_vcf_header_array(bool stats_enabled);
+
+  /** Returns if tiledb stats are enabled for the vcf header array */
+  void tiledb_stats_enabled_vcf_header_array(bool* enabled) const;
 
   /** Fetches tiledb stats as a string */
   void tiledb_stats(char** stats);

--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -167,10 +167,13 @@ void Writer::register_samples() {
 
 void Writer::ingest_samples() {
   auto start_all = std::chrono::steady_clock::now();
+  dataset_->set_tiledb_stats_enabled(ingestion_params_.tiledb_stats_enabled);
+  dataset_->set_tiledb_stats_enabled_vcf_header(
+      ingestion_params_.tiledb_stats_enabled_vcf_header_array);
 
   // If the user requests stats, enable them on read
   // Multiple calls to enable stats has no effect
-  if (this->ingestion_params_.tiledb_stats_enabled) {
+  if (ingestion_params_.tiledb_stats_enabled) {
     tiledb::Stats::enable();
   } else {
     // Else we will make sure they are disable and reset
@@ -585,8 +588,16 @@ void Writer::set_tiledb_stats_enabled(bool stats_enabled) {
   this->ingestion_params_.tiledb_stats_enabled = stats_enabled;
 }
 
-void Writer::tiledb_stats_enabled(bool* enabled) {
+void Writer::tiledb_stats_enabled(bool* enabled) const {
   *enabled = this->ingestion_params_.tiledb_stats_enabled;
+}
+
+void Writer::set_tiledb_stats_enabled_vcf_header_array(bool stats_enabled) {
+  this->ingestion_params_.tiledb_stats_enabled_vcf_header_array = stats_enabled;
+}
+
+void Writer::tiledb_stats_enabled_vcf_header_array(bool* enabled) const {
+  *enabled = this->ingestion_params_.tiledb_stats_enabled_vcf_header_array;
 }
 
 void Writer::tiledb_stats(char** stats) {

--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -66,7 +66,7 @@ void Writer::init(const std::string& uri, const std::string& config_str) {
     tiledb_config = registration_params_.tiledb_config;
 
   try {
-    dataset_->open(uri, ingestion_params_.tiledb_config);
+    dataset_->open(uri, tiledb_config);
   } catch (std::exception& e) {
     // If the dataset doesn't exist lets not error out, the user might be
     // creating a new dataset
@@ -79,7 +79,12 @@ void Writer::init(const IngestionParams& params) {
   array_.reset(nullptr);
 
   dataset_.reset(new TileDBVCFDataset);
-  dataset_->open(ingestion_params_.uri, ingestion_params_.tiledb_config);
+
+  dataset_->set_tiledb_stats_enabled(params.tiledb_stats_enabled);
+  dataset_->set_tiledb_stats_enabled_vcf_header(
+      params.tiledb_stats_enabled_vcf_header_array);
+
+  dataset_->open(params.uri, params.tiledb_config);
 
   tiledb_config_.reset(new Config);
   (*tiledb_config_)["vfs.s3.multipart_part_size"] =
@@ -167,9 +172,6 @@ void Writer::register_samples() {
 
 void Writer::ingest_samples() {
   auto start_all = std::chrono::steady_clock::now();
-  dataset_->set_tiledb_stats_enabled(ingestion_params_.tiledb_stats_enabled);
-  dataset_->set_tiledb_stats_enabled_vcf_header(
-      ingestion_params_.tiledb_stats_enabled_vcf_header_array);
 
   // If the user requests stats, enable them on read
   // Multiple calls to enable stats has no effect

--- a/libtiledbvcf/src/write/writer.h
+++ b/libtiledbvcf/src/write/writer.h
@@ -60,6 +60,7 @@ struct IngestionParams {
   uint64_t max_record_buffer_size = 50000;
   std::vector<std::string> tiledb_config;
   bool tiledb_stats_enabled = false;
+  bool tiledb_stats_enabled_vcf_header_array = false;
 
   /**
    * Max length (# columns) of an ingestion "task". This value is derived
@@ -177,7 +178,13 @@ class Writer {
   void set_tiledb_stats_enabled(bool stats_enabled);
 
   /** Returns if tiledb stats are enabled */
-  void tiledb_stats_enabled(bool* enabled);
+  void tiledb_stats_enabled(bool* enabled) const;
+
+  /** Enable tiledb stats for the vcf header array */
+  void set_tiledb_stats_enabled_vcf_header_array(bool stats_enabled);
+
+  /** Returns if tiledb stats are enabled for the vcf header array */
+  void tiledb_stats_enabled_vcf_header_array(bool* enabled) const;
 
   /** Fetches tiledb stats as a string */
   void tiledb_stats(char** stats);


### PR DESCRIPTION
By default we will not longer collect tiledb statistics for the vcf header access. Most of the time this just pollutes the TileDB stats when trying to inspect the data array access.

Depends on #210 due to conflicts