### PR TITLE
Fix native library building for tags

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -74,7 +74,7 @@ stages:
         - template: ci/build-images.yml
 
   - stage: BuildNativeLibs
-    condition: and(succeeded(), or(eq(variables.isMaster, true), eq(variables.isRefTag, true)))
+    condition: or(eq(variables.isMaster, true), eq(variables.isRefTag, true))
     jobs:
       - job: Linux_OSX
         strategy:


### PR DESCRIPTION
This drops the `succeeded()` condition on the `BuildNativeLibs` stage. The `succeeded()` requires all previous stages to succeed which does not work for tags because the first CI stage of the unit tests are skipped. This means we are not building the multi-lib jar for spark and instead are only building linux. This commit solves this problem.