### PR TITLE
Revert "Workaround homebrew openssl error for CI"

### DIFF
--- a/ci/azure-linux_mac.yml
+++ b/ci/azure-linux_mac.yml
@@ -9,14 +9,6 @@ steps:
   displayName: 'Check function name/signature mismatches'
 
 - bash: |
-    set -ex
-    brew uninstall openssl@1.0.2t
-    rm -rf /usr/local/etc/openssl
-    rm -rf /usr/local/etc/openssl@1.1
-  condition: eq(variables['Agent.OS'], 'Darwin')
-  displayName: 'Workaround openssl homebrew issue (OSX only)'
-
-- bash: |
     set -e pipefail
     brew install clang-format
     src=$BUILD_REPOSITORY_LOCALPATH/libtiledbvcf

--- a/ci/native_libs-linux_osx.yml
+++ b/ci/native_libs-linux_osx.yml
@@ -1,13 +1,5 @@
 steps:
     - bash: |
-        set -ex
-        brew uninstall openssl@1.0.2t
-        rm -rf /usr/local/etc/openssl
-        rm -rf /usr/local/etc/openssl@1.1
-      condition: eq(variables['Agent.OS'], 'Darwin')
-      displayName: 'Workaround openssl homebrew issue (OSX only)'
-
-    - bash: |
         set -e pipefail
         # Install bcftools (only required for running the CLI tests)
         version=1.10.2


### PR DESCRIPTION
Reverts TileDB-Inc/TileDB-VCF#203

This was fixed upsteam.