### PR TITLE
Fix crash in Py VCF due to buffer lifetime

### DIFF
--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -219,7 +219,12 @@ class Dataset(object):
         :return: Pandas DataFrame
         """
         table = self.continue_read_arrow(release_buffers=release_buffers)
-        return table.to_pandas()
+
+        # Grab buffers and hold reference on the pandas dataframe so they are not gc'ed when the reader goes out of scope
+        table_buffers = self.reader.get_buffers()
+        df = table.to_pandas()
+        df.attrs["_vcf_buffers"] = table_buffers
+        return df
 
     def continue_read_arrow(self, release_buffers=True):
         """


### PR DESCRIPTION
The Arrow export uses the VCF C API to get buffer pointers. The lifetime
of these pointers (then wrapped by arrow) is tied to the lifetime of the
Reader/Dataset. When the Reader is destructed, the buffers are freed
which can cause a crash if the buffers are later accessed. To avoid this,
we (1) call Reader::getbuffers to get handles to all of the underlying
NumPy arrays allocated in the reader. (2) attach these arrays to the
result dataframe returned by table.to_pandas. This ensures that
the buffers used by the dataframe  are not deallocated until the
dataframe itself is deallocated.

x-ref same technique in https://github.com/TileDB-Inc/TileDB-VCF/pull/198

In the future, we will refactor to transfer ownership of the NumPy
arrays directly, in order to avoid the small risk of problems that
could arise if the NumPy buffers attached to the result pandas
dataframe become desynchronized from the df lifetime  without
accounting for the `table_buffers` reference (because the df arrays
do not own their data).