### PR TITLE
Add % of query processed in verbose output

### DIFF
--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -25,6 +25,9 @@
  */
 
 #include <future>
+#include <iomanip>
+#include <random>
+#include <thread>
 
 #include "dataset/attribute_buffer_set.h"
 #include "read/bcf_exporter.h"
@@ -484,6 +487,33 @@ bool Reader::next_read_batch_v2_v3() {
               << std::endl;
   }
 
+  // Get estimated records for verbose output
+  read_state_.total_query_records_processed = 0;
+  read_state_.query_estimated_num_records = 1;
+  if (params_.verbose) {
+    if (dataset_->metadata().version == TileDBVCFDataset::Version::V2) {
+      read_state_.query_estimated_num_records =
+          read_state_.query->est_result_size(
+              TileDBVCFDataset::DimensionNames::V2::end_pos) /
+          tiledb_datatype_size(
+              dataset_->data_array()
+                  ->schema()
+                  .domain()
+                  .dimension(TileDBVCFDataset::DimensionNames::V2::end_pos)
+                  .type());
+    } else {
+      read_state_.query_estimated_num_records =
+          read_state_.query->est_result_size(
+              TileDBVCFDataset::DimensionNames::V3::start_pos) /
+          tiledb_datatype_size(
+              dataset_->data_array()
+                  ->schema()
+                  .domain()
+                  .dimension(TileDBVCFDataset::DimensionNames::V3::start_pos)
+                  .type());
+    }
+  }
+
   return true;
 }
 
@@ -588,6 +618,22 @@ bool Reader::next_read_batch_v4() {
               << "/" << read_state_.query_regions_v4.size() << ", sample batch "
               << read_state_.batch_idx + 1 << "/"
               << read_state_.sample_batches.size() << ")." << std::endl;
+  }
+
+  // Get estimated records for verbose output
+  read_state_.total_query_records_processed = 0;
+  read_state_.query_estimated_num_records = 1;
+
+  if (params_.verbose) {
+    read_state_.query_estimated_num_records =
+        read_state_.query->est_result_size(
+            TileDBVCFDataset::DimensionNames::V4::start_pos) /
+        tiledb_datatype_size(
+            dataset_->data_array()
+                ->schema()
+                .domain()
+                .dimension(TileDBVCFDataset::DimensionNames::V4::start_pos)
+                .type());
   }
 
   return true;
@@ -707,6 +753,8 @@ bool Reader::read_current_batch() {
 
     // Process the query results.
     auto old_num_exported = read_state_.last_num_records_exported;
+    read_state_.total_query_records_processed +=
+        read_state_.query_results.num_cells();
     auto t0 = std::chrono::steady_clock::now();
 
     bool complete;
@@ -724,7 +772,13 @@ bool Reader::read_current_batch() {
                 << " cells in " << utils::chrono_duration(t0)
                 << " sec. Reported "
                 << (read_state_.last_num_records_exported - old_num_exported)
-                << " cells." << std::endl;
+                << " cells. Approximately " << std::fixed
+                << std::setprecision(2)
+                << (read_state_.total_query_records_processed /
+                    static_cast<double>(
+                        read_state_.query_estimated_num_records) *
+                    100)
+                << "% completed with query cells." << std::endl;
 
     // Return early if we couldn't process all the results.
     if (!complete)

--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -436,6 +436,10 @@ class Reader {
     /** Total number of records exported across all incomplete reads. */
     uint64_t total_num_records_exported = 0;
 
+    /** Estimated number of records for query. */
+    uint64_t query_estimated_num_records = 0;
+    uint64_t total_query_records_processed = 0;
+
     /** The number of records exported during the last read, complete or not. */
     uint64_t last_num_records_exported = 0;
 


### PR DESCRIPTION
This is just an estimate based on the TileDB Query estimated result size. However it provides a decent guess to the user about how much data is left to query.