### PR TITLE
Add threshold for double buffering of TileDB Query

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -23,6 +23,7 @@ stages:
             BUILD_PYTHON_API: ON
             BUILD_SPARK_API: ON
             DOWNLOAD_TILEDB_PREBUILT: ON
+            ARTIFACT_NAME: linux
           linux_tiledb_source_build:
             imageName: 'ubuntu-18.04'
             python.version: '3.x'
@@ -30,7 +31,8 @@ stages:
             BUILD_PYTHON_API: OFF
             BUILD_SPARK_API: OFF
             DOWNLOAD_TILEDB_PREBUILT: OFF
-          mac:
+            ARTIFACT_NAME: linux_tiledb_source_build
+          macos:
             imageName: 'macOS-10.14'
             python.version: '3.7'
             CXX: clang++
@@ -38,6 +40,7 @@ stages:
             BUILD_SPARK_API: ON
             DOWNLOAD_TILEDB_PREBUILT: ON
             SDKROOT: '/Applications/Xcode_10.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk'
+            ARTIFACT_NAME: macos
 
       pool:
         vmImage: $(imageName)

--- a/ci/azure-linux_mac.yml
+++ b/ci/azure-linux_mac.yml
@@ -47,6 +47,11 @@ steps:
   displayName: 'Install dependencies'
 
 - bash: |
+    ulimit -c               # should output 0 if disabled
+    ulimit -c unlimited     # Enable core dumps to be captured (must be in same run block) 
+    ulimit -c               # should output 'unlimited' now    
+
+  
     # azure bash does not treat intermediate failure as error
     # https://github.com/Microsoft/azure-pipelines-yaml/issues/135
     set -e pipefail
@@ -61,17 +66,54 @@ steps:
     # Configure and build TileDB-VCF
     mkdir -p $BUILD_REPOSITORY_LOCALPATH/libtiledbvcf/build
     cd $BUILD_REPOSITORY_LOCALPATH/libtiledbvcf/build
-    cmake -DCMAKE_INSTALL_PREFIX=$BUILD_REPOSITORY_LOCALPATH/dist -DDOWNLOAD_TILEDB_PREBUILT=${DOWNLOAD_TILEDB_PREBUILT} ..
+    cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$BUILD_REPOSITORY_LOCALPATH/dist -DDOWNLOAD_TILEDB_PREBUILT=${DOWNLOAD_TILEDB_PREBUILT} ..
 
     make -j4
     make -j4 -C libtiledbvcf tiledb_vcf_unit
-    make check
+    # cmake catches the segfault and blocks the core dump
+    # sudo make check
+    ./libtiledbvcf/test/tiledb_vcf_unit
+  
     ../test/run-cli-tests.sh . ../test/inputs
 
     make install-libtiledbvcf
 
   displayName: 'Build and test TileDB-VCF'
 
+# Currently the core dump on linux goes to the current directory, these might be needed on other distros/osx
+# - bash: |
+#     sudo chmod -R +rwx /var/crash/* # Enable access to core dumps (doesn't need to be in same run block)
+#   condition: and(failed(), eq(variables['Agent.OS'], 'Linux')) # only run this job if the build step failed
+#   displayName: "Enable Access to core dumps (failed checks only)"
+# 
+# - bash: |
+#     sudo chmod -R +rwx /cores/* # Enable access to core dumps (doesn't need to be in same run block)
+#   condition: and(failed(), eq(variables['Agent.OS'], 'Darwin')) # only run this job if the build step failed
+#   displayName: "Enable Access to core dumps (failed checks only)"
+  
+- task: PublishBuildArtifacts@1
+  inputs:
+    pathtoPublish: 'libtiledbvcf/build/core'
+    artifactName: '$(ARTIFACT_NAME)-coredump'
+  condition: failed() # only run this job if the build step failed
+  
+- task: ArchiveFiles@2
+  inputs:
+    rootFolderOrFile: '$(Build.Repository.LocalPath)'
+    includeRootFolder: false
+    archiveType: 'tar' # Options: zip, 7z, tar, wim
+    tarCompression: 'gz' # Optional. Options: gz, bz2, xz, none
+    archiveFile: '$(Build.ArtifactStagingDirectory)/$(ARTIFACT_NAME)-build-dir.tar.gz'
+    replaceExistingArchive: true
+    verbose: true # Optional
+  condition: or(failed(), succeeded()) # only run this job if the build step failed
+  
+- task: PublishBuildArtifacts@1
+  inputs:
+    pathtoPublish: '$(Build.ArtifactStagingDirectory)/$(ARTIFACT_NAME)-build-dir.tar.gz'
+    artifactName: 'build-dirs'
+  condition: or(failed(), succeeded()) # only run this job if the build step failed
+  
 - bash: |
     set -e pipefail
     if [[ "$BUILD_SPARK_API" == "ON" ]]; then

--- a/libtiledbvcf/cmake/Modules/FindTileDB_EP.cmake
+++ b/libtiledbvcf/cmake/Modules/FindTileDB_EP.cmake
@@ -87,6 +87,7 @@ else()
             -DTILEDB_S3=${TILEDB_S3}
             -DTILEDB_VERBOSE=ON
             -DTILEDB_SERIALIZATION=ON
+            -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
           UPDATE_COMMAND ""
           INSTALL_COMMAND
             ${CMAKE_COMMAND} --build . --target install-tiledb

--- a/libtiledbvcf/src/dataset/attribute_buffer_set.h
+++ b/libtiledbvcf/src/dataset/attribute_buffer_set.h
@@ -44,7 +44,19 @@ namespace vcf {
  */
 class AttributeBufferSet {
  public:
-  AttributeBufferSet(bool verbose = false);
+  explicit AttributeBufferSet(bool verbose = false);
+
+  /**
+   * Compute the size of the buffers in bytes based on memory budget and list of
+   * attributes to select
+   * @param attr_names
+   * @param mem_budget_mb
+   * @return size of buffers in bytes
+   */
+  static uint64_t compute_buffer_size(
+      const std::unordered_set<std::string>& attr_names,
+      uint64_t mem_budget_mb);
+
   /**
    * Resize buffers for the given set of attributes using the given allocation
    * budget.

--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -85,6 +85,9 @@ struct ExportParams {
 
   // Memory/performance params:
   unsigned memory_budget_mb = 2 * 1024;
+
+  // Size in bytes at which if the buffers are larger we will double buffer
+  uint64_t double_buffering_threshold = 200 * 1024 * 1024;
 };
 
 /* ********************************* */
@@ -477,6 +480,9 @@ class Reader {
 
   /** Set of attribute buffers holding TileDB query results. */
   std::unique_ptr<AttributeBufferSet> buffers_b;
+
+  /** Indicates if we are double buffering or not. */
+  bool double_buffering_ = true;
 
   /* ********************************* */
   /*           PRIVATE METHODS         */


### PR DESCRIPTION
This add an internal threshold for double buffering of the TileDB query. If the buffers are too small, then the overhead of splitting further and running two queries is large compared to the gains. The processing of the results has been optimized greatly and is no longer a major bottleneck. Most of the time is spent in TileDB for large queries.

As a heuristic we use a size of 200MB (that would be 100MB per buffer in double buffering) as the threshold. If the buffers are smaller than this we disable double buffering and only run a single set of buffers in hope of minimizing the incomplete queries.