### PR TITLE
Add verbose output and logging of buffer sizes

### DIFF
--- a/apis/spark/src/main/java/io/tiledb/vcf/VCFInputPartitionReader.java
+++ b/apis/spark/src/main/java/io/tiledb/vcf/VCFInputPartitionReader.java
@@ -342,7 +342,11 @@ public class VCFInputPartitionReader implements InputPartitionReader<ColumnarBat
                 + bufferSizeMB
                 + " is small. Increase the memory budget from its current setting of "
                 + (memBudgetMB * 2)
-                + " MB.");
+                + " MB. Or reduce fields current selection of "
+                + numColumns
+                + " fields ("
+                + nBuffers
+                + " buffers)");
       }
 
       if (bufferSizeMB > 2048) {
@@ -351,11 +355,20 @@ public class VCFInputPartitionReader implements InputPartitionReader<ColumnarBat
         log.warn(
             String.format(
                 ""
-                    + "Size of individfaual buffers is larger than 2048 MB which is not supported by Arrow 0.10.0 (Spark 2.4). "
+                    + "Size of individual buffers is larger than 2048 MB which is not supported by Arrow 0.10.0 (Spark 2.4). "
                     + "Using %d buffers, a reasonable memory budget is %d."
                     + "Setting buffer size to 2048 instead.",
                 nBuffers, memBudgetMB));
       }
+
+      log.info(
+          "Initializing "
+              + numColumns
+              + " columns with "
+              + nBuffers
+              + " buffers of size "
+              + bufferSizeMB
+              + "MB");
 
       long bufferSizeBytes = bufferSizeMB * (1024 * 1024);
 

--- a/libtiledbvcf/src/dataset/attribute_buffer_set.cc
+++ b/libtiledbvcf/src/dataset/attribute_buffer_set.cc
@@ -4,6 +4,9 @@
 namespace tiledb {
 namespace vcf {
 
+AttributeBufferSet::AttributeBufferSet(bool verbose)
+    : verbose_(verbose){};
+
 void AttributeBufferSet::allocate_fixed(
     const std::unordered_set<std::string>& attr_names,
     unsigned mem_budget_mb,
@@ -27,6 +30,12 @@ void AttributeBufferSet::allocate_fixed(
   if (mem_budget_mb == 0) {
     nbytes = 1024;
     num_offsets = nbytes / sizeof(uint64_t);
+  }
+
+  if (verbose_) {
+    std::cout << "Allocating " << attr_names.size() << " fields ("
+              << num_buffers << " buffers) of size " << nbytes << " bytes ("
+              << nbytes / (1024.0f * 1024.0f) << "MB)" << std::endl;
   }
 
   using attrNamesV4 = TileDBVCFDataset::AttrNames::V4;

--- a/libtiledbvcf/src/dataset/attribute_buffer_set.h
+++ b/libtiledbvcf/src/dataset/attribute_buffer_set.h
@@ -44,6 +44,7 @@ namespace vcf {
  */
 class AttributeBufferSet {
  public:
+  AttributeBufferSet(bool verbose = false);
   /**
    * Resize buffers for the given set of attributes using the given allocation
    * budget.
@@ -224,6 +225,9 @@ class AttributeBufferSet {
    * attributes.
    */
   std::vector<std::tuple<bool, std::string, Buffer*, unsigned>> fixed_alloc_;
+
+  /** verbose output enabled */
+  bool verbose_;
 };
 
 }  // namespace vcf

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -1822,8 +1822,8 @@ void Reader::prepare_attribute_buffers() {
         TileDBVCFDataset::AttrNames::V2::real_end};
   }
 
-  buffers_a.reset(new AttributeBufferSet);
-  buffers_b.reset(new AttributeBufferSet);
+  buffers_a.reset(new AttributeBufferSet(params_.verbose));
+  buffers_b.reset(new AttributeBufferSet(params_.verbose));
 
   const auto* user_exp = dynamic_cast<const InMemoryExporter*>(exporter_.get());
   if (params_.cli_count_only || exporter_ == nullptr ||


### PR DESCRIPTION
This helps to understand the size of the core C++ buffer sizes or the spark buffer sizes.