### PR TITLE
Preemptively clear buffers when read is complete

### DIFF
--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -301,7 +301,9 @@ void Reader::read() {
   switch (read_state_.status) {
     case ReadStatus::COMPLETED:
     case ReadStatus::FAILED:
-      // Do nothing and return.
+      // Reset buffers as the are no longer needed
+      buffers_a.reset(nullptr);
+      buffers_b.reset(nullptr);
       return;
     case ReadStatus::INCOMPLETE:
       // Do nothing; read will resume.


### PR DESCRIPTION
This allows for the query buffers in C++ to free their memory when the user might hang onto the reader class. This can happen in python if the user keeps the Dataset class in the current scope. In spark there can also be a delay due to GC in cleaning up the reader. Once the TileDB-VCF query is complete it is safe to free the TileDB query buffers.