### PR TITLE
Always recompute the memory sizes after budget set

### DIFF
--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -158,6 +158,7 @@ InMemoryExporter* Reader::set_in_memory_exporter() {
 
 void Reader::set_memory_budget(unsigned mb) {
   params_.memory_budget_mb = mb;
+  compute_memory_budget_details();
 }
 
 void Reader::set_record_limit(uint64_t max_num_records) {


### PR DESCRIPTION
There is a sequence of events problem with spark calling init before setting the buffer sizes. This patch handles by always computing the memory budget breakdown for each call to the memory setter.