### PR TITLE
C/Python APIs for writer config params

### DIFF
--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -55,6 +55,7 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("set_tile_capacity", &Writer::set_tile_capacity)
       .def("set_anchor_gap", &Writer::set_anchor_gap)
       .def("set_num_threads", &Writer::set_num_threads)
+      .def("set_thread_task_size", &Writer::set_thread_task_size)
       .def("set_memory_budget", &Writer::set_memory_budget)
       .def("set_scratch_space", &Writer::set_scratch_space)
       .def("set_max_num_records", &Writer::set_max_num_records)

--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -54,6 +54,7 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("set_allow_duplicates", &Writer::set_allow_duplicates)
       .def("set_tile_capacity", &Writer::set_tile_capacity)
       .def("set_anchor_gap", &Writer::set_anchor_gap)
+      .def("set_memory_budget", &Writer::set_memory_budget)
       .def("set_scratch_space", &Writer::set_scratch_space)
       .def("create_dataset", &Writer::create_dataset)
       .def("register_samples", &Writer::register_samples)

--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -57,6 +57,7 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("set_num_threads", &Writer::set_num_threads)
       .def("set_memory_budget", &Writer::set_memory_budget)
       .def("set_scratch_space", &Writer::set_scratch_space)
+      .def("set_max_num_records", &Writer::set_max_num_records)
       .def("create_dataset", &Writer::create_dataset)
       .def("register_samples", &Writer::register_samples)
       .def("set_verbose", &Writer::set_verbose)

--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -52,6 +52,7 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("set_extra_attributes", &Writer::set_extra_attributes)
       .def("set_checksum", &Writer::set_checksum)
       .def("set_allow_duplicates", &Writer::set_allow_duplicates)
+      .def("set_tile_capacity", &Writer::set_tile_capacity)
       .def("set_scratch_space", &Writer::set_scratch_space)
       .def("create_dataset", &Writer::create_dataset)
       .def("register_samples", &Writer::register_samples)

--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -53,6 +53,7 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("set_checksum", &Writer::set_checksum)
       .def("set_allow_duplicates", &Writer::set_allow_duplicates)
       .def("set_tile_capacity", &Writer::set_tile_capacity)
+      .def("set_anchor_gap", &Writer::set_anchor_gap)
       .def("set_scratch_space", &Writer::set_scratch_space)
       .def("create_dataset", &Writer::create_dataset)
       .def("register_samples", &Writer::register_samples)

--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -54,6 +54,7 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("set_allow_duplicates", &Writer::set_allow_duplicates)
       .def("set_tile_capacity", &Writer::set_tile_capacity)
       .def("set_anchor_gap", &Writer::set_anchor_gap)
+      .def("set_num_threads", &Writer::set_num_threads)
       .def("set_memory_budget", &Writer::set_memory_budget)
       .def("set_scratch_space", &Writer::set_scratch_space)
       .def("create_dataset", &Writer::create_dataset)

--- a/apis/python/src/tiledbvcf/binding/writer.cc
+++ b/apis/python/src/tiledbvcf/binding/writer.cc
@@ -114,6 +114,12 @@ void Writer::set_anchor_gap(const uint32_t anchor_gap) {
   check_error(writer, tiledb_vcf_writer_set_anchor_gap(writer, anchor_gap));
 }
 
+void Writer::set_memory_budget(const uint64_t size) {
+  auto writer = ptr.get();
+  check_error(
+      writer, tiledb_vcf_writer_set_memory_budget(writer, size));
+}
+
 void Writer::set_scratch_space(const std::string& path, uint64_t size) {
   auto writer = ptr.get();
   check_error(

--- a/apis/python/src/tiledbvcf/binding/writer.cc
+++ b/apis/python/src/tiledbvcf/binding/writer.cc
@@ -114,10 +114,14 @@ void Writer::set_anchor_gap(const uint32_t anchor_gap) {
   check_error(writer, tiledb_vcf_writer_set_anchor_gap(writer, anchor_gap));
 }
 
+void Writer::set_num_threads(const uint32_t threads) {
+  auto writer = ptr.get();
+  check_error(writer, tiledb_vcf_writer_set_num_threads(writer, threads));
+}
+
 void Writer::set_memory_budget(const uint64_t size) {
   auto writer = ptr.get();
-  check_error(
-      writer, tiledb_vcf_writer_set_memory_budget(writer, size));
+  check_error(writer, tiledb_vcf_writer_set_memory_budget(writer, size));
 }
 
 void Writer::set_scratch_space(const std::string& path, uint64_t size) {

--- a/apis/python/src/tiledbvcf/binding/writer.cc
+++ b/apis/python/src/tiledbvcf/binding/writer.cc
@@ -130,6 +130,12 @@ void Writer::set_scratch_space(const std::string& path, uint64_t size) {
       writer, tiledb_vcf_writer_set_scratch_space(writer, path.c_str(), size));
 }
 
+void Writer::set_max_num_records(const uint64_t max_num_records) {
+  auto writer = ptr.get();
+  check_error(
+      writer, tiledb_vcf_writer_set_max_num_records(writer, max_num_records));
+}
+
 void Writer::set_verbose(bool verbose) {
   auto writer = ptr.get();
   check_error(writer, tiledb_vcf_writer_set_verbose(writer, verbose));

--- a/apis/python/src/tiledbvcf/binding/writer.cc
+++ b/apis/python/src/tiledbvcf/binding/writer.cc
@@ -119,6 +119,11 @@ void Writer::set_num_threads(const uint32_t threads) {
   check_error(writer, tiledb_vcf_writer_set_num_threads(writer, threads));
 }
 
+void Writer::set_thread_task_size(const uint32_t size) {
+  auto writer = ptr.get();
+  check_error(writer, tiledb_vcf_writer_set_thread_task_size(writer, size));
+}
+
 void Writer::set_memory_budget(const uint32_t memory_mb) {
   auto writer = ptr.get();
   check_error(writer, tiledb_vcf_writer_set_memory_budget(writer, memory_mb));

--- a/apis/python/src/tiledbvcf/binding/writer.cc
+++ b/apis/python/src/tiledbvcf/binding/writer.cc
@@ -103,6 +103,12 @@ void Writer::set_allow_duplicates(const bool& allow_duplicates) {
       writer, tiledb_vcf_writer_set_allow_duplicates(writer, allow_duplicates));
 }
 
+void Writer::set_tile_capacity(const uint64_t tile_capacity) {
+  auto writer = ptr.get();
+  check_error(
+      writer, tiledb_vcf_writer_set_tile_capacity(writer, tile_capacity));
+}
+
 void Writer::set_scratch_space(const std::string& path, int64_t size) {
   auto writer = ptr.get();
   check_error(

--- a/apis/python/src/tiledbvcf/binding/writer.cc
+++ b/apis/python/src/tiledbvcf/binding/writer.cc
@@ -109,7 +109,8 @@ void Writer::set_tile_capacity(const uint64_t tile_capacity) {
       writer, tiledb_vcf_writer_set_tile_capacity(writer, tile_capacity));
 }
 
-void Writer::set_scratch_space(const std::string& path, int64_t size) {
+
+void Writer::set_scratch_space(const std::string& path, uint64_t size) {
   auto writer = ptr.get();
   check_error(
       writer, tiledb_vcf_writer_set_scratch_space(writer, path.c_str(), size));

--- a/apis/python/src/tiledbvcf/binding/writer.cc
+++ b/apis/python/src/tiledbvcf/binding/writer.cc
@@ -111,8 +111,7 @@ void Writer::set_tile_capacity(const uint64_t tile_capacity) {
 
 void Writer::set_anchor_gap(const uint32_t anchor_gap) {
   auto writer = ptr.get();
-  check_error(
-      writer, tiledb_vcf_writer_set_anchor_gap(writer, anchor_gap));
+  check_error(writer, tiledb_vcf_writer_set_anchor_gap(writer, anchor_gap));
 }
 
 void Writer::set_scratch_space(const std::string& path, uint64_t size) {

--- a/apis/python/src/tiledbvcf/binding/writer.cc
+++ b/apis/python/src/tiledbvcf/binding/writer.cc
@@ -109,6 +109,11 @@ void Writer::set_tile_capacity(const uint64_t tile_capacity) {
       writer, tiledb_vcf_writer_set_tile_capacity(writer, tile_capacity));
 }
 
+void Writer::set_anchor_gap(const uint32_t anchor_gap) {
+  auto writer = ptr.get();
+  check_error(
+      writer, tiledb_vcf_writer_set_anchor_gap(writer, anchor_gap));
+}
 
 void Writer::set_scratch_space(const std::string& path, uint64_t size) {
   auto writer = ptr.get();

--- a/apis/python/src/tiledbvcf/binding/writer.cc
+++ b/apis/python/src/tiledbvcf/binding/writer.cc
@@ -119,9 +119,9 @@ void Writer::set_num_threads(const uint32_t threads) {
   check_error(writer, tiledb_vcf_writer_set_num_threads(writer, threads));
 }
 
-void Writer::set_memory_budget(const uint64_t size) {
+void Writer::set_memory_budget(const uint32_t memory_mb) {
   auto writer = ptr.get();
-  check_error(writer, tiledb_vcf_writer_set_memory_budget(writer, size));
+  check_error(writer, tiledb_vcf_writer_set_memory_budget(writer, memory_mb));
 }
 
 void Writer::set_scratch_space(const std::string& path, uint64_t size) {

--- a/apis/python/src/tiledbvcf/binding/writer.h
+++ b/apis/python/src/tiledbvcf/binding/writer.h
@@ -68,14 +68,14 @@ class Writer {
   */
   void set_allow_duplicates(const bool& allow_duplicates);
 
- /**
-    [Creation only] Sets the data array's tile capacity
-  */
+  /**
+     [Creation only] Sets the data array's tile capacity
+   */
   void set_tile_capacity(const uint64_t tile_capacity);
 
- /**
-    [Creation only] Set the length of gaps between inserted anchor records.
-  */
+  /**
+     [Creation only] Set the length of gaps between inserted anchor records.
+   */
   void set_anchor_gap(const uint32_t anchor_gap);
 
   /**
@@ -89,7 +89,7 @@ class Writer {
 
   void ingest_samples();
 
-    /** Returns schema version number of the TileDB VCF dataset */
+  /** Returns schema version number of the TileDB VCF dataset */
   int32_t get_schema_version();
 
   /**

--- a/apis/python/src/tiledbvcf/binding/writer.h
+++ b/apis/python/src/tiledbvcf/binding/writer.h
@@ -68,6 +68,11 @@ class Writer {
   */
   void set_allow_duplicates(const bool& allow_duplicates);
 
+ /**
+    [Creation only] Sets the data array's tile capacity
+  */
+  void set_tile_capacity(const uint64_t tile_capacity);
+
   /**
     [Creation only] Allocates scratch space for downloading sample files
   */

--- a/apis/python/src/tiledbvcf/binding/writer.h
+++ b/apis/python/src/tiledbvcf/binding/writer.h
@@ -79,6 +79,11 @@ class Writer {
   void set_anchor_gap(const uint32_t anchor_gap);
 
   /**
+    [Store only] Set the number of threads used for ingestion.
+  */
+  void set_num_threads(const uint32_t threads);
+
+  /**
     [Store only] Set the max size of TileDB buffers before flushing.
   */
   void set_memory_budget(const uint64_t size);

--- a/apis/python/src/tiledbvcf/binding/writer.h
+++ b/apis/python/src/tiledbvcf/binding/writer.h
@@ -76,7 +76,7 @@ class Writer {
   /**
     [Creation only] Allocates scratch space for downloading sample files
   */
-  void set_scratch_space(const std::string& path, int64_t size);
+  void set_scratch_space(const std::string& path, uint64_t size);
 
   void create_dataset();
 

--- a/apis/python/src/tiledbvcf/binding/writer.h
+++ b/apis/python/src/tiledbvcf/binding/writer.h
@@ -79,7 +79,12 @@ class Writer {
   void set_anchor_gap(const uint32_t anchor_gap);
 
   /**
-    [Creation only] Allocates scratch space for downloading sample files
+    [Store only] Set the max size of TileDB buffers before flushing.
+  */
+  void set_memory_budget(const uint64_t size);
+
+  /**
+    [Store only] Allocates scratch space for downloading sample files
   */
   void set_scratch_space(const std::string& path, uint64_t size);
 

--- a/apis/python/src/tiledbvcf/binding/writer.h
+++ b/apis/python/src/tiledbvcf/binding/writer.h
@@ -93,6 +93,11 @@ class Writer {
   */
   void set_scratch_space(const std::string& path, uint64_t size);
 
+  /**
+    [Store only] Limits the number of VCF records to buffer per file
+  */
+  void set_max_num_records(const uint64_t max_num_records);
+
   void create_dataset();
 
   void register_samples();

--- a/apis/python/src/tiledbvcf/binding/writer.h
+++ b/apis/python/src/tiledbvcf/binding/writer.h
@@ -84,6 +84,11 @@ class Writer {
   void set_num_threads(const uint32_t threads);
 
   /**
+    [Store only] Set the max size of an ingestion task.
+  */
+  void set_thread_task_size(const uint32_t size);
+
+  /**
     [Store only] Set the max size of TileDB buffers before flushing.
   */
   void set_memory_budget(const uint32_t memory_mb);

--- a/apis/python/src/tiledbvcf/binding/writer.h
+++ b/apis/python/src/tiledbvcf/binding/writer.h
@@ -86,7 +86,7 @@ class Writer {
   /**
     [Store only] Set the max size of TileDB buffers before flushing.
   */
-  void set_memory_budget(const uint64_t size);
+  void set_memory_budget(const uint32_t memory_mb);
 
   /**
     [Store only] Allocates scratch space for downloading sample files

--- a/apis/python/src/tiledbvcf/binding/writer.h
+++ b/apis/python/src/tiledbvcf/binding/writer.h
@@ -73,6 +73,11 @@ class Writer {
   */
   void set_tile_capacity(const uint64_t tile_capacity);
 
+ /**
+    [Creation only] Set the length of gaps between inserted anchor records.
+  */
+  void set_anchor_gap(const uint32_t anchor_gap);
+
   /**
     [Creation only] Allocates scratch space for downloading sample files
   */

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -211,8 +211,9 @@ class Dataset(object):
         self,
         extra_attrs=None,
         tile_capacity=None,
+        anchor_gap=None,
         checksum_type=None,
-        allow_duplicates=True
+        allow_duplicates=True,
     ):
         """Create a new dataset
 
@@ -220,6 +221,8 @@ class Dataset(object):
             materialize from fmt field
         :param int tile_capacity: Tile capacity to use for the array schema
             (default = 10000).
+        :param int anchor_gap: Length of gaps between inserted anchor records in
+            bases (default = 1000).
         :param str checksum_type: Optional override checksum type for creating
             new dataset valid values are sha256, md5 or none.
         :param bool allow_duplicates: Allow records with duplicate start
@@ -233,6 +236,9 @@ class Dataset(object):
 
         if tile_capacity is not None:
             self.writer.set_tile_capacity(tile_capacity)
+
+        if anchor_gap is not None:
+            self.writer.set_anchor_gap(anchor_gap)
 
         if checksum_type is not None:
             checksum_type = checksum_type.lower()

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -254,6 +254,7 @@ class Dataset(object):
         self,
         sample_uris=None,
         threads=None,
+        thread_task_size=None,
         memory_budget_mb=None,
         scratch_space_path=None,
         scratch_space_size=None,
@@ -265,6 +266,9 @@ class Dataset(object):
         :param list of str sample_uris: CSV list of sample names to include in
             the count.
         :param int threads: Set the number of threads used for ingestion.
+        :param int thread_task_size: Set the max length (# columns) of an
+            ingestion task. Affects load balancing of ingestion work across
+            threads, and total memory consumption.
         :param int memory_budget_mb: Set the max size (MB) of TileDB buffers before flushing
             (default = 1024).
         :param str scratch_space_path: Directory used for local storage of
@@ -283,6 +287,9 @@ class Dataset(object):
 
         if threads is not None:
             self.writer.set_num_threads(threads)
+
+        if thread_task_size is not None:
+            self.writer.set_thread_task_size(thread_task_size)
 
         if memory_budget_mb is not None:
             self.writer.set_memory_budget(memory_budget_mb)

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -253,6 +253,7 @@ class Dataset(object):
     def ingest_samples(
         self,
         sample_uris=None,
+        threads=None,
         memory_budget=None,
         scratch_space_path=None,
         scratch_space_size=None,
@@ -262,6 +263,7 @@ class Dataset(object):
 
         :param list of str sample_uris: CSV list of sample names to include in
             the count.
+        :param int threads: Set the number of threads used for ingestion.
         :param int memory_budget: Set the max size (MB) of TileDB buffers before flushing
             (default = 1024).
         :param str scratch_space_path: Directory used for local storage of
@@ -275,6 +277,9 @@ class Dataset(object):
 
         if sample_uris is None:
             return
+
+        if threads is not None:
+            self.writer.set_num_threads(threads)
 
         if memory_budget is not None:
             self.writer.set_memory_budget(memory_budget)

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -254,7 +254,7 @@ class Dataset(object):
         self,
         sample_uris=None,
         threads=None,
-        memory_budget=None,
+        memory_budget_mb=None,
         scratch_space_path=None,
         scratch_space_size=None,
         sample_batch_size=None,
@@ -264,7 +264,7 @@ class Dataset(object):
         :param list of str sample_uris: CSV list of sample names to include in
             the count.
         :param int threads: Set the number of threads used for ingestion.
-        :param int memory_budget: Set the max size (MB) of TileDB buffers before flushing
+        :param int memory_budget_mb: Set the max size (MB) of TileDB buffers before flushing
             (default = 1024).
         :param str scratch_space_path: Directory used for local storage of
             downloaded remote samples.
@@ -281,8 +281,8 @@ class Dataset(object):
         if threads is not None:
             self.writer.set_num_threads(threads)
 
-        if memory_budget is not None:
-            self.writer.set_memory_budget(memory_budget)
+        if memory_budget_mb is not None:
+            self.writer.set_memory_budget(memory_budget_mb)
 
         if scratch_space_path is not None and scratch_space_size is not None:
             self.writer.set_scratch_space(scratch_space_path, scratch_space_size)

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -208,12 +208,18 @@ class Dataset(object):
         return self.reader.result_num_records()
 
     def create_dataset(
-        self, extra_attrs=None, checksum_type=None, allow_duplicates=True
+        self,
+        extra_attrs=None,
+        tile_capacity=None,
+        checksum_type=None,
+        allow_duplicates=True
     ):
         """Create a new dataset
 
         :param list of str extra_attrs: CSV list of extra attributes to
             materialize from fmt field
+        :param int tile_capacity: Tile capacity to use for the array schema
+            (default = 10000).
         :param str checksum_type: Optional override checksum type for creating
             new dataset valid values are sha256, md5 or none.
         :param bool allow_duplicates: Allow records with duplicate start
@@ -224,6 +230,9 @@ class Dataset(object):
 
         extra_attrs = "" if extra_attrs is None else extra_attrs
         self.writer.set_extra_attributes(",".join(extra_attrs))
+
+        if tile_capacity is not None:
+            self.writer.set_tile_capacity(tile_capacity)
 
         if checksum_type is not None:
             checksum_type = checksum_type.lower()

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -257,6 +257,7 @@ class Dataset(object):
         memory_budget_mb=None,
         scratch_space_path=None,
         scratch_space_size=None,
+        record_limit=None,
         sample_batch_size=None,
     ):
         """Ingest samples
@@ -270,6 +271,8 @@ class Dataset(object):
             downloaded remote samples.
         :param int scratch_space_size: Amount of local storage that can be used
             for downloading remote samples (MB).
+        :param int record_limit Limit the number of VCF records read into memory
+            per file (default 50000)
         """
 
         if self.mode != "w":
@@ -290,6 +293,9 @@ class Dataset(object):
             raise Exception(
                 "Must set both scratch_space_path and scratch_space_size to use scratch space"
             )
+
+        if record_limit is not None:
+            self.writer.set_max_num_records(record_limit)
 
         if sample_batch_size is not None:
             self.writer.set_sample_batch_size(sample_batch_size)

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -253,14 +253,17 @@ class Dataset(object):
     def ingest_samples(
         self,
         sample_uris=None,
+        memory_budget=None,
         scratch_space_path=None,
         scratch_space_size=None,
         sample_batch_size=None,
     ):
         """Ingest samples
 
-        :param list of str samples: CSV list of sample names to include in
+        :param list of str sample_uris: CSV list of sample names to include in
             the count.
+        :param int memory_budget: Set the max size (MB) of TileDB buffers before flushing
+            (default = 1024).
         :param str scratch_space_path: Directory used for local storage of
             downloaded remote samples.
         :param int scratch_space_size: Amount of local storage that can be used
@@ -272,6 +275,9 @@ class Dataset(object):
 
         if sample_uris is None:
             return
+
+        if memory_budget is not None:
+            self.writer.set_memory_budget(memory_budget)
 
         if scratch_space_path is not None and scratch_space_size is not None:
             self.writer.set_scratch_space(scratch_space_path, scratch_space_size)

--- a/libtiledbvcf/src/c_api/tiledbvcf.cc
+++ b/libtiledbvcf/src/c_api/tiledbvcf.cc
@@ -926,6 +926,18 @@ int32_t tiledb_vcf_writer_set_scratch_space(
   return TILEDB_VCF_OK;
 }
 
+int32_t tiledb_vcf_writer_set_max_num_records(
+    tiledb_vcf_writer_t* writer, uint64_t max_num_records) {
+  if (sanity_check(writer) == TILEDB_VCF_ERR)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          writer, writer->writer_->set_record_limit(max_num_records)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
 int32_t tiledb_vcf_writer_set_verbose(
     tiledb_vcf_writer_t* writer, const bool verbose) {
   if (sanity_check(writer) == TILEDB_VCF_ERR)

--- a/libtiledbvcf/src/c_api/tiledbvcf.cc
+++ b/libtiledbvcf/src/c_api/tiledbvcf.cc
@@ -822,6 +822,18 @@ int32_t tiledb_vcf_writer_set_allow_duplicates(
   return TILEDB_VCF_OK;
 }
 
+int32_t tiledb_vcf_writer_set_tile_capacity(
+    tiledb_vcf_writer_t* writer, uint64_t tile_capacity) {
+  if (sanity_check(writer) == TILEDB_VCF_ERR)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          writer, writer->writer_->set_tile_capacity(tile_capacity)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
 int32_t tiledb_vcf_writer_create_dataset(tiledb_vcf_writer_t* writer) {
   if (sanity_check(writer) == TILEDB_VCF_ERR)
     return TILEDB_VCF_ERR;

--- a/libtiledbvcf/src/c_api/tiledbvcf.cc
+++ b/libtiledbvcf/src/c_api/tiledbvcf.cc
@@ -893,6 +893,17 @@ int32_t tiledb_vcf_writer_get_last_error(
   return TILEDB_VCF_OK;
 }
 
+int32_t tiledb_vcf_writer_set_memory_budget(
+    tiledb_vcf_writer_t* writer, uint64_t size) {
+  if (sanity_check(writer) == TILEDB_VCF_ERR)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(writer, writer->writer_->set_memory_budget(size)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
 int32_t tiledb_vcf_writer_set_scratch_space(
     tiledb_vcf_writer_t* writer, const char* path, uint64_t size) {
   writer->writer_->set_scratch_space(path, size);

--- a/libtiledbvcf/src/c_api/tiledbvcf.cc
+++ b/libtiledbvcf/src/c_api/tiledbvcf.cc
@@ -893,6 +893,17 @@ int32_t tiledb_vcf_writer_get_last_error(
   return TILEDB_VCF_OK;
 }
 
+int32_t tiledb_vcf_writer_set_num_threads(
+    tiledb_vcf_writer_t* writer, uint32_t threads) {
+  if (sanity_check(writer) == TILEDB_VCF_ERR)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(writer, writer->writer_->set_num_threads(threads)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
 int32_t tiledb_vcf_writer_set_memory_budget(
     tiledb_vcf_writer_t* writer, uint64_t size) {
   if (sanity_check(writer) == TILEDB_VCF_ERR)

--- a/libtiledbvcf/src/c_api/tiledbvcf.cc
+++ b/libtiledbvcf/src/c_api/tiledbvcf.cc
@@ -839,8 +839,7 @@ int32_t tiledb_vcf_writer_set_anchor_gap(
   if (sanity_check(writer) == TILEDB_VCF_ERR)
     return TILEDB_VCF_ERR;
 
-  if (SAVE_ERROR_CATCH(
-          writer, writer->writer_->set_anchor_gap(anchor_gap)))
+  if (SAVE_ERROR_CATCH(writer, writer->writer_->set_anchor_gap(anchor_gap)))
     return TILEDB_VCF_ERR;
 
   return TILEDB_VCF_OK;

--- a/libtiledbvcf/src/c_api/tiledbvcf.cc
+++ b/libtiledbvcf/src/c_api/tiledbvcf.cc
@@ -906,7 +906,11 @@ int32_t tiledb_vcf_writer_set_memory_budget(
 
 int32_t tiledb_vcf_writer_set_scratch_space(
     tiledb_vcf_writer_t* writer, const char* path, uint64_t size) {
-  writer->writer_->set_scratch_space(path, size);
+  if (sanity_check(writer) == TILEDB_VCF_ERR)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(writer, writer->writer_->set_scratch_space(path, size)))
+    return TILEDB_VCF_ERR;
 
   return TILEDB_VCF_OK;
 }

--- a/libtiledbvcf/src/c_api/tiledbvcf.cc
+++ b/libtiledbvcf/src/c_api/tiledbvcf.cc
@@ -904,6 +904,17 @@ int32_t tiledb_vcf_writer_set_num_threads(
   return TILEDB_VCF_OK;
 }
 
+int32_t tiledb_vcf_writer_set_thread_task_size(
+    tiledb_vcf_writer_t* writer, uint32_t size) {
+  if (sanity_check(writer) == TILEDB_VCF_ERR)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(writer, writer->writer_->set_thread_task_size(size)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
 int32_t tiledb_vcf_writer_set_memory_budget(
     tiledb_vcf_writer_t* writer, uint64_t size) {
   if (sanity_check(writer) == TILEDB_VCF_ERR)

--- a/libtiledbvcf/src/c_api/tiledbvcf.cc
+++ b/libtiledbvcf/src/c_api/tiledbvcf.cc
@@ -834,6 +834,18 @@ int32_t tiledb_vcf_writer_set_tile_capacity(
   return TILEDB_VCF_OK;
 }
 
+int32_t tiledb_vcf_writer_set_anchor_gap(
+    tiledb_vcf_writer_t* writer, uint32_t anchor_gap) {
+  if (sanity_check(writer) == TILEDB_VCF_ERR)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          writer, writer->writer_->set_anchor_gap(anchor_gap)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
 int32_t tiledb_vcf_writer_create_dataset(tiledb_vcf_writer_t* writer) {
   if (sanity_check(writer) == TILEDB_VCF_ERR)
     return TILEDB_VCF_ERR;

--- a/libtiledbvcf/src/c_api/tiledbvcf.h
+++ b/libtiledbvcf/src/c_api/tiledbvcf.h
@@ -952,6 +952,16 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_set_allow_duplicates(
     tiledb_vcf_writer_t* writer, bool allow_duplicates);
 
 /**
+ * [Creation only] Set the dataset's tile capacity upon creation.
+ *
+ * @param writer VCF writer object
+ * @param tile_capacity tile capacity for the data array
+ * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
+ */
+TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_set_tile_capacity(
+    tiledb_vcf_writer_t* writer, uint64_t tile_capacity);
+
+/**
  * Creates a new TileDB-VCF dataset, using previously set parameters.
  *
  * @param writer VCF writer object

--- a/libtiledbvcf/src/c_api/tiledbvcf.h
+++ b/libtiledbvcf/src/c_api/tiledbvcf.h
@@ -1022,6 +1022,18 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_set_num_threads(
     tiledb_vcf_writer_t* writer, uint32_t threads);
 
 /**
+ * Set max length (# columns) of an ingestion task. Affects load balancing of
+ * ingestion work across threads, and total memory consumption.
+ *
+ * @param writer VCF writer object
+ * @param size The number of threads used for sample ingestion.
+ * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
+ */
+
+TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_set_thread_task_size(
+    tiledb_vcf_writer_t* writer, uint32_t size);
+
+/**
  * Set memory budget for ingestion
  *
  * @param writer VCF writer object

--- a/libtiledbvcf/src/c_api/tiledbvcf.h
+++ b/libtiledbvcf/src/c_api/tiledbvcf.h
@@ -1046,6 +1046,16 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_set_scratch_space(
     tiledb_vcf_writer_t* writer, const char* path, uint64_t size_mb);
 
 /**
+ * Set max record buffer size
+ *
+ * @param writer VCF writer object
+ * @param max_num_records The number of VCF records to buffer per file
+ * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
+ */
+TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_set_max_num_records(
+    tiledb_vcf_writer_t* writer, uint64_t max_num_records);
+
+/**
  * Sets verbose mode on or off
  * @param reader VCF writter object
  * @param writer VCF writer object

--- a/libtiledbvcf/src/c_api/tiledbvcf.h
+++ b/libtiledbvcf/src/c_api/tiledbvcf.h
@@ -962,6 +962,16 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_set_tile_capacity(
     tiledb_vcf_writer_t* writer, uint64_t tile_capacity);
 
 /**
+ * [Creation only] Set the length of gaps between inserted anchor records.
+ *
+ * @param writer VCF writer object
+ * @param anchor_gap anchor gap length (in bases)
+ * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
+ */
+TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_set_anchor_gap(
+    tiledb_vcf_writer_t* writer, uint32_t anchor_gap);
+
+/**
  * Creates a new TileDB-VCF dataset, using previously set parameters.
  *
  * @param writer VCF writer object

--- a/libtiledbvcf/src/c_api/tiledbvcf.h
+++ b/libtiledbvcf/src/c_api/tiledbvcf.h
@@ -1011,6 +1011,17 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_get_last_error(
     tiledb_vcf_writer_t* writer, tiledb_vcf_error_t** error);
 
 /**
+ * Set number of ingestion threads
+ *
+ * @param writer VCF writer object
+ * @param threads The number of threads used for sample ingestion.
+ * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
+ */
+
+TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_set_num_threads(
+    tiledb_vcf_writer_t* writer, uint32_t threads);
+
+/**
  * Set memory budget for ingestion
  *
  * @param writer VCF writer object
@@ -1018,8 +1029,8 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_get_last_error(
  * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
  */
 
-TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_set_memory_budget(
-    tiledb_vcf_writer_t* writer, uint64_t size);
+TILEDBVCF_EXPORT int32_t
+tiledb_vcf_writer_set_memory_budget(tiledb_vcf_writer_t* writer, uint64_t size);
 
 /**
  * Set scratch space for ingestion or registration

--- a/libtiledbvcf/src/c_api/tiledbvcf.h
+++ b/libtiledbvcf/src/c_api/tiledbvcf.h
@@ -1011,6 +1011,17 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_get_last_error(
     tiledb_vcf_writer_t* writer, tiledb_vcf_error_t** error);
 
 /**
+ * Set memory budget for ingestion
+ *
+ * @param writer VCF writer object
+ * @param size The max size of TileDB buffers before flushing. Defaults to 1GB.
+ * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
+ */
+
+TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_set_memory_budget(
+    tiledb_vcf_writer_t* writer, uint64_t size);
+
+/**
  * Set scratch space for ingestion or registration
  *
  * @param writer VCF writer object

--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -152,6 +152,10 @@ void Writer::set_allow_duplicates(const bool& allow_duplicates) {
   creation_params_.allow_duplicates = allow_duplicates;
 }
 
+void Writer::set_tile_capacity(const uint64_t tile_capacity) {
+  creation_params_.tile_capacity = tile_capacity;
+}
+
 void Writer::create_dataset() {
   TileDBVCFDataset::create(creation_params_);
 }

--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -759,6 +759,10 @@ void Writer::set_memory_budget(const unsigned mb) {
   ingestion_params_.max_tiledb_buffer_size_mb = mb;
 }
 
+void Writer::set_record_limit(const uint64_t max_num_records) {
+  ingestion_params_.max_record_buffer_size = max_num_records;
+}
+
 void Writer::set_scratch_space(const std::string& path, uint64_t size) {
   ScratchSpaceInfo scratchSpaceInfo;
   scratchSpaceInfo.path = path;

--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -751,6 +751,10 @@ std::vector<Region> Writer::prepare_region_list(
   return result;
 }
 
+void Writer::set_num_threads(const unsigned threads) {
+  ingestion_params_.num_threads = threads;
+}
+
 void Writer::set_memory_budget(const uint64_t size) {
   ingestion_params_.max_tiledb_buffer_size_mb = size;
 }

--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -755,6 +755,10 @@ void Writer::set_num_threads(const unsigned threads) {
   ingestion_params_.num_threads = threads;
 }
 
+void Writer::set_thread_task_size(const unsigned size) {
+  ingestion_params_.thread_task_size = size;
+}
+
 void Writer::set_memory_budget(const unsigned mb) {
   ingestion_params_.max_tiledb_buffer_size_mb = mb;
 }

--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -755,8 +755,8 @@ void Writer::set_num_threads(const unsigned threads) {
   ingestion_params_.num_threads = threads;
 }
 
-void Writer::set_memory_budget(const uint64_t size) {
-  ingestion_params_.max_tiledb_buffer_size_mb = size;
+void Writer::set_memory_budget(const unsigned mb) {
+  ingestion_params_.max_tiledb_buffer_size_mb = mb;
 }
 
 void Writer::set_scratch_space(const std::string& path, uint64_t size) {

--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -156,6 +156,10 @@ void Writer::set_tile_capacity(const uint64_t tile_capacity) {
   creation_params_.tile_capacity = tile_capacity;
 }
 
+void Writer::set_anchor_gap(const uint32_t anchor_gap) {
+  creation_params_.anchor_gap = anchor_gap;
+}
+
 void Writer::create_dataset() {
   TileDBVCFDataset::create(creation_params_);
 }

--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -751,6 +751,10 @@ std::vector<Region> Writer::prepare_region_list(
   return result;
 }
 
+void Writer::set_memory_budget(const uint64_t size) {
+  ingestion_params_.max_tiledb_buffer_size_mb = size;
+}
+
 void Writer::set_scratch_space(const std::string& path, uint64_t size) {
   ScratchSpaceInfo scratchSpaceInfo;
   scratchSpaceInfo.path = path;

--- a/libtiledbvcf/src/write/writer.h
+++ b/libtiledbvcf/src/write/writer.h
@@ -164,6 +164,12 @@ class Writer {
    */
   void set_allow_duplicates(const bool& allow_duplicates);
 
+  /**
+   * Sets the data array's tile capacity
+   * @param tile_capacity
+   */
+  void set_tile_capacity(const uint64_t tile_capacity);
+
   /** Creates an empty dataset based on parameters that have been set. */
   void create_dataset();
 

--- a/libtiledbvcf/src/write/writer.h
+++ b/libtiledbvcf/src/write/writer.h
@@ -189,7 +189,7 @@ class Writer {
   void set_num_threads(const unsigned threads);
 
   /** Set the max size of TileDB buffers before flushing. Defaults to 1GB. */
-  void set_memory_budget(const uint64_t size);
+  void set_memory_budget(const unsigned mb);
 
   /** Set ingestion scatch space for ingestion or registration */
   void set_scratch_space(const std::string& path, uint64_t size);

--- a/libtiledbvcf/src/write/writer.h
+++ b/libtiledbvcf/src/write/writer.h
@@ -170,6 +170,12 @@ class Writer {
    */
   void set_tile_capacity(const uint64_t tile_capacity);
 
+  /**
+   * Defines the length of gaps between inserted anchor records.
+   * @param tile_capacity
+   */
+  void set_anchor_gap(const uint32_t anchor_gap);
+
   /** Creates an empty dataset based on parameters that have been set. */
   void create_dataset();
 

--- a/libtiledbvcf/src/write/writer.h
+++ b/libtiledbvcf/src/write/writer.h
@@ -188,6 +188,9 @@ class Writer {
   /** Set number of ingestion threads. */
   void set_num_threads(const unsigned threads);
 
+  /** Set the max length of an ingestion task. */
+  void set_thread_task_size(const unsigned size);
+
   /** Set the max size of TileDB buffers before flushing. Defaults to 1GB. */
   void set_memory_budget(const unsigned mb);
 

--- a/libtiledbvcf/src/write/writer.h
+++ b/libtiledbvcf/src/write/writer.h
@@ -185,6 +185,8 @@ class Writer {
   /** Ingests samples based on parameters that have been set. */
   void ingest_samples();
 
+  /** Set number of ingestion threads. */
+  void set_num_threads(const unsigned threads);
 
   /** Set the max size of TileDB buffers before flushing. Defaults to 1GB. */
   void set_memory_budget(const uint64_t size);

--- a/libtiledbvcf/src/write/writer.h
+++ b/libtiledbvcf/src/write/writer.h
@@ -185,6 +185,10 @@ class Writer {
   /** Ingests samples based on parameters that have been set. */
   void ingest_samples();
 
+
+  /** Set the max size of TileDB buffers before flushing. Defaults to 1GB. */
+  void set_memory_budget(const uint64_t size);
+
   /** Set ingestion scatch space for ingestion or registration */
   void set_scratch_space(const std::string& path, uint64_t size);
 

--- a/libtiledbvcf/src/write/writer.h
+++ b/libtiledbvcf/src/write/writer.h
@@ -194,6 +194,9 @@ class Writer {
   /** Set ingestion scatch space for ingestion or registration */
   void set_scratch_space(const std::string& path, uint64_t size);
 
+  /** Set max number of VCF records to buffer per file */
+  void set_record_limit(const uint64_t max_num_records);
+
   /**
    * Sets verbose mode on or off
    * @param verbose setting


### PR DESCRIPTION
Extends the C API to allow setting the following dataset creation/ingestion parameters and exposes them to Python:

**Creation parameters**
- `anchor_gap`
- `tile_capacity`

**Ingestion parameters**
- `num_threads`
- `thread_task_size`
- `memory_budget_mb`
- `max_buffer_limit`