### PR TITLE
Tile cache is fixed percentage of memory_budget_mb

### DIFF
--- a/libtiledbvcf/src/dataset/attribute_buffer_set.cc
+++ b/libtiledbvcf/src/dataset/attribute_buffer_set.cc
@@ -8,7 +8,7 @@ AttributeBufferSet::AttributeBufferSet(bool verbose)
     : verbose_(verbose){};
 
 uint64_t AttributeBufferSet::compute_buffer_size(
-    const std::unordered_set<std::string>& attr_names, uint64_t mem_budget_mb) {
+    const std::unordered_set<std::string>& attr_names, uint64_t mem_budget) {
   // Get count of number of query buffers being allocated
   size_t num_buffers = 0;
   for (const auto& s : attr_names) {
@@ -17,11 +17,11 @@ uint64_t AttributeBufferSet::compute_buffer_size(
   }
 
   // Every buffer alloc gets the same size.
-  uint64_t nbytes = (uint64_t(mem_budget_mb) * 1024 * 1024) / num_buffers;
+  uint64_t nbytes = mem_budget / num_buffers;
 
   // Requesting 0 MB will result in a 1 KB allocation. This is used by the
   // tests to test the path of incomplete TileDB queries.
-  if (mem_budget_mb == 0) {
+  if (mem_budget == 0) {
     nbytes = 1024;
   }
 
@@ -30,12 +30,12 @@ uint64_t AttributeBufferSet::compute_buffer_size(
 
 void AttributeBufferSet::allocate_fixed(
     const std::unordered_set<std::string>& attr_names,
-    unsigned mem_budget_mb,
+    uint64_t memory_budget,
     unsigned version) {
   clear();
   fixed_alloc_.clear();
 
-  buffer_size_bytes_ = compute_buffer_size(attr_names, mem_budget_mb);
+  buffer_size_bytes_ = compute_buffer_size(attr_names, memory_budget);
   uint64_t num_offsets = buffer_size_bytes_ / sizeof(uint64_t);
 
   if (verbose_) {

--- a/libtiledbvcf/src/dataset/attribute_buffer_set.h
+++ b/libtiledbvcf/src/dataset/attribute_buffer_set.h
@@ -50,12 +50,11 @@ class AttributeBufferSet {
    * Compute the size of the buffers in bytes based on memory budget and list of
    * attributes to select
    * @param attr_names
-   * @param mem_budget_mb
+   * @param mem_budget
    * @return size of buffers in bytes
    */
   static uint64_t compute_buffer_size(
-      const std::unordered_set<std::string>& attr_names,
-      uint64_t mem_budget_mb);
+      const std::unordered_set<std::string>& attr_names, uint64_t mem_budget);
 
   /**
    * Resize buffers for the given set of attributes using the given allocation
@@ -64,13 +63,13 @@ class AttributeBufferSet {
    * Used when reading.
    *
    * @param extra List of attributes to allocate buffers for.
-   * @param mem_budget_mb Memory budget (MB) of sum of allocations.
+   * @param memory_budget Memory budget (MB) of sum of allocations.
    * @param version dataset version
    * @return size of buffers allocated in bytes
    */
   void allocate_fixed(
       const std::unordered_set<std::string>& attr_names,
-      unsigned mem_budget_mb,
+      uint64_t memory_budget,
       unsigned version);
 
   /**

--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -59,6 +59,12 @@ struct PartitionInfo {
   unsigned num_partitions = 1;
 };
 
+struct MemoryBudgetBreakdown {
+  uint64_t buffers = 1024;
+  uint64_t tiledb_tile_cache = 1024;
+  uint64_t tiledb_memory_budget = 1024;
+};
+
 /** Arguments/params for export. */
 struct ExportParams {
   // Basic export params:
@@ -86,7 +92,8 @@ struct ExportParams {
   bool tiledb_stats_enabled_vcf_header_array = false;
 
   // Memory/performance params:
-  unsigned memory_budget_mb = 2 * 1024;
+  uint64_t memory_budget_mb = 2 * 1024;
+  MemoryBudgetBreakdown memory_budget_breakdown;
 
   // Size in bytes at which if the buffers are larger we will double buffer
   uint64_t double_buffering_threshold = 200 * 1024 * 1024;
@@ -623,6 +630,8 @@ class Reader {
    * `sm.memory_buget_var`
    */
   void set_tiledb_query_config();
+
+  void compute_memory_budget_details();
 };
 
 }  // namespace vcf


### PR DESCRIPTION
This change makes it so that we compute the size of the tile cache as 10% of the VCF memory budget. This will limit the size of the memory usage as a user would expect. Previously the tile cache was set to 1GB or user configured, which would be mean if the user hadn't set it they might end up using more than expected memory.