### PR TITLE
Handle all sample export for v4 with optimal range

### DIFF
--- a/apis/python/tests/test_tiledbvcf.py
+++ b/apis/python/tests/test_tiledbvcf.py
@@ -174,9 +174,11 @@ def test_basic_reads(test_ds):
                 dtype=np.int32,
             ),
         }
-    ).sort_values(by=["sample_name", "pos_start"])
+    ).sort_values(ignore_index=True, by=["sample_name", "pos_start"])
     df = test_ds.read(attrs=["sample_name", "pos_start", "pos_end"])
-    _check_dfs(expected_df, df.sort_values(by=["sample_name", "pos_start"]))
+    _check_dfs(
+        expected_df, df.sort_values(ignore_index=True, by=["sample_name", "pos_start"])
+    )
 
     # Region intersection
     df = test_ds.read(
@@ -194,8 +196,10 @@ def test_basic_reads(test_ds):
                 [12771, 12771, 13374, 13389, 13395, 13413], dtype=np.int32
             ),
         }
-    ).sort_values(by=["sample_name", "pos_start"])
-    _check_dfs(expected_df, df.sort_values(by=["sample_name", "pos_start"]))
+    ).sort_values(ignore_index=True, by=["sample_name", "pos_start"])
+    _check_dfs(
+        expected_df, df.sort_values(ignore_index=True, by=["sample_name", "pos_start"])
+    )
 
     # Region and sample intersection
     df = test_ds.read(
@@ -209,8 +213,10 @@ def test_basic_reads(test_ds):
             "pos_start": pd.Series([12546, 13354], dtype=np.int32),
             "pos_end": pd.Series([12771, 13389], dtype=np.int32),
         }
-    ).sort_values(by=["sample_name", "pos_start"])
-    _check_dfs(expected_df, df.sort_values(by=["sample_name", "pos_start"]))
+    ).sort_values(ignore_index=True, by=["sample_name", "pos_start"])
+    _check_dfs(
+        expected_df, df.sort_values(ignore_index=True, by=["sample_name", "pos_start"])
+    )
 
     # Sample only
     df = test_ds.read(
@@ -222,8 +228,10 @@ def test_basic_reads(test_ds):
             "pos_start": pd.Series([12141, 12546, 13354], dtype=np.int32),
             "pos_end": pd.Series([12277, 12771, 13389], dtype=np.int32),
         }
-    ).sort_values(by=["sample_name", "pos_start"])
-    _check_dfs(expected_df, df.sort_values(by=["sample_name", "pos_start"]))
+    ).sort_values(ignore_index=True, by=["sample_name", "pos_start"])
+    _check_dfs(
+        expected_df, df.sort_values(ignore_index=True, by=["sample_name", "pos_start"])
+    )
 
 
 def test_multiple_counts(test_ds):
@@ -356,8 +364,10 @@ def test_read_filters(test_ds):
                 )
             ),
         }
-    ).sort_values(by=["sample_name", "pos_start"])
-    _check_dfs(expected_df, df.sort_values(by=["sample_name", "pos_start"]))
+    ).sort_values(ignore_index=True, by=["sample_name", "pos_start"])
+    _check_dfs(
+        expected_df, df.sort_values(ignore_index=True, by=["sample_name", "pos_start"])
+    )
 
 
 def test_read_var_length_filters(tmp_path):
@@ -406,9 +416,9 @@ def test_read_var_length_filters(tmp_path):
                 )
             ),
         }
-    ).sort_values(by=["pos_start"])
+    ).sort_values(ignore_index=True, by=["pos_start"])
 
-    _check_dfs(expected_df, df.sort_values(by=["pos_start"]))
+    _check_dfs(expected_df, df.sort_values(ignore_index=True, by=["pos_start"]))
 
 
 def test_read_alleles(test_ds):
@@ -458,8 +468,10 @@ def test_read_alleles(test_ds):
                 )
             ),
         }
-    ).sort_values(by=["sample_name", "pos_start"])
-    _check_dfs(expected_df, df.sort_values(by=["sample_name", "pos_start"]))
+    ).sort_values(ignore_index=True, by=["sample_name", "pos_start"])
+    _check_dfs(
+        expected_df, df.sort_values(ignore_index=True, by=["sample_name", "pos_start"])
+    )
 
 
 def test_read_multiple_alleles(tmp_path):
@@ -491,8 +503,10 @@ def test_read_multiple_alleles(tmp_path):
                 )
             ),
         }
-    ).sort_values(by=["sample_name", "pos_start"])
-    _check_dfs(expected_df, df.sort_values(by=["sample_name", "pos_start"]))
+    ).sort_values(ignore_index=True, by=["sample_name", "pos_start"])
+    _check_dfs(
+        expected_df, df.sort_values(ignore_index=True, by=["sample_name", "pos_start"])
+    )
 
 
 def test_read_var_len_attrs(test_ds):
@@ -543,9 +557,11 @@ def test_read_var_len_attrs(test_ds):
                 )
             ),
         }
-    ).sort_values(by=["sample_name", "pos_start"])
+    ).sort_values(ignore_index=True, by=["sample_name", "pos_start"])
 
-    _check_dfs(expected_df, df.sort_values(by=["sample_name", "pos_start"]))
+    _check_dfs(
+        expected_df, df.sort_values(ignore_index=True, by=["sample_name", "pos_start"])
+    )
 
 
 def test_sample_args(test_ds, tmp_path):
@@ -675,8 +691,10 @@ def test_read_null_attrs(tmp_path):
             ),
             "fmt_MIN_DP": pd.Series([0, 14, 3, 1, 0, 30, 20, None, 24, None, 23, 19]),
         }
-    ).sort_values(by=["sample_name", "pos_start"])
-    _check_dfs(expected_df, df.sort_values(by=["sample_name", "pos_start"]))
+    ).sort_values(ignore_index=True, by=["sample_name", "pos_start"])
+    _check_dfs(
+        expected_df, df.sort_values(ignore_index=True, by=["sample_name", "pos_start"])
+    )
 
 
 def test_read_config():

--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -424,6 +424,10 @@ class Reader {
      * resuming incomplete reads.
      */
     uint64_t cell_idx = 0;
+
+    /** indicates if the user is querying all samples in the array, this cause
+     * some special case optimizations. */
+    bool all_samples;
   };
 
   /* ********************************* */
@@ -495,16 +499,24 @@ class Reader {
 
   /**
    * Prepares sample batches for export
-   * @return
+   * @param all_samples Boolean which is set as ouput to indicated if all
+   * samples are being queried by the user or not
+   * @return vector of samples
    */
-  std::vector<std::vector<SampleAndId>> prepare_sample_batches_v4() const;
+  std::vector<std::vector<SampleAndId>> prepare_sample_batches_v4(
+      bool* all_samples) const;
 
   /** Merges the list of sample names with the contents of the samples file. */
   std::vector<SampleAndId> prepare_sample_names() const;
 
   /** Merges the list of sample names with the contents of the samples file for
-   * v4 arrays. */
-  std::vector<SampleAndId> prepare_sample_names_v4() const;
+   * v4 arrays.
+   *
+   * @param all_samples Boolean which is set as ouput to indicated if all
+   * samples are being queried by the user or not
+   * @return vector of samples
+   */
+  std::vector<SampleAndId> prepare_sample_names_v4(bool* all_samples) const;
 
   /**
    * Prepares the regions to be queried and exported. This merges the list of


### PR DESCRIPTION
In v4 since we have strings core will not coalesce the point ranges. In the special case that we are exporting all samples, we can optimize by only setting one range with the first and last sample of the partition/batch.