### PR TITLE
Automatically set the TileDB memory budget config

### DIFF
--- a/libtiledbvcf/src/dataset/attribute_buffer_set.h
+++ b/libtiledbvcf/src/dataset/attribute_buffer_set.h
@@ -66,6 +66,7 @@ class AttributeBufferSet {
    * @param extra List of attributes to allocate buffers for.
    * @param mem_budget_mb Memory budget (MB) of sum of allocations.
    * @param version dataset version
+   * @return size of buffers allocated in bytes
    */
   void allocate_fixed(
       const std::unordered_set<std::string>& attr_names,
@@ -186,6 +187,13 @@ class AttributeBufferSet {
    */
   bool extra_attr(const std::string& name, Buffer** buffer);
 
+  /**
+   * Returns the size of each buffer allocated. If you want the total size of
+   * all buffers see total_size()
+   * @return size
+   */
+  uint64_t size_per_buffer() const;
+
  private:
   /** sample_name v4 dimension (string) */
   Buffer sample_name_;
@@ -240,6 +248,9 @@ class AttributeBufferSet {
 
   /** verbose output enabled */
   bool verbose_;
+
+  /** size of allocated buffers in bytes */
+  uint64_t buffer_size_bytes_;
 };
 
 }  // namespace vcf

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -1880,8 +1880,10 @@ void Reader::init_tiledb() {
   cfg["sm.sm.compute_concurrency_level"] =
       uint64_t(std::thread::hardware_concurrency() * 1.5f);
 
-  // User overrides
-  utils::set_tiledb_config(params_.tiledb_config, &cfg);
+  // User overrides. We set it on the map and actual config
+  utils::set_tiledb_config_map(
+      params_.tiledb_config, &params_.tiledb_config_map);
+  utils::set_tiledb_config(params_.tiledb_config_map, &cfg);
 
   ctx_.reset(new tiledb::Context(cfg));
   vfs_.reset(new tiledb::VFS(*ctx_, cfg));
@@ -1991,8 +1993,14 @@ void Reader::set_tiledb_query_config() {
   assert(buffers_a != nullptr);
 
   tiledb::Config cfg;
-  cfg["sm.memory_budget"] = buffers_a->size_per_buffer();
-  cfg["sm.memory_budget_var"] = buffers_a->size_per_buffer();
+  if (params_.tiledb_config_map.find("sm.memory_budget") ==
+      params_.tiledb_config_map.end())
+    cfg["sm.memory_budget"] = buffers_a->size_per_buffer();
+
+  if (params_.tiledb_config_map.find("sm.memory_budget_var") ==
+      params_.tiledb_config_map.end())
+    cfg["sm.memory_budget_var"] = buffers_a->size_per_buffer();
+
   read_state_.query->set_config(cfg);
 }
 

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -1850,13 +1850,15 @@ void Reader::prepare_attribute_buffers() {
         "requirements.");
   }
 
-  // We get half of the memory budget for the query buffers.
-  uint64_t alloc_budget = params_.memory_budget_mb / 2;
+  // We get one-forth of the memory budget for the query buffers.
+  // another one-forth goes to TileDB for `sm.memory_budget` and
+  // `sm.memory_budget_var`
+  uint64_t alloc_budget = params_.memory_budget_mb / 2 / 2;
 
   // If the query buffers would be less than 100MB don't double buffer
   if (AttributeBufferSet::compute_buffer_size(attrs, alloc_budget) >
       params_.double_buffering_threshold) {
-    alloc_budget = params_.memory_budget_mb / 4;
+    alloc_budget = params_.memory_budget_mb / 4 / 2;
     buffers_a->allocate_fixed(
         attrs, alloc_budget, dataset_->metadata().version);
     buffers_b->allocate_fixed(

--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -613,6 +613,14 @@ class Reader {
   /** Checks that the partitioning values are valid. */
   static void check_partitioning(
       uint64_t partition_idx, uint64_t num_partitions);
+
+  /**
+   * Builds and sets a TileDB config for the query
+   *
+   * Currently used for setting things like the `sm.memory_budget` and
+   * `sm.memory_buget_var`
+   */
+  void set_tiledb_query_config();
 };
 
 }  // namespace vcf

--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -80,6 +80,8 @@ struct ExportParams {
   bool sort_regions = true;
   uint64_t max_num_records = std::numeric_limits<uint64_t>::max();
   std::vector<std::string> tiledb_config;
+  std::unordered_map<std::string, std::string> tiledb_config_map;
+
   bool tiledb_stats_enabled = false;
   bool tiledb_stats_enabled_vcf_header_array = false;
 

--- a/libtiledbvcf/src/utils/utils.cc
+++ b/libtiledbvcf/src/utils/utils.cc
@@ -279,6 +279,21 @@ int bcf_type_size(const int type) {
   }
 }
 
+void set_tiledb_config_map(
+    const std::vector<std::string>& params,
+    std::unordered_map<std::string, std::string>* cfg) {
+  for (const auto& s : params) {
+    auto kv = utils::split(s, '=');
+    if (kv.size() != 2)
+      throw std::runtime_error(
+          "Error setting TileDB config parameter; bad value '" + s + "'");
+
+    utils::trim(&kv[0]);
+    utils::trim(&kv[1]);
+    cfg->emplace(kv[0], kv[1]);
+  }
+}
+
 void set_tiledb_config(
     const std::vector<std::string>& params, tiledb::Config* cfg) {
   set_tiledb_config(params, cfg->ptr().get());
@@ -295,6 +310,22 @@ void set_tiledb_config(
     utils::trim(&kv[0]);
     utils::trim(&kv[1]);
     tiledb_config_set(cfg, kv[0].c_str(), kv[1].c_str(), &err);
+    tiledb::impl::check_config_error(err);
+  }
+}
+
+void set_tiledb_config(
+    const std::unordered_map<std::string, std::string>& params,
+    tiledb::Config* cfg) {
+  set_tiledb_config(params, cfg->ptr().get());
+}
+
+void set_tiledb_config(
+    const std::unordered_map<std::string, std::string>& params,
+    tiledb_config_t* cfg) {
+  tiledb_error_t* err;
+  for (const auto& kv : params) {
+    tiledb_config_set(cfg, kv.first.c_str(), kv.second.c_str(), &err);
     tiledb::impl::check_config_error(err);
   }
 }

--- a/libtiledbvcf/src/utils/utils.h
+++ b/libtiledbvcf/src/utils/utils.h
@@ -307,6 +307,16 @@ void append_from_file(const std::string& uri, std::vector<std::string>* lines);
 int bcf_type_size(const int type);
 
 /**
+ * Parse the give list of params (of the format 'param.name=value') and set them
+ * on the unordered map
+ * @param params vector of params
+ * @param cfg unordered_map to set values on
+ */
+void set_tiledb_config_map(
+    const std::vector<std::string>& params,
+    std::unordered_map<std::string, std::string>* cfg);
+
+/**
  * Parses the given list of params (of the format 'param.name=value') and sets
  * them on the given Config instance.
  */
@@ -322,6 +332,24 @@ void set_tiledb_config(
  */
 void set_tiledb_config(
     const std::vector<std::string>& params, tiledb_config_t* cfg);
+
+/**
+ * Sets a map of parameters to a TileDB Config
+ * @param params unordered map of configuration parameters
+ * @param cfg TileDB Config to set
+ */
+void set_tiledb_config(
+    const std::unordered_map<std::string, std::string>& params,
+    tiledb::Config* cfg);
+
+/**
+ * Sets a map of parameters to a TileDB Config
+ * @param params unordered map of configuration parameters
+ * @param cfg TileDB Config to set
+ */
+void set_tiledb_config(
+    const std::unordered_map<std::string, std::string>& params,
+    tiledb_config_t* cfg);
 
 /**
  * Set the htslib global config and context. We use this c++ function to provide


### PR DESCRIPTION
This changes the TileDB memory budget parameters to be set on a configuration option that is now attached to the query. TileDB 2.2.2 introduced the ability to set a config object on the query which allows certain parameters to be set more localized. This includes the `sm.memory_budget` and `sm.memory_budget_var` parameters. We now will set this to the same size as the query buffer sizes.