### PR TITLE
Update HTSLIB to 1.10

### DIFF
--- a/apis/java/src/main/java/io/tiledb/libvcfnative/NativeLibLoader.java
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/NativeLibLoader.java
@@ -95,7 +95,7 @@ public class NativeLibLoader {
   /** Finds and loads native HTSlib. */
   static void loadNativeHTSLib() {
     String os = getOSClassifier();
-    String versionedLibName = os.startsWith("osx") ? "libhts.1.8.dylib" : "libhts.so.1.8";
+    String versionedLibName = os.startsWith("osx") ? "libhts.1.10.dylib" : "libhts.so.1.10";
     try {
       // Don't use name mapping to get the versioned htslib
       loadNativeLib(versionedLibName, false);

--- a/libtiledbvcf/cmake/Modules/FindHTSlib_EP.cmake
+++ b/libtiledbvcf/cmake/Modules/FindHTSlib_EP.cmake
@@ -65,14 +65,14 @@ if (NOT HTSLIB_FOUND)
     message(STATUS "Adding HTSlib as an external project")
     # Use explicit soname to avoid having to use library symlinks (easier for embedding).
     if (APPLE)
-      set(EXTRA_LDFLAGS "-Wl,-install_name,@rpath/libhts.1.8.dylib")
+      set(EXTRA_LDFLAGS "-Wl,-install_name,@rpath/libhts.1.10.dylib")
     else()
-      set(EXTRA_LDFLAGS "-Wl,-soname,libhts.so.1.8")
+      set(EXTRA_LDFLAGS "-Wl,-soname,libhts.so.1.10")
     endif()
     ExternalProject_Add(ep_htslib
       PREFIX "externals"
-      URL "https://github.com/samtools/htslib/archive/1.8.zip"
-      URL_HASH SHA1=bfda9ba326197eba3072a959c669f024bbe5c23d
+      URL "https://github.com/samtools/htslib/archive/1.10.zip"
+      URL_HASH SHA1=3f4c5a18ac5f91e7ff69ec6d347b0b60e3621af5
       UPDATE_COMMAND ""
       CONFIGURE_COMMAND
           autoheader


### PR DESCRIPTION
There is a few improvements in HTSLIB but most importantly a bug fix in double free in hts_iter_destroy. Version 1.10 was selected as this has been previously validated by @aaronwolen .