### PR TITLE
Let htslib manage info/fmt field count on export

### DIFF
--- a/libtiledbvcf/cmake/Modules/FindHTSlib_EP.cmake
+++ b/libtiledbvcf/cmake/Modules/FindHTSlib_EP.cmake
@@ -69,6 +69,11 @@ if (NOT HTSLIB_FOUND)
     else()
       set(EXTRA_LDFLAGS "-Wl,-soname,libhts.so.1.10")
     endif()
+    SET(CFLAGS "")
+    string( TOUPPER "${CMAKE_BUILD_TYPE}" BUILD_TYPE)
+    if (BUILD_TYPE STREQUAL "DEBUG")
+      SET(CFLAGS "-g")
+    endif()
     ExternalProject_Add(ep_htslib
       PREFIX "externals"
       URL "https://github.com/samtools/htslib/archive/1.10.zip"
@@ -79,7 +84,7 @@ if (NOT HTSLIB_FOUND)
         COMMAND
           autoconf
         COMMAND
-          ./configure --prefix=${EP_INSTALL_PREFIX} LDFLAGS=${EXTRA_LDFLAGS}
+          ./configure --prefix=${EP_INSTALL_PREFIX} LDFLAGS=${EXTRA_LDFLAGS} CFLAGS=${CFLAGS}
       BUILD_COMMAND
         $(MAKE)
       INSTALL_COMMAND

--- a/libtiledbvcf/src/read/exporter.cc
+++ b/libtiledbvcf/src/read/exporter.cc
@@ -230,9 +230,6 @@ void Exporter::recover_record(
       num_fmt_fields++;
     }
   }
-
-  dst->n_fmt = num_fmt_fields;
-  dst->n_info = num_info_fields + 1;  // + 1 because we add "END"
 }
 
 }  // namespace vcf


### PR DESCRIPTION
For exports to vcf/vcf we should let htslib manage the info/fmt field counts. As we add the fields on export, htlib increments the account automatically. Manually override it is typically fine, except we were adding an extra count for the END field which might not always exist. The proper solution is to just stop override the field counts.