### PR TITLE
Add new `--sample-batch-size` for store command

### DIFF
--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -58,5 +58,6 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("set_verbose", &Writer::set_verbose)
       .def("ingest_samples", &Writer::ingest_samples)
       .def("get_schema_version", &Writer::get_schema_version)
-      .def("set_tiledb_config", &Writer::set_tiledb_config);
+      .def("set_tiledb_config", &Writer::set_tiledb_config)
+      .def("set_sample_batch_size", &Writer::set_sample_batch_size);
 }

--- a/apis/python/src/tiledbvcf/binding/writer.cc
+++ b/apis/python/src/tiledbvcf/binding/writer.cc
@@ -141,9 +141,14 @@ int32_t Writer::get_schema_version() {
 }
 
 void Writer::set_tiledb_config(const std::string& config_str) {
-  auto reader = ptr.get();
+  auto writer = ptr.get();
   check_error(
-      reader, tiledb_vcf_writer_set_tiledb_config(reader, config_str.c_str()));
+      writer, tiledb_vcf_writer_set_tiledb_config(writer, config_str.c_str()));
+}
+
+void Writer::set_sample_batch_size(const uint64_t size) {
+  auto writer = ptr.get();
+  check_error(writer, tiledb_vcf_writer_set_sample_batch_size(writer, size));
 }
 
 }  // namespace tiledbvcfpy

--- a/apis/python/src/tiledbvcf/binding/writer.h
+++ b/apis/python/src/tiledbvcf/binding/writer.h
@@ -89,8 +89,13 @@ class Writer {
    */
   void set_verbose(bool verbose);
 
-/** Sets CSV TileDB config parameters. */
+  /** Sets CSV TileDB config parameters. */
   void set_tiledb_config(const std::string& config_str);
+
+  /**
+    [Store only] Sets the number of samples per batch for ingestion
+  */
+  void set_sample_batch_size(const uint64_t size);
 
  private:
   /** Helper function to free a C writer instance */

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -215,6 +215,7 @@ class Dataset(object):
         allow_duplicates=True,
         scratch_space_path=None,
         scratch_space_size=None,
+        sample_batch_size=None,
     ):
         """Ingest samples
 
@@ -248,6 +249,9 @@ class Dataset(object):
             raise Exception(
                 "Must set both scratch_space_path and scratch_space_size to use scratch space"
             )
+
+        if sample_batch_size is not None:
+            self.writer.set_sample_batch_size(sample_batch_size)
 
         self.writer.set_samples(",".join(sample_uris))
 

--- a/libtiledbvcf/src/c_api/tiledbvcf.cc
+++ b/libtiledbvcf/src/c_api/tiledbvcf.cc
@@ -971,6 +971,17 @@ int32_t tiledb_vcf_writer_set_tiledb_config(
   return TILEDB_VCF_OK;
 }
 
+int32_t tiledb_vcf_writer_set_sample_batch_size(
+    tiledb_vcf_writer_t* writer, const uint64_t size) {
+  if (sanity_check(writer) == TILEDB_VCF_ERR)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(writer, writer->writer_->set_sample_batch_size(size)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
 /* ********************************* */
 /*               ERROR               */
 /* ********************************* */

--- a/libtiledbvcf/src/c_api/tiledbvcf.h
+++ b/libtiledbvcf/src/c_api/tiledbvcf.h
@@ -1091,6 +1091,16 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_get_dataset_version(
 TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_set_tiledb_config(
     tiledb_vcf_writer_t* reader, const char* config);
 
+/**
+ * Set sample batch size for ingestion
+ *
+ * @param writer VCF writer object
+ * @param size number of samples to ingest per batch
+ * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
+ */
+TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_set_sample_batch_size(
+    tiledb_vcf_writer_t* writer, uint64_t size);
+
 /* ********************************* */
 /*               ERROR               */
 /* ********************************* */

--- a/libtiledbvcf/src/cli/tiledbvcf.cc
+++ b/libtiledbvcf/src/cli/tiledbvcf.cc
@@ -253,11 +253,6 @@ int main(int argc, char** argv) {
                    "Tile capacity to use for the array schema",
                    create_args.tile_capacity) &
            value("N", create_args.tile_capacity),
-       option("-e", "--tile-extent") %
-               defaulthelp(
-                   "Row tile extent to use for the array schema",
-                   create_args.row_tile_extent) &
-           value("N", create_args.row_tile_extent),
        option("-g", "--anchor-gap") %
                defaulthelp("Anchor gap size to use", create_args.anchor_gap) &
            value("N", create_args.anchor_gap),
@@ -365,6 +360,11 @@ int main(int argc, char** argv) {
         value("path", store_args.samples_file_uri)) |
            (values("paths", store_args.sample_uris) %
             "Argument list of VCF files to ingest"),
+       option("-e", "--sample-batch-size") %
+               defaulthelp(
+                   "Number of samples per batch for ingestion",
+                   store_args.sample_batch_size) &
+           value("N", store_args.sample_batch_size),
        option("--stats").set(store_args.tiledb_stats_enabled) %
            "Enable TileDB stats",
        option("--stats-vcf-header-array")

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -52,7 +52,6 @@ struct CreationParams {
   std::string uri;
   std::vector<std::string> extra_attributes;
   uint64_t tile_capacity = 10000;
-  uint32_t row_tile_extent = 10;
   uint32_t anchor_gap = 1000;
   std::vector<std::string> tiledb_config;
   tiledb_filter_type_t checksum = TILEDB_FILTER_CHECKSUM_SHA256;
@@ -163,7 +162,7 @@ class TileDBVCFDataset {
   struct Metadata {
     unsigned version = Version::V4;
     uint64_t tile_capacity;
-    uint32_t row_tile_extent;
+    uint32_t ingestion_sample_batch_size;
     uint32_t anchor_gap;
     std::vector<std::string> extra_attributes;
 

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -1185,7 +1185,8 @@ std::vector<std::vector<SampleAndId>> Reader::prepare_sample_batches() const {
       &samples);
 
   // Group partition into space tile batches.
-  const uint32_t space_tile_extent = dataset_->metadata().row_tile_extent;
+  const uint32_t space_tile_extent =
+      dataset_->metadata().ingestion_sample_batch_size;
   std::vector<std::vector<SampleAndId>> result;
   uint32_t curr_space_tile = std::numeric_limits<uint32_t>::max();
   for (const auto& s : samples) {

--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -201,11 +201,11 @@ void Writer::ingest_samples() {
   std::vector<std::vector<SampleAndIndex>> batches;
   if (dataset_->metadata().version == TileDBVCFDataset::V2 ||
       dataset_->metadata().version == TileDBVCFDataset::Version::V3)
-    batches =
-        batch_elements_by_tile(samples, dataset_->metadata().row_tile_extent);
+    batches = batch_elements_by_tile(
+        samples, dataset_->metadata().ingestion_sample_batch_size);
   else
-    batches = batch_elements_by_tile_v4(
-        samples, dataset_->metadata().row_tile_extent);
+    batches =
+        batch_elements_by_tile_v4(samples, ingestion_params_.sample_batch_size);
 
   // Set up parameters for two scratch spaces.
   const auto scratch_size_mb = ingestion_params_.scratch_space.size_mb / 2;
@@ -773,6 +773,10 @@ void Writer::dataset_version(int32_t* version) const {
 
 void Writer::finalize_query(std::unique_ptr<tiledb::Query> query) {
   query->finalize();
+}
+
+void Writer::set_sample_batch_size(const uint64_t size) {
+  ingestion_params_.sample_batch_size = size;
 }
 
 }  // namespace vcf

--- a/libtiledbvcf/src/write/writer.h
+++ b/libtiledbvcf/src/write/writer.h
@@ -73,6 +73,9 @@ struct IngestionParams {
 
   // Max size of TileDB buffers before flushing. Defaults to 1GB
   uint64_t max_tiledb_buffer_size_mb = 1024;
+
+  // Number of samples per batch for ingestion
+  uint64_t sample_batch_size = 10;
 };
 
 /* ********************************* */
@@ -196,6 +199,8 @@ class Writer {
 
   /** Gets the version number of the open dataset. */
   void dataset_version(int32_t* version) const;
+
+  void set_sample_batch_size(const uint64_t size);
 
  private:
   /* ********************************* */

--- a/libtiledbvcf/test/src/unit-vcf-store.cc
+++ b/libtiledbvcf/test/src/unit-vcf-store.cc
@@ -65,7 +65,7 @@ TEST_CASE("TileDB-VCF: Test create", "[tiledbvcf][ingest]") {
   ds.open(dataset_uri);
   REQUIRE(ds.metadata().tile_capacity == 123);
   REQUIRE(ds.metadata().anchor_gap == 1000);
-  REQUIRE(ds.metadata().row_tile_extent == 10);
+  REQUIRE(ds.metadata().ingestion_sample_batch_size == 10);
   REQUIRE(
       ds.metadata().extra_attributes ==
       std::vector<std::string>{"info_a1", "fmt_a2"});


### PR DESCRIPTION
This allow for setting the number of samples to batch per ingestion. This removes the parameter from the create of the dataset as its no longer required to be uniform for all ingestions.

This also adds the equivalent c-api and support in python.