### PR TITLE
Ingestion improvements

### DIFF
--- a/libtiledbvcf/src/cli/tiledbvcf.cc
+++ b/libtiledbvcf/src/cli/tiledbvcf.cc
@@ -341,6 +341,12 @@ int main(int argc, char** argv) {
                    "memory consumption.",
                    store_args.thread_task_size) &
            value("N", store_args.thread_task_size),
+       option("-b", "--mem-budget-mb") %
+               defaulthelp(
+                   "The total memory budget (MB) used when submitting TileDB "
+                   "queries.",
+                   store_args.max_tiledb_buffer_size_mb) &
+           value("MB", store_args.max_tiledb_buffer_size_mb),
        option("-v", "--verbose").set(store_args.verbose) %
            "Enable verbose output",
        option("--remove-sample-file").set(store_args.remove_samples_file) %

--- a/libtiledbvcf/src/vcf/vcf_v4.h
+++ b/libtiledbvcf/src/vcf/vcf_v4.h
@@ -192,6 +192,9 @@ class VCFV4 {
 
   /** Swap all fields with the given VCFV3 instance. */
   void swap(VCFV4& other);
+
+  /** name of contig last seeked to. */
+  std::string seeked_contig_name_;
 };
 
 }  // namespace vcf

--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -429,6 +429,12 @@ std::pair<uint64_t, uint64_t> Writer::ingest_samples(
             throw std::runtime_error(
                 "Error submitting TileDB write query; unexpected query "
                 "status.");
+
+          if (ingestion_params_.verbose)
+            std::cout << "Writing " << worker->records_buffered()
+                      << " for contig " << worker->region().seq_name
+                      << " (task " << i << " / " << tasks.size() << ")"
+                      << std::endl;
         }
         records_ingested += worker->records_buffered();
         anchors_ingested += worker->anchors_buffered();

--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -315,6 +315,8 @@ std::pair<uint64_t, uint64_t> Writer::ingest_samples(
     }
 
     workers[i]->init(*dataset_, params, samples);
+    workers[i]->set_max_total_buffer_size_bytes(
+        params.max_tiledb_buffer_size_mb * 1024 * 1024);
   }
 
   // First compose the set of contigs that are nonempty.

--- a/libtiledbvcf/src/write/writer.h
+++ b/libtiledbvcf/src/write/writer.h
@@ -57,6 +57,7 @@ struct IngestionParams {
   bool verbose = false;
   ScratchSpaceInfo scratch_space;
   bool remove_samples_file = false;
+  // Max number of VCF records to read into memory
   uint64_t max_record_buffer_size = 50000;
   std::vector<std::string> tiledb_config;
   bool tiledb_stats_enabled = false;
@@ -67,6 +68,9 @@ struct IngestionParams {
    * parallelism as well as load balancing of ingestion work across threads.
    */
   unsigned thread_task_size = 5000000;
+
+  // Max size of TileDB buffers before flushing. Defaults to 1GB
+  uint64_t max_tiledb_buffer_size_mb = 1024;
 };
 
 /* ********************************* */

--- a/libtiledbvcf/src/write/writer_worker.h
+++ b/libtiledbvcf/src/write/writer_worker.h
@@ -95,12 +95,27 @@ class WriterWorker {
   /** Returns the number of anchors buffered by the last parse operation. */
   virtual uint64_t anchors_buffered() const = 0;
 
+  /**
+   * Return region set for worker
+   * @return Region
+   */
   Region region() const {
     return region_;
   }
 
   /** Region being parsed. */
   Region region_;
+
+  /** max bytes to buffer before flushing to TileDB. */
+  uint64_t max_total_buffer_size_bytes_;
+
+  /**
+   * Set the max buffer size in bytes for worker
+   * @param size
+   */
+  void set_max_total_buffer_size_bytes(uint64_t size) {
+    max_total_buffer_size_bytes_ = size;
+  }
 };
 
 }  // namespace vcf

--- a/libtiledbvcf/src/write/writer_worker.h
+++ b/libtiledbvcf/src/write/writer_worker.h
@@ -94,6 +94,13 @@ class WriterWorker {
 
   /** Returns the number of anchors buffered by the last parse operation. */
   virtual uint64_t anchors_buffered() const = 0;
+
+  Region region() const {
+    return region_;
+  }
+
+  /** Region being parsed. */
+  Region region_;
 };
 
 }  // namespace vcf

--- a/libtiledbvcf/src/write/writer_worker_v2.cc
+++ b/libtiledbvcf/src/write/writer_worker_v2.cc
@@ -283,7 +283,7 @@ bool WriterWorkerV2::buffer_record(
 
   // TODO: make this max buffer size check a parameter.
   const uint64_t buffer_size = buffers_.total_size();
-  if (buffer_size > ((uint64_t)1 * 1024 * 1024 * 1024)) {
+  if (buffer_size > max_total_buffer_size_bytes_) {
     return false;
   }
 

--- a/libtiledbvcf/src/write/writer_worker_v2.h
+++ b/libtiledbvcf/src/write/writer_worker_v2.h
@@ -116,9 +116,6 @@ class WriterWorkerV2 : public WriterWorker {
   /** Current number of anchors buffered. */
   uint64_t anchors_buffered_;
 
-  /** Region being parsed. */
-  Region region_;
-
   /** Record heap for sorting records across samples. */
   RecordHeapV2 record_heap_;
 

--- a/libtiledbvcf/src/write/writer_worker_v3.cc
+++ b/libtiledbvcf/src/write/writer_worker_v3.cc
@@ -314,7 +314,7 @@ bool WriterWorkerV3::buffer_record(
 
   // TODO: make this max buffer size check a parameter.
   const uint64_t buffer_size = buffers_.total_size();
-  if (buffer_size > ((uint64_t)1 * 1024 * 1024 * 1024)) {
+  if (buffer_size > max_total_buffer_size_bytes_) {
     return false;
   }
 

--- a/libtiledbvcf/src/write/writer_worker_v3.h
+++ b/libtiledbvcf/src/write/writer_worker_v3.h
@@ -117,9 +117,6 @@ class WriterWorkerV3 : public WriterWorker {
   /** Current number of anchors buffered. */
   uint64_t anchors_buffered_;
 
-  /** Region being parsed. */
-  Region region_;
-
   /** Record heap for sorting records across samples. */
   RecordHeapV3 record_heap_;
 

--- a/libtiledbvcf/src/write/writer_worker_v4.cc
+++ b/libtiledbvcf/src/write/writer_worker_v4.cc
@@ -319,7 +319,7 @@ bool WriterWorkerV4::buffer_record(const RecordHeapV4::Node& node) {
 
   // TODO: make this max buffer size check a parameter.
   const uint64_t buffer_size = buffers_.total_size();
-  if (buffer_size > ((uint64_t)1 * 1024 * 1024 * 1024)) {
+  if (buffer_size > max_total_buffer_size_bytes_) {
     return false;
   }
 

--- a/libtiledbvcf/src/write/writer_worker_v4.h
+++ b/libtiledbvcf/src/write/writer_worker_v4.h
@@ -117,9 +117,6 @@ class WriterWorkerV4 : public WriterWorker {
   /** Current number of anchors buffered. */
   uint64_t anchors_buffered_;
 
-  /** Region being parsed. */
-  Region region_;
-
   /** Record heap for sorting records across samples. */
   RecordHeapV4 record_heap_;
 


### PR DESCRIPTION
This PR adds 3 improvements to ingestion:

1) A new memory budget parameter for setting the max size of the TileDB query buffer for write
2) Store the contig used for seek on the VCF record
3) Add more verbose output on ingestion to show the write counts
