### PR TITLE
Set the contig for ingestion on seek of VCF file

### DIFF
--- a/libtiledbvcf/src/vcf/vcf_v4.h
+++ b/libtiledbvcf/src/vcf/vcf_v4.h
@@ -192,6 +192,9 @@ class VCFV4 {
 
   /** Swap all fields with the given VCFV3 instance. */
   void swap(VCFV4& other);
+
+  /** name of contig last seeked to. */
+  std::string seeked_contig_name_;
 };
 
 }  // namespace vcf


### PR DESCRIPTION
Previously it was possible for the VCF record to read beyond the contig seeked too. If the queue was empty then then vcf class would resume reading but it always checked the first record's contig. This might be a different contig then the record was suppose to be tracking.