### PR TITLE
Skew memory budget towards core library

### DIFF
--- a/libtiledbvcf/src/dataset/attribute_buffer_set.cc
+++ b/libtiledbvcf/src/dataset/attribute_buffer_set.cc
@@ -38,18 +38,18 @@ void AttributeBufferSet::allocate_fixed(
   buffer_size_bytes_ = compute_buffer_size(attr_names, memory_budget);
   uint64_t num_offsets = buffer_size_bytes_ / sizeof(uint64_t);
 
-  if (verbose_) {
-    // Get count of number of query buffers being allocated
-    size_t num_buffers = 0;
-    for (const auto& s : attr_names) {
-      bool fixed_len = TileDBVCFDataset::attribute_is_fixed_len(s);
-      num_buffers += fixed_len ? 1 : 2;
-    }
+  // Get count of number of query buffers being allocated
+  number_of_buffers_ = 0;
+  for (const auto& s : attr_names) {
+    bool fixed_len = TileDBVCFDataset::attribute_is_fixed_len(s);
+    number_of_buffers_ += fixed_len ? 1 : 2;
+  }
 
+  if (verbose_) {
     std::cout << "Allocating " << attr_names.size() << " fields ("
-              << num_buffers << " buffers) of size " << buffer_size_bytes_
-              << " bytes (" << buffer_size_bytes_ / (1024.0f * 1024.0f) << "MB)"
-              << std::endl;
+              << number_of_buffers_ << " buffers) of size "
+              << buffer_size_bytes_ << " bytes ("
+              << buffer_size_bytes_ / (1024.0f * 1024.0f) << "MB)" << std::endl;
   }
 
   using attrNamesV4 = TileDBVCFDataset::AttrNames::V4;
@@ -551,6 +551,10 @@ bool AttributeBufferSet::extra_attr(const std::string& name, Buffer** buffer) {
 
 uint64_t AttributeBufferSet::size_per_buffer() const {
   return buffer_size_bytes_;
+}
+
+uint64_t AttributeBufferSet::nbuffers() const {
+  return number_of_buffers_;
 }
 
 }  // namespace vcf

--- a/libtiledbvcf/src/dataset/attribute_buffer_set.h
+++ b/libtiledbvcf/src/dataset/attribute_buffer_set.h
@@ -193,6 +193,12 @@ class AttributeBufferSet {
    */
   uint64_t size_per_buffer() const;
 
+  /**
+   * Number of buffers allocated
+   * @return number of buffers allocated
+   */
+  uint64_t nbuffers() const;
+
  private:
   /** sample_name v4 dimension (string) */
   Buffer sample_name_;
@@ -250,6 +256,9 @@ class AttributeBufferSet {
 
   /** size of allocated buffers in bytes */
   uint64_t buffer_size_bytes_;
+
+  /** Total number of buffers allocated */
+  uint64_t number_of_buffers_;
 };
 
 }  // namespace vcf

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -2005,11 +2005,15 @@ void Reader::set_tiledb_query_config() {
   tiledb::Config cfg;
   if (params_.tiledb_config_map.find("sm.memory_budget") ==
       params_.tiledb_config_map.end())
-    cfg["sm.memory_budget"] = buffers_a->size_per_buffer();
+    cfg["sm.memory_budget"] =
+        params_.memory_budget_breakdown.tiledb_memory_budget /
+        buffers_a->nbuffers();
 
   if (params_.tiledb_config_map.find("sm.memory_budget_var") ==
       params_.tiledb_config_map.end())
-    cfg["sm.memory_budget_var"] = buffers_a->size_per_buffer();
+    cfg["sm.memory_budget_var"] =
+        params_.memory_budget_breakdown.tiledb_memory_budget /
+        buffers_a->nbuffers();
 
   read_state_.query->set_config(cfg);
 }
@@ -2021,12 +2025,12 @@ void Reader::compute_memory_budget_details() {
   params_.memory_budget_breakdown.tiledb_tile_cache = memory_budget * 0.1;
   memory_budget -= params_.memory_budget_breakdown.tiledb_tile_cache;
 
-  // Set the buffers to 50% of the remaining budget
-  params_.memory_budget_breakdown.buffers = memory_budget / 2;
+  // Set the buffers to 25% of the remaining budget
+  params_.memory_budget_breakdown.buffers = memory_budget * 0.25;
   memory_budget -= params_.memory_budget_breakdown.buffers;
 
-  // Set the buffers to all of the remaining budget (which is the same as the
-  // buffers)
+  // Set the buffers to all of the remaining budget (3x the buffers for a 25/75
+  // split between buffers and memory budget
   params_.memory_budget_breakdown.tiledb_memory_budget = memory_budget;
 }
 


### PR DESCRIPTION
In most cases TileDB core library will need to decompress more tiles/chunks to filter to the data requested then will be set in the
query buffers. This means than an even split is likely to cause more incomplete queries. As such, switch from a 50/50 split to a 75/25 split will yield performance improvements.

This depends on #260 