### PR TITLE
Properly exit early when sample is missing contig

### DIFF
--- a/libtiledbvcf/src/vcf/vcf_v3.cc
+++ b/libtiledbvcf/src/vcf/vcf_v3.cc
@@ -220,6 +220,10 @@ bool VCFV3::seek(const std::string& contig_name, uint32_t pos) {
   if (!open_)
     return false;
 
+  // Reset the record queue on all seeks
+  if (!record_queue_.empty())
+    std::queue<SafeSharedBCFRec>().swap(record_queue_);
+
   SafeBCFFh fh(bcf_open(path_.c_str(), "r"), hts_close);
   if (fh == nullptr)
     throw std::runtime_error("Error seeking in VCF; bcf_open failed");

--- a/libtiledbvcf/src/vcf/vcf_v4.cc
+++ b/libtiledbvcf/src/vcf/vcf_v4.cc
@@ -220,6 +220,10 @@ bool VCFV4::seek(const std::string& contig_name, uint32_t pos) {
 
   seeked_contig_name_ = contig_name;
 
+  // Reset the record queue on all seeks
+  if (!record_queue_.empty())
+    std::queue<SafeSharedBCFRec>().swap(record_queue_);
+
   SafeBCFFh fh(bcf_open(path_.c_str(), "r"), hts_close);
   if (fh == nullptr)
     throw std::runtime_error("Error seeking in VCF; bcf_open failed");

--- a/libtiledbvcf/src/write/writer_worker_v2.cc
+++ b/libtiledbvcf/src/write/writer_worker_v2.cc
@@ -74,7 +74,9 @@ bool WriterWorkerV2::parse(const Region& region) {
   const auto& metadata = dataset_->metadata();
   const uint32_t contig_offset = metadata.contig_offsets.at(region.seq_name);
   for (auto& vcf : vcfs_) {
-    vcf->seek(region.seq_name, region.min);
+    // If seek returns false there is no records for this contig
+    if (!vcf->seek(region.seq_name, region.min))
+      continue;
 
     bcf1_t* r = vcf->curr_rec();
     if (r == nullptr) {

--- a/libtiledbvcf/src/write/writer_worker_v3.cc
+++ b/libtiledbvcf/src/write/writer_worker_v3.cc
@@ -95,7 +95,9 @@ bool WriterWorkerV3::parse(const Region& region) {
   const auto& metadata = dataset_->metadata();
   const uint32_t contig_offset = metadata.contig_offsets.at(region.seq_name);
   for (auto& vcf : vcfs_) {
-    vcf->seek(region.seq_name, region.min);
+    // If seek returns false there is no records for this contig
+    if (!vcf->seek(region.seq_name, region.min))
+      continue;
 
     SafeSharedBCFRec r = vcf->front_record();
     if (r == nullptr) {

--- a/libtiledbvcf/src/write/writer_worker_v4.cc
+++ b/libtiledbvcf/src/write/writer_worker_v4.cc
@@ -96,7 +96,9 @@ bool WriterWorkerV4::parse(const Region& region) {
 
   // Initialize the record heap with the first record from each sample.
   for (auto& vcf : vcfs_) {
-    vcf->seek(region.seq_name, region.min);
+    // If seek returns false there is no records for this contig
+    if (!vcf->seek(region.seq_name, region.min))
+      continue;
 
     SafeSharedBCFRec r = vcf->front_record();
     if (r == nullptr) {


### PR DESCRIPTION
Properly exit early when sample is missing contig. We also properly reset the queue on seeking a new contig in case of early exit in seek to not leave old/invalid records on the queue.

This issue has existed in all versions, but only manifested in errors due to v4's splitting of a write per contig.

A unit test is not added because I'm unsure of the license of the data that produced this bug. I've been trying to create a synthetic  VCF to replicate but I'll wait for @aaronwolen 's expertise next week to help.