### PR TITLE
Parallelize finalize calls for v4

### DIFF
--- a/libtiledbvcf/src/write/writer.h
+++ b/libtiledbvcf/src/write/writer.h
@@ -27,6 +27,7 @@
 #ifndef TILEDB_VCF_WRITER_H
 #define TILEDB_VCF_WRITER_H
 
+#include <future>
 #include <map>
 #include <memory>
 #include <string>
@@ -208,6 +209,8 @@ class Writer {
   std::unique_ptr<Query> query_;
   /** Handle on the dataset being written to. */
   std::unique_ptr<TileDBVCFDataset> dataset_;
+  /** Vector of futures from async query finalizes. */
+  std::vector<std::future<void>> finalize_tasks_;
 
   CreationParams creation_params_;
   RegistrationParams registration_params_;
@@ -283,6 +286,8 @@ class Writer {
       const IngestionParams& params,
       const std::vector<SampleAndIndex>& samples,
       std::vector<Region>& regions);
+
+  static void finalize_query(std::unique_ptr<tiledb::Query> query);
 };
 
 }  // namespace vcf


### PR DESCRIPTION
The finalize calls on all the fragments can add up to detrimental performance because it blocks further writes. This change launches all finalizes in separate non-blocking threads.