### PR TITLE
Add new utils cli command for consolidate/vacuum

### DIFF
--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -1614,5 +1614,97 @@ void TileDBVCFDataset::set_tiledb_stats_enabled_vcf_header(
   tiledb_stats_enabled_vcf_header_ = stats_enabled;
 }
 
+void TileDBVCFDataset::consolidate_vcf_header_array_fragment_metadata(
+    const UtilsParams& params) {
+  Config cfg;
+  utils::set_tiledb_config(params.tiledb_config, &cfg);
+  cfg["sm.consolidation.mode"] = "fragment_meta";
+  tiledb::Array::consolidate(ctx_, vcf_headers_uri(root_uri_), &cfg);
+}
+
+void TileDBVCFDataset::consolidate_data_array_fragment_metadata(
+    const UtilsParams& params) {
+  Config cfg;
+  utils::set_tiledb_config(params.tiledb_config, &cfg);
+  cfg["sm.consolidation.mode"] = "fragment_meta";
+  tiledb::Array::consolidate(ctx_, data_array_uri(root_uri_), &cfg);
+}
+
+void TileDBVCFDataset::consolidate_fragment_metadata(
+    const UtilsParams& params) {
+  consolidate_data_array_fragment_metadata(params);
+  consolidate_vcf_header_array_fragment_metadata(params);
+}
+
+void TileDBVCFDataset::consolidate_vcf_header_array_fragments(
+    const UtilsParams& params) {
+  Config cfg;
+  utils::set_tiledb_config(params.tiledb_config, &cfg);
+  cfg["sm.consolidation.mode"] = "fragments";
+  tiledb::Array::consolidate(ctx_, vcf_headers_uri(root_uri_), &cfg);
+}
+
+void TileDBVCFDataset::consolidate_data_array_fragments(
+    const UtilsParams& params) {
+  Config cfg;
+  utils::set_tiledb_config(params.tiledb_config, &cfg);
+  cfg["sm.consolidation.mode"] = "fragments";
+  tiledb::Array::consolidate(ctx_, data_array_uri(root_uri_), &cfg);
+}
+
+void TileDBVCFDataset::consolidate_fragments(const UtilsParams& params) {
+  consolidate_data_array_fragments(params);
+  consolidate_vcf_header_array_fragments(params);
+}
+
+void TileDBVCFDataset::vacuum_vcf_header_array_fragment_metadata(
+    const UtilsParams& params) {
+  Config cfg;
+  utils::set_tiledb_config(params.tiledb_config, &cfg);
+  cfg["sm.vacuum.mode"] = "fragment_meta";
+  vcf_header_array_->close();
+  tiledb::Array::vacuum(ctx_, vcf_headers_uri(root_uri_), &cfg);
+  data_array_ = open_data_array(TILEDB_READ);
+  vcf_header_array_ = open_vcf_array(TILEDB_READ);
+}
+
+void TileDBVCFDataset::vacuum_data_array_fragment_metadata(
+    const UtilsParams& params) {
+  Config cfg;
+  utils::set_tiledb_config(params.tiledb_config, &cfg);
+  cfg["sm.vacuum.mode"] = "fragment_meta";
+  data_array_->close();
+  tiledb::Array::vacuum(ctx_, data_array_uri(root_uri_), &cfg);
+  data_array_ = open_data_array(TILEDB_READ);
+}
+
+void TileDBVCFDataset::vacuum_fragment_metadata(const UtilsParams& params) {
+  vacuum_data_array_fragment_metadata(params);
+  vacuum_vcf_header_array_fragment_metadata(params);
+}
+
+void TileDBVCFDataset::vacuum_vcf_header_array_fragments(
+    const UtilsParams& params) {
+  Config cfg;
+  utils::set_tiledb_config(params.tiledb_config, &cfg);
+  cfg["sm.vacuum.mode"] = "fragments";
+  vcf_header_array_->close();
+  tiledb::Array::vacuum(ctx_, vcf_headers_uri(root_uri_), &cfg);
+  vcf_header_array_ = open_vcf_array(TILEDB_READ);
+}
+
+void TileDBVCFDataset::vacuum_data_array_fragments(const UtilsParams& params) {
+  Config cfg;
+  utils::set_tiledb_config(params.tiledb_config, &cfg);
+  cfg["sm.vacuum.mode"] = "fragments";
+  data_array_->close();
+  tiledb::Array::vacuum(ctx_, data_array_uri(root_uri_), &cfg);
+  data_array_ = open_data_array(TILEDB_READ);
+}
+
+void TileDBVCFDataset::vacuum_fragments(const UtilsParams& params) {
+  vacuum_data_array_fragments(params);
+  vacuum_vcf_header_array_fragments(params);
+}
 }  // namespace vcf
 }  // namespace tiledb

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -79,6 +79,11 @@ struct StatParams {
   std::vector<std::string> tiledb_config;
 };
 
+struct UtilsParams {
+  std::string uri;
+  std::vector<std::string> tiledb_config;
+};
+
 /* ********************************* */
 /*         TILEDBVCFDATASET          */
 /* ********************************* */
@@ -367,6 +372,80 @@ class TileDBVCFDataset {
    * @param stats_enabled
    */
   void set_tiledb_stats_enabled_vcf_header(const bool stats_enabled);
+
+  /**
+   * Consolidate fragment metadata of the vcf header array
+   * @param params
+   */
+  void consolidate_vcf_header_array_fragment_metadata(
+      const UtilsParams& params);
+
+  /**
+   * Consolidate fragment metadata of the data array
+   * @param params
+   */
+  void consolidate_data_array_fragment_metadata(const UtilsParams& params);
+
+  /**
+   * Consolidate fragment metadata of all arrays (vcf header array and data
+   * array)
+   * @param params
+   */
+  void consolidate_fragment_metadata(const UtilsParams& params);
+
+  /**
+   * Consolidate fragments  of the vcf header array
+   * @param params
+   */
+  void consolidate_vcf_header_array_fragments(const UtilsParams& params);
+
+  /**
+   * Consolidate fragments  of the data array
+   * @param params
+   */
+  void consolidate_data_array_fragments(const UtilsParams& params);
+
+  /**
+   * Consolidate fragments of all arrays (vcf header array and data array)
+   * @param params
+   */
+  void consolidate_fragments(const UtilsParams& params);
+
+  /**
+   * Vacuum fragment metadata of the vcf header array
+   * @param params
+   */
+  void vacuum_vcf_header_array_fragment_metadata(const UtilsParams& params);
+
+  /**
+   * Vacuum fragment metadata of the data array
+   * @param params
+   */
+  void vacuum_data_array_fragment_metadata(const UtilsParams& params);
+
+  /**
+   * Vacuum fragment metadata of all arrays (vcf header array and data array)
+   * @param params
+   */
+  void vacuum_fragment_metadata(const UtilsParams& params);
+
+  /**
+   * Vacuum fragments  of the vcf header array
+   * @param params
+   */
+  void vacuum_vcf_header_array_fragments(const UtilsParams& params);
+
+  /**
+   * Vacuum fragments  of the data array
+   * @param params
+   */
+  void vacuum_data_array_fragments(const UtilsParams& params);
+
+  /**
+   * Vacuum fragments of all arrays (vcf header array and data array)
+   * @param params
+   */
+  void vacuum_fragments(const UtilsParams& params);
 
  private:
   /* ********************************* */

--- a/libtiledbvcf/test/CMakeLists.txt
+++ b/libtiledbvcf/test/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(tiledb_vcf_unit EXCLUDE_FROM_ALL
   ${CMAKE_CURRENT_SOURCE_DIR}/src/unit-vcf-export.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/src/unit-vcf-iter.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/src/unit-vcf-store.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/unit-vcf-utils.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/src/unit.cc
 )
 

--- a/libtiledbvcf/test/src/unit-vcf-utils.cc
+++ b/libtiledbvcf/test/src/unit-vcf-utils.cc
@@ -1,0 +1,202 @@
+/**
+ * @file   unit-vcf-utils.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2019 TileDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests for VCF export.
+ */
+
+#include "catch.hpp"
+
+#include "dataset/tiledbvcfdataset.h"
+#include "read/reader.h"
+#include "write/writer.h"
+
+#include <cstring>
+#include <fstream>
+#include <iostream>
+
+using namespace tiledb::vcf;
+
+static const std::string input_dir = TILEDB_VCF_TEST_INPUT_DIR;
+
+TEST_CASE("TileDB-VCF: Test consolidate and vacuum", "[tiledbvcf][utils]") {
+  tiledb::Context ctx;
+  tiledb::VFS vfs(ctx);
+
+  std::string dataset_uri = "test_dataset";
+  if (vfs.is_dir(dataset_uri))
+    vfs.remove_dir(dataset_uri);
+
+  CreationParams create_args;
+  create_args.uri = dataset_uri;
+  create_args.tile_capacity = 10000;
+  create_args.allow_duplicates = false;
+  TileDBVCFDataset::create(create_args);
+
+  // Ingest
+  {
+    Writer writer;
+    IngestionParams params;
+    params.uri = dataset_uri;
+    params.sample_uris = {input_dir + "/small.bcf", input_dir + "/small2.bcf"};
+    params.max_record_buffer_size = 1;
+    writer.set_all_params(params);
+    writer.ingest_samples();
+  }
+
+  // Check count operation
+  {
+    Reader reader;
+    ExportParams params;
+    params.uri = dataset_uri;
+    params.sample_names = {"HG00280", "HG01762"};
+    params.regions = {"1:12700-13400", "1:17000-17400"};
+    reader.set_all_params(params);
+    reader.open_dataset(dataset_uri);
+    reader.read();
+    REQUIRE(reader.read_status() == ReadStatus::COMPLETED);
+    REQUIRE(reader.num_records_exported() == 7);
+  }
+
+  // Ingest a second time to double the fragments
+  {
+    Writer writer;
+    IngestionParams params;
+    params.uri = dataset_uri;
+    params.sample_uris = {input_dir + "/small.bcf", input_dir + "/small2.bcf"};
+    params.max_record_buffer_size = 1;
+    writer.set_all_params(params);
+    writer.ingest_samples();
+  }
+
+  // Check count operation to make sure results are the same as before.
+  // Duplicates are disabled so this should be true
+  {
+    Reader reader;
+    ExportParams params;
+    params.uri = dataset_uri;
+    params.sample_names = {"HG00280", "HG01762"};
+    params.regions = {"1:12700-13400", "1:17000-17400"};
+    reader.set_all_params(params);
+    reader.open_dataset(dataset_uri);
+    reader.read();
+    REQUIRE(reader.read_status() == ReadStatus::COMPLETED);
+    REQUIRE(reader.num_records_exported() == 7);
+  }
+
+  // Consolidate fragment metadata
+  {
+    TileDBVCFDataset dataset;
+    dataset.open(dataset_uri);
+    UtilsParams params;
+    dataset.consolidate_fragment_metadata(params);
+  }
+
+  // Check count operation after consolidating fragment metadata
+  {
+    Reader reader;
+    ExportParams params;
+    params.uri = dataset_uri;
+    params.sample_names = {"HG00280", "HG01762"};
+    params.regions = {"1:12700-13400", "1:17000-17400"};
+    reader.set_all_params(params);
+    reader.open_dataset(dataset_uri);
+    reader.read();
+    REQUIRE(reader.read_status() == ReadStatus::COMPLETED);
+    REQUIRE(reader.num_records_exported() == 7);
+  }
+
+  // Consolidate fragments
+  {
+    TileDBVCFDataset dataset;
+    dataset.open(dataset_uri);
+    UtilsParams params;
+    dataset.consolidate_fragments(params);
+  }
+
+  // Check count operation after consolidating fragments
+  {
+    Reader reader;
+    ExportParams params;
+    params.uri = dataset_uri;
+    params.sample_names = {"HG00280", "HG01762"};
+    params.regions = {"1:12700-13400", "1:17000-17400"};
+    reader.set_all_params(params);
+    reader.open_dataset(dataset_uri);
+    reader.read();
+    REQUIRE(reader.read_status() == ReadStatus::COMPLETED);
+    REQUIRE(reader.num_records_exported() == 7);
+  }
+
+  // Vacuum fragment metadata
+  {
+    TileDBVCFDataset dataset;
+    dataset.open(dataset_uri);
+    UtilsParams params;
+    dataset.vacuum_fragment_metadata(params);
+  }
+
+  // Check count operation after consolidating fragment metadata
+  {
+    Reader reader;
+    ExportParams params;
+    params.uri = dataset_uri;
+    params.sample_names = {"HG00280", "HG01762"};
+    params.regions = {"1:12700-13400", "1:17000-17400"};
+    reader.set_all_params(params);
+    reader.open_dataset(dataset_uri);
+    reader.read();
+    REQUIRE(reader.read_status() == ReadStatus::COMPLETED);
+    REQUIRE(reader.num_records_exported() == 7);
+  }
+
+  // Vacuum fragments
+  {
+    TileDBVCFDataset dataset;
+    dataset.open(dataset_uri);
+    UtilsParams params;
+    dataset.vacuum_fragments(params);
+  }
+
+  // Check count operation after consolidating fragments
+  {
+    Reader reader;
+    ExportParams params;
+    params.uri = dataset_uri;
+    params.sample_names = {"HG00280", "HG01762"};
+    params.regions = {"1:12700-13400", "1:17000-17400"};
+    reader.set_all_params(params);
+    reader.open_dataset(dataset_uri);
+    reader.read();
+    REQUIRE(reader.read_status() == ReadStatus::COMPLETED);
+    REQUIRE(reader.num_records_exported() == 7);
+  }
+
+  if (vfs.is_dir(dataset_uri))
+    vfs.remove_dir(dataset_uri);
+}


### PR DESCRIPTION
A new CLI command is added for supporting array fragment consolidation, and array fragment metadata consolidation. The equivalent vacuum functions are also implemented. Most users will want to periodically consolidate the fragment metadata in order to improve performance with the large number of fragments.

Usage:
```
tiledbvcf utils consolidate fragment_meta -u <array>
tiledbvcf utils consolidate fragments -u <array>
tiledbvcf utils vacuum fragment_meta -u <array>
tiledbvcf utils vacuum fragments -u <array>
```