### PR TITLE
Add write message for verbose ingestion

### DIFF
--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -429,6 +429,12 @@ std::pair<uint64_t, uint64_t> Writer::ingest_samples(
             throw std::runtime_error(
                 "Error submitting TileDB write query; unexpected query "
                 "status.");
+
+          if (ingestion_params_.verbose)
+            std::cout << "Recorded " << worker->records_buffered()
+                      << " cells for contig " << worker->region().seq_name
+                      << " (task " << i + 1 << " / " << tasks.size() << ")"
+                      << std::endl;
         }
         records_ingested += worker->records_buffered();
         anchors_ingested += worker->anchors_buffered();

--- a/libtiledbvcf/src/write/writer_worker.h
+++ b/libtiledbvcf/src/write/writer_worker.h
@@ -94,6 +94,13 @@ class WriterWorker {
 
   /** Returns the number of anchors buffered by the last parse operation. */
   virtual uint64_t anchors_buffered() const = 0;
+
+  Region region() const {
+    return region_;
+  }
+
+  /** Region being parsed. */
+  Region region_;
 };
 
 }  // namespace vcf

--- a/libtiledbvcf/src/write/writer_worker_v2.h
+++ b/libtiledbvcf/src/write/writer_worker_v2.h
@@ -116,9 +116,6 @@ class WriterWorkerV2 : public WriterWorker {
   /** Current number of anchors buffered. */
   uint64_t anchors_buffered_;
 
-  /** Region being parsed. */
-  Region region_;
-
   /** Record heap for sorting records across samples. */
   RecordHeapV2 record_heap_;
 

--- a/libtiledbvcf/src/write/writer_worker_v3.h
+++ b/libtiledbvcf/src/write/writer_worker_v3.h
@@ -117,9 +117,6 @@ class WriterWorkerV3 : public WriterWorker {
   /** Current number of anchors buffered. */
   uint64_t anchors_buffered_;
 
-  /** Region being parsed. */
-  Region region_;
-
   /** Record heap for sorting records across samples. */
   RecordHeapV3 record_heap_;
 

--- a/libtiledbvcf/src/write/writer_worker_v4.h
+++ b/libtiledbvcf/src/write/writer_worker_v4.h
@@ -117,9 +117,6 @@ class WriterWorkerV4 : public WriterWorker {
   /** Current number of anchors buffered. */
   uint64_t anchors_buffered_;
 
-  /** Region being parsed. */
-  Region region_;
-
   /** Record heap for sorting records across samples. */
   RecordHeapV4 record_heap_;
 


### PR DESCRIPTION
Add write message for verbose ingestion details. This is similar to the export logs of "processed X cells in Y time".