### PR TITLE
Add c-api/java/spark/python api for materialized attrs

### DIFF
--- a/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.c
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.c
@@ -555,6 +555,42 @@ JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1rea
   return rc;
 }
 
+
+JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1get_1materialized_1attribute_1count
+  (JNIEnv* env, jclass self, jlong readerPtr, jintArray countOut) {
+  (void)self;
+  tiledb_vcf_reader_t* reader = (tiledb_vcf_reader_t*)readerPtr;
+  if (reader == 0) {
+    return TILEDB_VCF_ERR;
+  }
+
+  int32_t count;
+  int32_t rc = tiledb_vcf_reader_get_materialized_attribute_count(reader, &count);
+  if (rc == TILEDB_VCF_OK) {
+    return set_out_param_int32(env, count, countOut);
+  }
+
+    return rc;
+}
+
+JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1get_1materialized_1attribute_1name
+  (JNIEnv* env, jclass self, jlong readerPtr, jint index, jbyteArray nameOut) {
+  (void)self;
+  tiledb_vcf_reader_t* reader = (tiledb_vcf_reader_t*)readerPtr;
+  if (reader == 0) {
+    return TILEDB_VCF_ERR;
+  }
+
+  char *buf;
+  int32_t rc = tiledb_vcf_reader_get_materialized_attribute_name(reader, index, &buf);
+  if (rc == TILEDB_VCF_OK) {
+    int length = strlen(buf);
+    (*env)->SetByteArrayRegion(env, nameOut, 0, length, buf);
+  }
+
+  return rc;
+}
+
 JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1get_1fmt_1attribute_1count
   (JNIEnv* env, jclass self, jlong readerPtr, jintArray countOut) {
   (void)self;

--- a/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.h
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.h
@@ -200,6 +200,22 @@ JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1rea
   (JNIEnv *, jclass, jlong, jint, jbyteArray);
 
 /*
+* Class:     io_tiledb_libvcfnative_LibVCFNative
+* Method:    tiledb_vcf_reader_get_materialized_attribute_count
+* Signature: (J[I)I
+*/
+JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1get_1materialized_1attribute_1count
+(JNIEnv *, jclass, jlong, jintArray);
+
+/*
+* Class:     io_tiledb_libvcfnative_LibVCFNative
+* Method:    tiledb_vcf_reader_get_materialized_attribute_name
+* Signature: (JI[B)I
+*/
+JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1get_1materialized_1attribute_1name
+(JNIEnv *, jclass, jlong, jint, jbyteArray);
+
+/*
  * Class:     io_tiledb_libvcfnative_LibVCFNative
  * Method:    tiledb_vcf_reader_get_fmt_attribute_count
  * Signature: (J[I)I

--- a/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.java
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.java
@@ -88,6 +88,12 @@ public class LibVCFNative {
   public static final native int tiledb_vcf_reader_get_attribute_name(
       long readerPtr, int index, byte[] name);
 
+  public static final native int tiledb_vcf_reader_get_materialized_attribute_count(
+      long readerPtr, int[] count);
+
+  public static final native int tiledb_vcf_reader_get_materialized_attribute_name(
+      long readerPtr, int index, byte[] name);
+
   public static final native int tiledb_vcf_reader_get_fmt_attribute_count(
       long readerPtr, int[] count);
 

--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -42,6 +42,7 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("get_fmt_attributes", &Reader::get_fmt_attributes)
       .def("get_info_attributes", &Reader::get_info_attributes)
       .def("get_queryable_attributes", &Reader::get_queryable_attributes)
+      .def("get_materialized_attributes", &Reader::get_materialized_attributes)
       .def("get_sample_count", &Reader::get_sample_count)
       .def("get_sample_names", &Reader::get_sample_names);
 

--- a/apis/python/src/tiledbvcf/binding/reader.cc
+++ b/apis/python/src/tiledbvcf/binding/reader.cc
@@ -408,6 +408,25 @@ std::vector<std::string> Reader::get_queryable_attributes() {
   return attrs;
 }
 
+
+std::vector<std::string> Reader::get_materialized_attributes() {
+  auto reader = ptr.get();
+  int32_t count;
+  std::vector<std::string> attrs;
+  check_error(
+      reader, tiledb_vcf_reader_get_materialized_attribute_count(reader, &count));
+
+  for (int32_t i = 0; i < count; i++) {
+    char* name;
+    check_error(
+        reader,
+        tiledb_vcf_reader_get_materialized_attribute_name(reader, i, &name));
+    attrs.emplace_back(name);
+  }
+
+  return attrs;
+}
+
 int32_t Reader::get_sample_count() {
   auto reader = ptr.get();
   int32_t count;

--- a/apis/python/src/tiledbvcf/binding/reader.h
+++ b/apis/python/src/tiledbvcf/binding/reader.h
@@ -127,6 +127,9 @@ class Reader {
   /** Returns all queryable attribute names */
   std::vector<std::string> get_queryable_attributes();
 
+  /** Returns all materialized attribute names */
+  std::vector<std::string> get_materialized_attributes();
+
   /** Returns number of registered samples in the dataset */
   int32_t get_sample_count();
 

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -368,11 +368,10 @@ class Dataset(object):
             return self._info_attrs()
         elif attr_type == "fmt":
             return self._fmt_attrs()
+        elif attr_type == "builtin":
+            return self._materialized_attrs()
         else:
-            attrs = set(self._queryable_attrs()).difference(comb_attrs)
-            if attr_type == "builtin":
-                attrs.difference_update(self._info_attrs() + self._fmt_attrs())
-            return sorted(list(attrs))
+            return self._queryable_attrs()
 
     def _queryable_attrs(self):
         return self.reader.get_queryable_attributes()
@@ -382,6 +381,9 @@ class Dataset(object):
 
     def _info_attrs(self):
         return self.reader.get_info_attributes()
+
+    def _materialized_attrs(self):
+        return self.reader.get_materialized_attributes()
 
     def _set_samples(self, samples=None, samples_file=None):
         if samples is not None and samples_file is not None:

--- a/apis/python/tests/test_tiledbvcf.py
+++ b/apis/python/tests/test_tiledbvcf.py
@@ -58,14 +58,16 @@ def test_retrieve_attributes(test_ds):
         "contig",
         "pos_start",
         "pos_end",
-        "query_bed_start",
-        "query_bed_end",
         "alleles",
         "id",
+        "fmt",
+        "info",
         "filters",
         "qual",
+        "query_bed_end",
+        "query_bed_start",
     ]
-    assert test_ds.attributes(attr_type="builtin") == sorted(builtin_attrs)
+    assert sorted(test_ds.attributes(attr_type="builtin")) == sorted(builtin_attrs)
 
     info_attrs = [
         "info_BaseQRankSum",

--- a/apis/spark/src/main/java/io/tiledb/vcf/VCFDataSourceOptions.java
+++ b/apis/spark/src/main/java/io/tiledb/vcf/VCFDataSourceOptions.java
@@ -134,6 +134,17 @@ public class VCFDataSourceOptions implements Serializable {
     return Optional.empty();
   }
 
+  /**
+   * @return If only materialized fields should be exposed. If false then the spark schema show all
+   *     selectable fields
+   */
+  public Optional<Boolean> getOnlyMaterializedFields() {
+    if (options.containsKey("only_materialized_fields")) {
+      return Optional.of(Boolean.parseBoolean(options.get("only_materialized_fields")));
+    }
+    return Optional.empty();
+  }
+
   /** @return Optional CSV String of config parameters */
   public Optional<String> getConfigCSV() {
     return getConfigCSV(options);

--- a/libtiledbvcf/src/c_api/tiledbvcf.cc
+++ b/libtiledbvcf/src/c_api/tiledbvcf.cc
@@ -637,6 +637,30 @@ int32_t tiledb_vcf_reader_get_queryable_attribute_name(
   return TILEDB_VCF_OK;
 }
 
+int32_t tiledb_vcf_reader_get_materialized_attribute_count(
+    tiledb_vcf_reader_t* reader, int32_t* count) {
+  if (sanity_check(reader) == TILEDB_VCF_ERR || count == nullptr)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          reader, reader->reader_->materialized_attribute_count(count)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
+int32_t tiledb_vcf_reader_get_materialized_attribute_name(
+    tiledb_vcf_reader_t* reader, int32_t index, char** name) {
+  if (sanity_check(reader) == TILEDB_VCF_ERR || name == nullptr)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          reader, reader->reader_->materialized_attribute_name(index, name)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
 int32_t tiledb_vcf_reader_get_fmt_attribute_count(
     tiledb_vcf_reader_t* reader, int32_t* count) {
   if (sanity_check(reader) == TILEDB_VCF_ERR || count == nullptr)

--- a/libtiledbvcf/src/c_api/tiledbvcf.h
+++ b/libtiledbvcf/src/c_api/tiledbvcf.h
@@ -749,12 +749,31 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_attribute_type(
     int32_t* list);
 
 /**
- * Get count of materialized attributes in the array
+ * Get count of queryable attributes in the array
  * @param reader VCF reader object
  * @param count int32_t which is set to count of attributes
  * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
  */
 TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_queryable_attribute_count(
+    tiledb_vcf_reader_t* reader, int32_t* count);
+
+/**
+ * Fetch name of a queryable attribute from the dataset
+ * @param reader VCF reader object
+ * @param index attribute to fetch name of
+ * @param name char* returned as name
+ * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
+ */
+TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_queryable_attribute_name(
+    tiledb_vcf_reader_t* reader, int32_t index, char** name);
+
+/**
+ * Get count of materialized attributes in the array
+ * @param reader VCF reader object
+ * @param count int32_t which is set to count of attributes
+ * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
+ */
+TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_materialized_attribute_count(
     tiledb_vcf_reader_t* reader, int32_t* count);
 
 /**
@@ -764,7 +783,7 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_queryable_attribute_count(
  * @param name char* returned as name
  * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
  */
-TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_queryable_attribute_name(
+TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_get_materialized_attribute_name(
     tiledb_vcf_reader_t* reader, int32_t index, char** name);
 
 /**

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -345,6 +345,13 @@ void TileDBVCFDataset::open(
     unique_queryable_attributes.emplace(s);
   }
 
+  // Set materialized attributes
+  for (const auto& key : unique_queryable_attributes) {
+    std::vector<char> name(key.begin(), key.end());
+    name.emplace_back('\0');
+    materialized_vcf_attributes_.push_back(name);
+  }
+
   for (const auto& info : info_field_types_) {
     unique_queryable_attributes.emplace("info_" + info.first);
   }
@@ -1465,6 +1472,15 @@ int32_t TileDBVCFDataset::queryable_attribute_count() const {
 const char* TileDBVCFDataset::queryable_attribute_name(
     const int32_t index) const {
   return this->vcf_attributes_[index].data();
+}
+
+int32_t TileDBVCFDataset::materialized_attribute_count() const {
+  return this->materialized_vcf_attributes_.size();
+}
+
+const char* TileDBVCFDataset::materialized_attribute_name(
+    const int32_t index) const {
+  return this->materialized_vcf_attributes_[index].data();
 }
 
 const char* TileDBVCFDataset::sample_name(const int32_t index) const {

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -322,6 +322,19 @@ class TileDBVCFDataset {
   const char* queryable_attribute_name(int32_t index) const;
 
   /**
+   * Get materialized attribute count
+   * @return
+   */
+  int32_t materialized_attribute_count() const;
+
+  /**
+   * Get materialized attribute name by index
+   * @param index
+   * @return
+   */
+  const char* materialized_attribute_name(int32_t index) const;
+
+  /**
    * Get sample name by index
    * @param index
    * @return
@@ -469,6 +482,9 @@ class TileDBVCFDataset {
 
   /** List of all attributes of vcf for querying */
   std::vector<std::vector<char>> vcf_attributes_;
+
+  /** List of all materialzied attributes of vcf for querying */
+  std::vector<std::vector<char>> materialized_vcf_attributes_;
 
   /** List of sample names for exporting */
   std::vector<std::vector<char>> sample_names_;

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -1894,6 +1894,17 @@ void Reader::queryable_attribute_name(int32_t index, char** name) {
   *name = const_cast<char*>(this->dataset_->queryable_attribute_name(index));
 }
 
+void Reader::materialized_attribute_count(int32_t* count) {
+  if (count == nullptr)
+    throw std::runtime_error("count must be non-null in attribute_count");
+
+  *count = this->dataset_->materialized_attribute_count();
+}
+
+void Reader::materialized_attribute_name(int32_t index, char** name) {
+  *name = const_cast<char*>(this->dataset_->materialized_attribute_name(index));
+}
+
 void Reader::fmt_attribute_count(int32_t* count) {
   if (count == nullptr)
     throw std::runtime_error("count must be non-null in attribute_count");

--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -276,17 +276,30 @@ class Reader {
       int32_t buffer_idx, const char** name, uint8_t** buff) const;
 
   /**
-   * Get the count of materialized attributes
+   * Get the count of queryable attributes
    * @param count of attributes
    */
   void queryable_attribute_count(int32_t* count);
+
+  /**
+   * Get a queryable attribute name by index
+   * @param index of attribute to fetch
+   * @param name of attribute
+   */
+  void queryable_attribute_name(int32_t index, char** name);
+
+  /**
+   * Get the count of materialized attributes
+   * @param count of attributes
+   */
+  void materialized_attribute_count(int32_t* count);
 
   /**
    * Get a materialized attribute name by index
    * @param index of attribute to fetch
    * @param name of attribute
    */
-  void queryable_attribute_name(int32_t index, char** name);
+  void materialized_attribute_name(int32_t index, char** name);
 
   /**
    * Get the count of fmt attributes


### PR DESCRIPTION
This is a new API to list materialized attributes. Sometimes its helpful to know the difference, and specifically in spark to allow for setting the spark schema to only materialized fields instead of all queryable fields.