### PR TITLE
Python API for enabling/printing TileDB write statistics

### DIFF
--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -48,6 +48,7 @@ PYBIND11_MODULE(libtiledbvcf, m) {
   py::class_<Writer>(m, "Writer")
       .def(py::init())
       .def("init", &Writer::init)
+      .def("set_tiledb_stats_enabled", &Writer::set_tiledb_stats_enabled)
       .def("set_samples", &Writer::set_samples)
       .def("set_extra_attributes", &Writer::set_extra_attributes)
       .def("set_checksum", &Writer::set_checksum)
@@ -65,5 +66,7 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("ingest_samples", &Writer::ingest_samples)
       .def("get_schema_version", &Writer::get_schema_version)
       .def("set_tiledb_config", &Writer::set_tiledb_config)
-      .def("set_sample_batch_size", &Writer::set_sample_batch_size);
+      .def("set_sample_batch_size", &Writer::set_sample_batch_size)
+      .def("get_tiledb_stats_enabled", &Writer::get_tiledb_stats_enabled)
+      .def("get_tiledb_stats", &Writer::get_tiledb_stats);
 }

--- a/apis/python/src/tiledbvcf/binding/writer.cc
+++ b/apis/python/src/tiledbvcf/binding/writer.cc
@@ -70,6 +70,13 @@ void Writer::init(const std::string& dataset_uri) {
   check_error(writer, tiledb_vcf_writer_init(writer, dataset_uri.c_str()));
 }
 
+void Writer::set_tiledb_stats_enabled(const bool stats_enabled) {
+  auto writer = ptr.get();
+  check_error(
+      writer,
+      tiledb_vcf_writer_set_tiledb_stats_enabled(writer, stats_enabled));
+}
+
 void Writer::set_samples(const std::string& samples) {
   auto writer = ptr.get();
   check_error(writer, tiledb_vcf_writer_set_samples(writer, samples.c_str()));
@@ -181,6 +188,22 @@ void Writer::set_tiledb_config(const std::string& config_str) {
 void Writer::set_sample_batch_size(const uint64_t size) {
   auto writer = ptr.get();
   check_error(writer, tiledb_vcf_writer_set_sample_batch_size(writer, size));
+}
+
+bool Writer::get_tiledb_stats_enabled() {
+  auto writer = ptr.get();
+  bool stats_enabled;
+  check_error(
+      writer,
+      tiledb_vcf_writer_get_tiledb_stats_enabled(writer, &stats_enabled));
+  return stats_enabled;
+}
+
+std::string Writer::get_tiledb_stats() {
+  auto writer = ptr.get();
+  char* stats;
+  check_error(writer, tiledb_vcf_writer_get_tiledb_stats(writer, &stats));
+  return std::string(stats);
 }
 
 }  // namespace tiledbvcfpy

--- a/apis/python/src/tiledbvcf/binding/writer.h
+++ b/apis/python/src/tiledbvcf/binding/writer.h
@@ -49,6 +49,9 @@ class Writer {
   /** Initializes the writer for creating or writing to the given dataset. */
   void init(const std::string& dataset_uri);
 
+  /** Enables or disables internal TileDB statistics. */
+  void set_tiledb_stats_enabled(const bool stats_enabled);
+
   /** Sets a CSV list of samples be registered or ingested. */
   void set_samples(const std::string& samples);
 
@@ -126,6 +129,16 @@ class Writer {
     [Store only] Sets the number of samples per batch for ingestion
   */
   void set_sample_batch_size(const uint64_t size);
+
+  /**
+    [Store only] Checks whether internal TileDB Statistics are enabled
+  */
+  bool get_tiledb_stats_enabled();
+
+  /**
+    Fetches internal TileDB statistics
+  */
+  std::string get_tiledb_stats();
 
  private:
   /** Helper function to free a C writer instance */


### PR DESCRIPTION
Updates the `Dataset` class to allow enabling tiledb stats in write mode.