### PR TITLE
Add proper checking for map lookups to throw useful errors

### DIFF
--- a/libtiledbvcf/src/read/exporter.cc
+++ b/libtiledbvcf/src/read/exporter.cc
@@ -183,6 +183,12 @@ void Exporter::recover_record(
     const bool is_info = parts.first == "info";
     const auto& field_name = parts.second;
 
+    auto sizes_iter = results.extra_attrs_size().find(attr.first);
+    if (sizes_iter == results.extra_attrs_size().end())
+      throw std::runtime_error(
+          "Could not find size for extra attribute" + attr.first +
+          " in recover_record");
+
     auto sizes = results.extra_attrs_size().at(attr.first);
     const char* field_ptr =
         attr.second.data<char>() + attr.second.offsets()[cell_idx];

--- a/libtiledbvcf/src/read/in_memory_exporter.cc
+++ b/libtiledbvcf/src/read/in_memory_exporter.cc
@@ -944,6 +944,13 @@ void InMemoryExporter::get_info_fmt_value(
   bool is_extracted_attr = false;
   if (curr_query_results_->buffers()->extra_attr(attr_name, &src)) {
     is_extracted_attr = true;
+
+    auto sizes_iter = curr_query_results_->extra_attrs_size().find(attr_name);
+    if (sizes_iter == curr_query_results_->extra_attrs_size().end())
+      throw std::runtime_error(
+          "Could not find size for extra attribute" + attr_name +
+          " in get_info_fmt_value");
+
     src_size = curr_query_results_->extra_attrs_size().at(attr_name);
   } else if (is_info) {
     src = &curr_query_results_->buffers()->info();

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -753,6 +753,13 @@ bool Reader::read_current_batch() {
         hdr = read_state_.current_hdrs.at(s.sample_id).get();
       else {
         assert(dataset_->metadata().version == TileDBVCFDataset::Version::V4);
+        auto hdr_iter = read_state_.current_hdrs.find(
+            read_state_.current_hdrs_lookup[s.sample_name]);
+        if (hdr_iter == read_state_.current_hdrs.end())
+          throw std::runtime_error(
+              "Could not find VCF header for " + s.sample_name +
+              " in read_current_batch for finalize_Export");
+
         hdr = read_state_.current_hdrs
                   .at(read_state_.current_hdrs_lookup[s.sample_name])
                   .get();
@@ -1165,6 +1172,12 @@ bool Reader::report_cell(
     sample = SampleAndId{std::string(sample_name, size)};
     hdr_index = read_state_.current_hdrs_lookup[sample.sample_name];
   }
+
+  auto hdr_iter = read_state_.current_hdrs.find(hdr_index);
+  if (hdr_iter == read_state_.current_hdrs.end())
+    throw std::runtime_error(
+        "Could not find VCF header for " + sample.sample_name +
+        " in report_cell");
 
   const auto& hdr = read_state_.current_hdrs.at(hdr_index);
   if (!exporter_->export_record(


### PR DESCRIPTION
We now check and throw a helpful exception with error details if any place (in v4 code) we attempt to lookup on a map and something isn't found. This effects header lookups and extra attribute lookups in the read algorithm.