### PR TITLE
 Add support for reading samples remote

### DIFF
--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -474,7 +474,7 @@ void TileDBVCFDataset::register_samples(const RegistrationParams& params) {
       utils::batch_elements(samples, 100);
   std::future<std::vector<SafeBCFHdr>> future_headers = std::async(
       std::launch::async,
-      SampleUtils::download_sample_headers,
+      SampleUtils::get_sample_headers,
       vfs,
       batches[0],
       params.scratch_space);
@@ -483,7 +483,7 @@ void TileDBVCFDataset::register_samples(const RegistrationParams& params) {
     // Start the next batch downloading
     future_headers = std::async(
         std::launch::async,
-        SampleUtils::download_sample_headers,
+        SampleUtils::get_sample_headers,
         vfs,
         batches[i],
         params.scratch_space);

--- a/libtiledbvcf/src/utils/sample_utils.cc
+++ b/libtiledbvcf/src/utils/sample_utils.cc
@@ -31,10 +31,16 @@
 namespace tiledb {
 namespace vcf {
 
-std::vector<SampleAndIndex> SampleUtils::download_samples(
+std::vector<SampleAndIndex> SampleUtils::get_samples(
     const tiledb::VFS& vfs,
     const std::vector<SampleAndIndex>& samples,
     ScratchSpaceInfo* scratch_space) {
+  // If the user doesn't have scratch space, use VFS htslib plugin to read
+  // remote samples
+  if (scratch_space->path.empty()) {
+    return build_vfs_plugin_sample_list(samples);
+  }
+
   // Set up some local scratch space
   const auto download_dest_dir =
       utils::uri_join(scratch_space->path, "sample-dl");
@@ -44,7 +50,7 @@ std::vector<SampleAndIndex> SampleUtils::download_samples(
   Buffer buffer;
   std::vector<SampleAndIndex> local_paths;
   for (const auto& s : samples) {
-    if (!utils::starts_with(s.sample_uri, "s3://")) {
+    if (utils::is_local_uri(s.sample_uri)) {
       local_paths.push_back(
           {.sample_uri = s.sample_uri, .index_uri = s.index_uri});
       continue;
@@ -101,7 +107,7 @@ std::vector<SampleAndIndex> SampleUtils::download_samples(
   return local_paths;
 }
 
-std::vector<SafeBCFHdr> SampleUtils::download_sample_headers(
+std::vector<SafeBCFHdr> SampleUtils::get_sample_headers(
     const tiledb::VFS& vfs,
     const std::vector<SampleAndIndex>& samples,
     const ScratchSpaceInfo& scratch_space) {
@@ -109,7 +115,7 @@ std::vector<SafeBCFHdr> SampleUtils::download_sample_headers(
       vfs, samples, scratch_space, [](SafeBCFHdr hdr) { return hdr; });
 }
 
-std::vector<std::string> SampleUtils::download_sample_names(
+std::vector<std::string> SampleUtils::get_sample_names(
     const tiledb::VFS& vfs,
     const std::vector<SampleAndIndex>& samples,
     const ScratchSpaceInfo& scratch_space) {
@@ -144,6 +150,38 @@ std::vector<SampleAndIndex> SampleUtils::build_samples_uri_list(
     result.push_back({.sample_uri = uri});
 
   return result;
+}
+
+std::string SampleUtils::build_vfs_plugin_uri(const std::string& uri) {
+  // Local URIs can be skipped and read directly with htslib
+  if (utils::is_local_uri(uri)) {
+    return uri;
+  }
+  std::string adjusted_uri = std::string(HFILE_TILEDB_VFS_SCHEME) + "://" + uri;
+  return adjusted_uri;
+}
+
+SampleAndIndex SampleUtils::build_vfs_plugin_sample_and_index(
+    const SampleAndIndex& sample) {
+  return {
+      .sample_uri = build_vfs_plugin_uri(sample.sample_uri),
+      .index_uri = build_vfs_plugin_uri(sample.index_uri)};
+}
+
+std::vector<SampleAndIndex> SampleUtils::build_vfs_plugin_sample_list(
+    const std::vector<SampleAndIndex>& samples) {
+  std::vector<SampleAndIndex> local_paths;
+  for (const auto& s : samples) {
+    // Local URIs can be skipped and read directly with htslib
+    if (utils::is_local_uri(s.sample_uri)) {
+      local_paths.push_back(
+          {.sample_uri = s.sample_uri, .index_uri = s.index_uri});
+      continue;
+    }
+    local_paths.push_back(build_vfs_plugin_sample_and_index(s));
+  }
+
+  return local_paths;
 }
 
 std::vector<std::vector<SampleAndIndex>> batch_elements_by_tile(

--- a/libtiledbvcf/src/utils/utils.cc
+++ b/libtiledbvcf/src/utils/utils.cc
@@ -399,6 +399,19 @@ bool compare_configs(const tiledb::Config& rhs, const tiledb::Config& lhs) {
   return true;
 }
 
+bool is_local_uri(const std::string& uri) {
+  if (starts_with(uri, "s3://"))
+    return false;
+  if (starts_with(uri, "azure://"))
+    return false;
+  if (starts_with(uri, "gcs://"))
+    return false;
+  if (starts_with(uri, "hdfs://"))
+    return false;
+
+  return true;
+}
+
 }  // namespace utils
 }  // namespace vcf
 }  // namespace tiledb

--- a/libtiledbvcf/src/utils/utils.cc
+++ b/libtiledbvcf/src/utils/utils.cc
@@ -340,6 +340,57 @@ void set_htslib_tiledb_context(const std::vector<std::string>& tiledb_config) {
 
     set_tiledb_config(tiledb_config, hfile_tiledb_vfs_config);
 
+    // Set read-ahead cache used for remote sample file reading/loading
+    // read ahead 256kib
+    std::string read_ahead_size = std::to_string(1024UL * 256);
+    rc = tiledb_config_set(
+        hfile_tiledb_vfs_config,
+        "vfs.read_ahead_size",
+        read_ahead_size.c_str(),
+        &error);
+    if (rc != TILEDB_OK) {
+      const char* msg;
+      tiledb_error_message(error, &msg);
+      throw std::runtime_error(msg);
+    }
+
+    std::string read_ahead_cache_size =
+        std::to_string(1024UL * 1024 * 1024 * 6);
+    rc = tiledb_config_set(
+        hfile_tiledb_vfs_config,
+        "vfs.read_ahead_cache_size",
+        read_ahead_cache_size.c_str(),
+        &error);
+    if (rc != TILEDB_OK) {
+      const char* msg;
+      tiledb_error_message(error, &msg);
+      throw std::runtime_error(msg);
+    }
+
+    std::string min_parallel_size = std::to_string(99999999);
+    rc = tiledb_config_set(
+        hfile_tiledb_vfs_config,
+        "vfs.min_parallel_size",
+        min_parallel_size.c_str(),
+        &error);
+    if (rc != TILEDB_OK) {
+      const char* msg;
+      tiledb_error_message(error, &msg);
+      throw std::runtime_error(msg);
+    }
+
+    std::string max_parallel_ops = std::to_string(1);
+    rc = tiledb_config_set(
+        hfile_tiledb_vfs_config,
+        "vfs.s3.max_parallel_ops",
+        max_parallel_ops.c_str(),
+        &error);
+    if (rc != TILEDB_OK) {
+      const char* msg;
+      tiledb_error_message(error, &msg);
+      throw std::runtime_error(msg);
+    }
+
     if (hfile_tiledb_vfs_ctx != nullptr)
       tiledb_ctx_free(&hfile_tiledb_vfs_ctx);
 

--- a/libtiledbvcf/src/utils/utils.h
+++ b/libtiledbvcf/src/utils/utils.h
@@ -351,6 +351,13 @@ void init_htslib();
  */
 bool compare_configs(const tiledb::Config& rhs, const tiledb::Config& lhs);
 
+/**
+ * Checks if a file path is local or remote
+ * @param uri to check
+ * @return true if file is local path (file:// or no prefix), else false
+ */
+bool is_local_uri(const std::string& uri);
+
 }  // namespace utils
 }  // namespace vcf
 }  // namespace tiledb

--- a/libtiledbvcf/src/vcf/vcf_v4.h
+++ b/libtiledbvcf/src/vcf/vcf_v4.h
@@ -62,6 +62,8 @@ class VCFV4 {
   VCFV4& operator=(const VCFV4&) = delete;
   VCFV4& operator=(VCFV4&&) = delete;
 
+  bool init(const std::string& contig_name, uint32_t pos);
+
   /**
    * Opens the specified VCF or BCF file and load the header.
    *
@@ -148,17 +150,22 @@ class VCFV4 {
     void reset();
     void swap(Iter& other);
     bool next(bcf1_t* rec);
+    bool seek(const std::string& contig_name, uint32_t pos);
 
    private:
     SafeBCFFh fh_;
     bcf_hdr_t* hdr_;
     hts_itr_t* hts_iter_;
     tbx_t* tbx_;
+    hts_idx_t* hts_idx_;
     kstring_t tmps_ = {0, 0, nullptr};
   };
 
   /** True if the file is open. */
   bool open_;
+
+  /** True if the file is init'ed by seek. */
+  bool inited_;
 
   /** Full path of the VCF file being read. */
   std::string path_;

--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -93,6 +93,10 @@ void Writer::init(const IngestionParams& params) {
   // User overrides
   utils::set_tiledb_config(params.tiledb_config, tiledb_config_.get());
 
+  // Set readahead cache used for remote sample file reading/loading
+  (*tiledb_config_)["vfs.read_ahead_size"] = 1024UL * 1024 * 10;
+  (*tiledb_config_)["vfs.read_ahead_cache_size"] = 1024UL * 1024 * 1024 * 6;
+
   ctx_.reset(new Context(*tiledb_config_));
 
   // Set htslib global config and context based on user passed TileDB config

--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -93,10 +93,6 @@ void Writer::init(const IngestionParams& params) {
   // User overrides
   utils::set_tiledb_config(params.tiledb_config, tiledb_config_.get());
 
-  // Set readahead cache used for remote sample file reading/loading
-  (*tiledb_config_)["vfs.read_ahead_size"] = 1024UL * 1024 * 10;
-  (*tiledb_config_)["vfs.read_ahead_cache_size"] = 1024UL * 1024 * 1024 * 6;
-
   ctx_.reset(new Context(*tiledb_config_));
 
   // Set htslib global config and context based on user passed TileDB config

--- a/libtiledbvcf/src/write/writer.h
+++ b/libtiledbvcf/src/write/writer.h
@@ -200,6 +200,7 @@ class Writer {
   /** Gets the version number of the open dataset. */
   void dataset_version(int32_t* version) const;
 
+  /** Set the sample batch size for storing. */
   void set_sample_batch_size(const uint64_t size);
 
  private:


### PR DESCRIPTION
If no scratch space is given we will automatically use the HTSLIB VFS plugin to remotely read sample files. This can be advantageous to remove the local temporary storage requirement during registration/ingestion.

This also fixes three places where we arbitrarily where checking for s3 paths and not any other remote file system. We will now properly support all files systems that core TileDB supports.

Note: The performance for reading remote samples leaves significant room for improvement, as such marking this as a draft.