### PR TITLE
Adjust TileDB-VCF version printing for tag name

### DIFF
--- a/libtiledbvcf/src/CMakeLists.txt
+++ b/libtiledbvcf/src/CMakeLists.txt
@@ -15,18 +15,29 @@ find_package(TileDB_EP REQUIRED)
 find_package(Git REQUIRED)
 
 execute_process(
-  COMMAND "${GIT_EXECUTABLE}" describe --dirty=-modified --always
+  COMMAND "${GIT_EXECUTABLE}" describe --exact-match --tags HEAD
   WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
   RESULT_VARIABLE res
   OUTPUT_VARIABLE BUILD_COMMIT_HASH
   ERROR_QUIET
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 
+# If we didn't find a tag name let's grab the SHA
+if (res)
+  execute_process(
+    COMMAND "${GIT_EXECUTABLE}" describe --dirty=-modified --always
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    RESULT_VARIABLE res
+    OUTPUT_VARIABLE BUILD_COMMIT_HASH
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+
 set_property(GLOBAL APPEND
   PROPERTY CMAKE_CONFIGURE_DEPENDS
   "${CMAKE_SOURCE_DIR}/.git/index")
 
-message(STATUS "Building with commit hash ${TILEDB_VCF_COMMIT_HASH}")
+message(STATUS "Building with commit hash ${BUILD_COMMIT_HASH}")
 
 ############################################################
 # Common object library

--- a/libtiledbvcf/src/cli/tiledbvcf.cc
+++ b/libtiledbvcf/src/cli/tiledbvcf.cc
@@ -50,7 +50,7 @@ std::string defaulthelp(const std::string& msg, T default_value) {
 /** Returns TileDB-VCF and TileDB version information in string form. */
 std::string version_info() {
   std::stringstream ss;
-  ss << "TileDB-VCF build " << utils::TILEDB_VCF_COMMIT_HASH << "\n";
+  ss << "TileDB-VCF version " << utils::TILEDB_VCF_COMMIT_HASH << "\n";
   auto v = tiledb::version();
   ss << "TileDB version " << std::get<0>(v) << "." << std::get<1>(v) << "."
      << std::get<2>(v);


### PR DESCRIPTION
We now first try to get the tag name from git before settling on the sha when TileDB-VCF is not built on a release tag.