### PR TITLE
Build Chunked Arrow Table in _read_partition()

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -214,7 +214,7 @@ def get_ext_modules():
             libraries=["tiledbvcf"],
             library_dirs=[],
             language="c++",
-        ),
+        )
     ]
     return ext_modules
 

--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -31,7 +31,7 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("set_attributes", &Reader::set_attributes)
       .def("set_tiledb_stats_enabled", &Reader::set_tiledb_stats_enabled)
       .def("set_verbose", &Reader::set_verbose)
-      .def("read", &Reader::read)
+      .def("read", &Reader::read, py::arg("release_buffs")=true)
       .def("get_buffers", &Reader::get_buffers)
       .def("get_results_arrow", &Reader::get_results_arrow)
       .def("completed", &Reader::completed)

--- a/apis/python/src/tiledbvcf/binding/reader.cc
+++ b/apis/python/src/tiledbvcf/binding/reader.cc
@@ -152,9 +152,9 @@ void Reader::set_verbose(bool verbose) {
   check_error(reader, tiledb_vcf_reader_set_verbose(reader, verbose));
 }
 
-void Reader::read() {
+void Reader::read(const bool release_buffs) {
   auto reader = ptr.get();
-  alloc_buffers();
+  alloc_buffers(release_buffs);
   set_buffers();
 
   check_error(reader, tiledb_vcf_reader_read(reader));
@@ -165,11 +165,12 @@ void Reader::read() {
         "TileDB-VCF-Py: Error submitting read; unhandled read status.");
 }
 
-void Reader::alloc_buffers() {
+void Reader::alloc_buffers(const bool release_buffs) {
   auto reader = ptr.get();
 
   // Release old buffers. TODO: reuse when possible
-  release_buffers();
+  if (release_buffs)
+    release_buffers();
 
   // Get a count of the number of buffers required.
   int num_buffers = 0;

--- a/apis/python/src/tiledbvcf/binding/reader.h
+++ b/apis/python/src/tiledbvcf/binding/reader.h
@@ -89,7 +89,7 @@ class Reader {
   void set_tiledb_stats_enabled(const bool stats_enabled);
 
   /** Performs a blocking read operation. */
-  void read();
+  void read(const bool release_buffs=true);
 
   /**
    * Returns a map of attribute name -> (offsets_buff, data_buff) containing the
@@ -177,7 +177,7 @@ class Reader {
   std::vector<BufferInfo> buffers_;
 
   /** Allocate buffers for the read. */
-  void alloc_buffers();
+  void alloc_buffers(const bool release_buffs=true);
 
   /** Sets the allocated buffers on the reader object. */
   void set_buffers();

--- a/apis/python/src/tiledbvcf/dask_functions.py
+++ b/apis/python/src/tiledbvcf/dask_functions.py
@@ -36,20 +36,17 @@ def _read_partition(read_args):
     table_fragments = []
 
     ds = Dataset(read_args.uri, "r", read_args.cfg)
-    pyar = ds.read(
+    pyar = ds.read_arrow(
         attrs=read_args.attrs,
         samples=read_args.samples,
         regions=read_args.regions,
         samples_file=read_args.samples_file,
         bed_file=read_args.bed_file,
-        return_type="arrow",
     )
     table_fragments.append(pyar)
 
     while not ds.read_completed():
-        table_fragments.append(
-            ds.continue_read(release_buffers=False, return_type="arrow")
-        )
+        table_fragments.append(ds.continue_read_arrow(release_buffers=False))
 
     table = pa.concat_tables(table_fragments, promote=False)
 

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -122,7 +122,15 @@ class Dataset(object):
                     pass
             self.writer.set_tiledb_config(",".join(tiledb_config_list))
 
-    def read(self, attrs, samples=None, regions=None, samples_file=None, bed_file=None):
+    def read(
+        self,
+        attrs,
+        samples=None,
+        regions=None,
+        samples_file=None,
+        bed_file=None,
+        return_type="pandas",
+    ):
 
         """Reads data from a TileDB-VCF dataset.
 
@@ -139,7 +147,8 @@ class Dataset(object):
         :param str samples_file: URI of file containing sample names to be read,
             one per line.
         :param str bed_file: URI of a BED file of genomic regions to be read.
-        :return: Pandas DataFrame containing results.
+        :param return_type: Type to return, 'pandas' for pandas dataframe or 'arrow' for raw arrow table
+        :return: Pandas DataFrame or PyArrow Array containing results.
         """
         if self.mode != "r":
             raise Exception("Dataset not open in read mode")
@@ -154,7 +163,7 @@ class Dataset(object):
         if bed_file is not None:
             self.reader.set_bed_file(bed_file)
 
-        return self.continue_read()
+        return self.continue_read(return_type=return_type)
 
     def read_iter(
         self, attrs, samples=None, regions=None, samples_file=None, bed_file=None
@@ -167,17 +176,23 @@ class Dataset(object):
         while not self.read_completed():
             yield self.continue_read()
 
-    def continue_read(self):
+    def continue_read(self, release_buffers=True, return_type="pandas"):
+        """
+        Continue an incomplete read
+        :param return_type: Type to return, 'pandas' for pandas dataframe or 'arrow' for raw arrow table
+        :return: pandas dataframe or pyarrow array
+        """
         if self.mode != "r":
             raise Exception("Dataset not open in read mode")
 
-        self.reader.read()
+        self.reader.read(release_buffers)
         table = self.reader.get_results_arrow()
+        if return_type == "arrow":
+            return table
         return table.to_pandas()
 
     def read_completed(self):
         """Returns true if the previous read operation was complete.
-
         A read is considered complete if the resulting dataframe contained
         all results."""
         if self.mode != "r":

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -122,20 +122,18 @@ class Dataset(object):
                     pass
             self.writer.set_tiledb_config(",".join(tiledb_config_list))
 
-    def read(
+    def read_arrow(
         self,
         attrs,
         samples=None,
         regions=None,
         samples_file=None,
         bed_file=None,
-        return_type="pandas",
     ):
-
-        """Reads data from a TileDB-VCF dataset.
+        """Reads data from a TileDB-VCF dataset into Arrow table.
 
         For large datasets, a call to `read()` may not be able to fit all
-        results in memory. In that case, the returned dataframe will contain as
+        results in memory. In that case, the returned table will contain as
         many results as possible, and in order to retrieve the rest of the
         results, use the `continue_read()` function.
 
@@ -147,7 +145,6 @@ class Dataset(object):
         :param str samples_file: URI of file containing sample names to be read,
             one per line.
         :param str bed_file: URI of a BED file of genomic regions to be read.
-        :param return_type: Type to return, 'pandas' for pandas dataframe or 'arrow' for raw arrow table
         :return: Pandas DataFrame or PyArrow Array containing results.
         """
         if self.mode != "r":
@@ -163,7 +160,47 @@ class Dataset(object):
         if bed_file is not None:
             self.reader.set_bed_file(bed_file)
 
-        return self.continue_read(return_type=return_type)
+        return self.continue_read_arrow()
+
+    def read(
+        self,
+        attrs,
+        samples=None,
+        regions=None,
+        samples_file=None,
+        bed_file=None,
+    ):
+        """Reads data from a TileDB-VCF dataset into Pandas dataframe.
+
+        For large datasets, a call to `read()` may not be able to fit all
+        results in memory. In that case, the returned table will contain as
+        many results as possible, and in order to retrieve the rest of the
+        results, use the `continue_read()` function.
+
+        You can also use the Python generator version, `read_iter()`.
+
+        :param list of str attrs: List of attribute names to be read.
+        :param list of str samples: CSV list of sample names to be read.
+        :param list of str regions: CSV list of genomic regions to be read.
+        :param str samples_file: URI of file containing sample names to be read,
+            one per line.
+        :param str bed_file: URI of a BED file of genomic regions to be read.
+        :return: Pandas DataFrame or PyArrow Array containing results.
+        """
+        if self.mode != "r":
+            raise Exception("Dataset not open in read mode")
+
+        self.reader.reset()
+        self._set_samples(samples, samples_file)
+
+        regions = "" if regions is None else regions
+        self.reader.set_regions(",".join(regions))
+        self.reader.set_attributes(attrs)
+
+        if bed_file is not None:
+            self.reader.set_bed_file(bed_file)
+
+        return self.continue_read()
 
     def read_iter(
         self, attrs, samples=None, regions=None, samples_file=None, bed_file=None
@@ -176,20 +213,25 @@ class Dataset(object):
         while not self.read_completed():
             yield self.continue_read()
 
-    def continue_read(self, release_buffers=True, return_type="pandas"):
+    def continue_read(self, release_buffers=True):
         """
         Continue an incomplete read
-        :param return_type: Type to return, 'pandas' for pandas dataframe or 'arrow' for raw arrow table
-        :return: pandas dataframe or pyarrow array
+        :return: Pandas DataFrame
+        """
+        table = self.continue_read_arrow(release_buffers=release_buffers)
+        return table.to_pandas()
+
+    def continue_read_arrow(self, release_buffers=True):
+        """
+        Continue an incomplete read
+        :return: PyArrow Table
         """
         if self.mode != "r":
             raise Exception("Dataset not open in read mode")
 
         self.reader.read(release_buffers)
         table = self.reader.get_results_arrow()
-        if return_type == "arrow":
-            return table
-        return table.to_pandas()
+        return table
 
     def read_completed(self):
         """Returns true if the previous read operation was complete.


### PR DESCRIPTION
The Dataset read() and continue_read() functions take in a return_type
parameter that allows specifying whether the results are contained in a Pandas
dataframe or Arrow table. The Dataset continue_read() function also takes in
a release_buffers parameter that indicates whether the previous results should
be freed before continuing the read.