### PR TITLE
Always reset the TileDB Query buffers

### DIFF
--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -811,6 +811,7 @@ bool Reader::read_current_batch() {
         query_status ==
         tiledb::Query::Status::INCOMPLETE) {  // resubmit existing buffers_a if
                                               // not double buffering
+      buffers_a->set_buffers(query, dataset_->metadata().version);
       read_state_.async_query =
           std::async(std::launch::async, [query, verbose]() {
             auto t0 = std::chrono::steady_clock::now();


### PR DESCRIPTION
When we are not double buffering we need to reset the query buffers so that the 'buffer size' as reported by the core library is the real size. This fixes an edge case when the core library is serializing the query that could cause the query buffer size to shrink each time a request was made. The problem was that the core library would send the buffer size instead of original buffer size to TileDB Cloud.

This works around the core issue but always setting the buffers. The core bug will be fixed in a pending release.