### PR TITLE
Optimizations for VCF Header Array Querying

### DIFF
--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -46,7 +46,8 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("get_sample_count", &Reader::get_sample_count)
       .def("get_sample_names", &Reader::get_sample_names)
       .def("set_buffer_percentage", &Reader::set_buffer_percentage)
-      .def("set_tiledb_tile_cache_percentage", &Reader::set_tiledb_tile_cache_percentage);
+      .def("set_tiledb_tile_cache_percentage", &Reader::set_tiledb_tile_cache_percentage)
+      .def("set_check_samples_exist", &Reader::set_check_samples_exist);
 
   py::class_<Writer>(m, "Writer")
       .def(py::init())

--- a/apis/python/src/tiledbvcf/binding/reader.cc
+++ b/apis/python/src/tiledbvcf/binding/reader.cc
@@ -483,4 +483,9 @@ void Reader::set_tiledb_tile_cache_percentage(float tile_percentage) {
   check_error(reader, tiledb_vcf_reader_set_tiledb_tile_cache_percentage(reader, tile_percentage));
 }
 
+void Reader::set_check_samples_exist(bool samples_exists) {
+  auto reader = ptr.get();
+  check_error(reader, tiledb_vcf_reader_set_check_samples_exist(reader, samples_exists));
+}
+
 }  // namespace tiledbvcfpy

--- a/apis/python/src/tiledbvcf/binding/reader.h
+++ b/apis/python/src/tiledbvcf/binding/reader.h
@@ -149,6 +149,9 @@ class Reader {
   /** Set the TileDB tile cache memory percentage */
   void set_tiledb_tile_cache_percentage(float tile_percentage);
 
+  /** Set to check if samples requested exist and error if not. */
+  void set_check_samples_exist(bool check_samples_exist);
+
  private:
   /** Buffer struct to hold attribute data read from the dataset. */
   struct BufferInfo {

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -139,6 +139,7 @@ class Dataset(object):
         regions=None,
         samples_file=None,
         bed_file=None,
+        skip_check_samples=False,
     ):
         """Reads data from a TileDB-VCF dataset into Arrow table.
 
@@ -155,6 +156,7 @@ class Dataset(object):
         :param str samples_file: URI of file containing sample names to be read,
             one per line.
         :param str bed_file: URI of a BED file of genomic regions to be read.
+        :param bool skip_check_samples: Should checking the samples requested exist in the array
         :return: Pandas DataFrame or PyArrow Array containing results.
         """
         if self.mode != "r":
@@ -166,6 +168,7 @@ class Dataset(object):
         regions = "" if regions is None else regions
         self.reader.set_regions(",".join(regions))
         self.reader.set_attributes(attrs)
+        self.reader.set_check_samples_exist(not skip_check_samples)
 
         if bed_file is not None:
             self.reader.set_bed_file(bed_file)
@@ -179,6 +182,7 @@ class Dataset(object):
         regions=None,
         samples_file=None,
         bed_file=None,
+        skip_check_samples=False,
     ):
         """Reads data from a TileDB-VCF dataset into Pandas dataframe.
 
@@ -195,6 +199,7 @@ class Dataset(object):
         :param str samples_file: URI of file containing sample names to be read,
             one per line.
         :param str bed_file: URI of a BED file of genomic regions to be read.
+        :param bool skip_check_samples: Should checking the samples requested exist in the array
         :return: Pandas DataFrame or PyArrow Array containing results.
         """
         if self.mode != "r":
@@ -206,6 +211,7 @@ class Dataset(object):
         regions = "" if regions is None else regions
         self.reader.set_regions(",".join(regions))
         self.reader.set_attributes(attrs)
+        self.reader.set_check_samples_exist(not skip_check_samples)
 
         if bed_file is not None:
             self.reader.set_bed_file(bed_file)

--- a/libtiledbvcf/src/c_api/tiledbvcf.cc
+++ b/libtiledbvcf/src/c_api/tiledbvcf.cc
@@ -765,6 +765,19 @@ int32_t tiledb_vcf_reader_set_tiledb_tile_cache_percentage(
   return TILEDB_VCF_OK;
 }
 
+int32_t tiledb_vcf_reader_set_check_samples_exist(
+    tiledb_vcf_reader_t* reader, bool check_samples_exist) {
+  if (sanity_check(reader) == TILEDB_VCF_ERR)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          reader,
+          reader->reader_->set_check_samples_exist(check_samples_exist)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
 /* ********************************* */
 /*              WRITER               */
 /* ********************************* */

--- a/libtiledbvcf/src/c_api/tiledbvcf.h
+++ b/libtiledbvcf/src/c_api/tiledbvcf.h
@@ -868,6 +868,15 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_set_tiledb_tile_cache_percentage(
     tiledb_vcf_reader_t* reader, float tile_percentage);
 
 /**
+ * Sets if the reader should validate all requested samples exist in the array
+ * before running the query
+ * @param reader VCF reader object
+ * @param check_samples_exist setting
+ */
+TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_set_check_samples_exist(
+    tiledb_vcf_reader_t* reader, bool check_samples_exist);
+
+/**
  * Returns the version number of the TileDB VCF dataset.
  *
  * @param reader VCF reader object

--- a/libtiledbvcf/src/cli/tiledbvcf.cc
+++ b/libtiledbvcf/src/cli/tiledbvcf.cc
@@ -546,8 +546,10 @@ int main(int argc, char** argv) {
        option("--stats-vcf-header-array")
                .set(export_args.tiledb_stats_enabled_vcf_header_array) %
            "Enable TileDB stats for vcf header array usage",
-       option("--check-samples-exist").set(export_args.check_samples_exist) %
-           "Validate that sample passed exist in dataset before executing "
+       option("--disable-check-samples")
+               .set(export_args.check_samples_exist, false) %
+           "Disable validating that sample passed exist in dataset before "
+           "executing "
            "query and error if any sample requested is not in the dataset");
 
   ListParams list_args;

--- a/libtiledbvcf/src/cli/tiledbvcf.cc
+++ b/libtiledbvcf/src/cli/tiledbvcf.cc
@@ -545,7 +545,10 @@ int main(int argc, char** argv) {
            "Enable TileDB stats",
        option("--stats-vcf-header-array")
                .set(export_args.tiledb_stats_enabled_vcf_header_array) %
-           "Enable TileDB stats for vcf header array usage");
+           "Enable TileDB stats for vcf header array usage",
+       option("--check-samples-exist").set(export_args.check_samples_exist) %
+           "Validate that sample passed exist in dataset before executing "
+           "query and error if any sample requested is not in the dataset");
 
   ListParams list_args;
   auto list_mode =

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -645,7 +645,8 @@ std::shared_ptr<tiledb::Array> TileDBVCFDataset::open_data_array(
 
 std::unordered_map<uint32_t, SafeBCFHdr> TileDBVCFDataset::fetch_vcf_headers_v4(
     const std::vector<SampleAndId>& samples,
-    std::unordered_map<std::string, size_t>* lookup_map) const {
+    std::unordered_map<std::string, size_t>* lookup_map,
+    const uint64_t memory_budget) const {
   if (!tiledb_stats_enabled_vcf_header_)
     tiledb::Stats::disable();
 
@@ -669,39 +670,16 @@ std::unordered_map<uint32_t, SafeBCFHdr> TileDBVCFDataset::fetch_vcf_headers_v4(
   }
   query.set_layout(TILEDB_ROW_MAJOR);
 
-  uint64_t header_offset_element = 0;
-  uint64_t header_data_element = 0;
-  uint64_t sample_offset_element = 0;
-  uint64_t sample_data_element = 0;
-#if TILEDB_VERSION_MAJOR == 2 and TILEDB_VERSION_MINOR < 2
-  std::pair<uint64_t, uint64_t> header_est_size =
-      query.est_result_size_var("header");
-  header_offset_element =
-      std::max(header_est_size.first, static_cast<uint64_t>(1));
-  header_data_element =
-      std::max(header_est_size.second / sizeof(char), static_cast<uint64_t>(1));
-
-  // Sample estimate
-  std::pair<uint64_t, uint64_t> sample_est_size =
-      query.est_result_size_var("sample");
-  sample_offset_element =
-      std::max(sample_est_size.first, static_cast<uint64_t>(1));
-  sample_data_element =
-      std::max(sample_est_size.second / sizeof(char), static_cast<uint64_t>(1));
-#else
-  std::array<uint64_t, 2> header_est_size = query.est_result_size_var("header");
-  header_offset_element =
-      std::max(header_est_size[0] / sizeof(uint64_t), static_cast<uint64_t>(1));
-  header_data_element =
-      std::max(header_est_size[1] / sizeof(char), static_cast<uint64_t>(1));
-
-  // Sample estimate
-  std::array<uint64_t, 2> sample_est_size = query.est_result_size_var("sample");
-  sample_offset_element =
-      std::max(sample_est_size[0] / sizeof(uint64_t), static_cast<uint64_t>(1));
-  sample_data_element =
-      std::max(sample_est_size[1] / sizeof(char), static_cast<uint64_t>(1));
-#endif
+  uint64_t memory_budget_per_buffer =
+      static_cast<uint64_t>(static_cast<double>(memory_budget) / 4.0);
+  uint64_t header_offset_element = std::max(
+      memory_budget_per_buffer / sizeof(uint64_t), static_cast<uint64_t>(1));
+  uint64_t header_data_element = std::max(
+      memory_budget_per_buffer / sizeof(char), static_cast<uint64_t>(1));
+  uint64_t sample_offset_element = std::max(
+      memory_budget_per_buffer / sizeof(uint64_t), static_cast<uint64_t>(1));
+  uint64_t sample_data_element = std::max(
+      memory_budget_per_buffer / sizeof(char), static_cast<uint64_t>(1));
 
   std::vector<uint64_t> offsets(header_offset_element);
   std::vector<char> data(header_data_element);
@@ -1626,8 +1604,8 @@ std::map<std::string, int> TileDBVCFDataset::fmt_field_types() const {
   return fmt_field_types_;
 }
 
-std::vector<std::string> TileDBVCFDataset::get_all_samples_from_vcf_headers()
-    const {
+std::vector<std::string> TileDBVCFDataset::get_all_samples_from_vcf_headers(
+    const uint64_t memory_budget) const {
   if (!tiledb_stats_enabled_vcf_header_)
     tiledb::Stats::disable();
 
@@ -1646,24 +1624,12 @@ std::vector<std::string> TileDBVCFDataset::get_all_samples_from_vcf_headers()
   query.add_range(0, non_empty_domain.first, non_empty_domain.second);
   query.set_layout(TILEDB_ROW_MAJOR);
 
-  uint64_t sample_offset_element = 0;
-  uint64_t sample_data_element = 0;
-#if TILEDB_VERSION_MAJOR == 2 and TILEDB_VERSION_MINOR < 2
-  // Sample estimate
-  std::pair<uint64_t, uint64_t> sample_est_size =
-      query.est_result_size_var("sample");
-  sample_offset_element =
-      std::max(sample_est_size.first, static_cast<uint64_t>(1));
-  sample_data_element =
-      std::max(sample_est_size.second / sizeof(char), static_cast<uint64_t>(1));
-#else
-  // Sample estimate
-  std::array<uint64_t, 2> sample_est_size = query.est_result_size_var("sample");
-  sample_offset_element =
-      std::max(sample_est_size[0] / sizeof(uint64_t), static_cast<uint64_t>(1));
-  sample_data_element =
-      std::max(sample_est_size[1] / sizeof(char), static_cast<uint64_t>(1));
-#endif
+  uint64_t memory_budget_per_buffer =
+      static_cast<uint64_t>(static_cast<double>(memory_budget) / 4.0);
+  uint64_t sample_offset_element = std::max(
+      memory_budget_per_buffer / sizeof(uint64_t), static_cast<uint64_t>(1));
+  uint64_t sample_data_element = std::max(
+      memory_budget_per_buffer / sizeof(char), static_cast<uint64_t>(1));
 
   std::vector<uint64_t> sample_offsets(sample_offset_element);
   std::vector<char> sample_data(sample_data_element);

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -294,7 +294,8 @@ class TileDBVCFDataset {
    */
   std::unordered_map<uint32_t, SafeBCFHdr> fetch_vcf_headers_v4(
       const std::vector<SampleAndId>& samples,
-      std::unordered_map<std::string, size_t>* lookup_map) const;
+      std::unordered_map<std::string, size_t>* lookup_map,
+      uint64_t memory_budget = 10485760) const;
 
   /**
    * Returns a list of regions, one per contig (spanning the entire contig),
@@ -420,7 +421,8 @@ class TileDBVCFDataset {
    *
    * @return vector of all sample names
    */
-  std::vector<std::string> get_all_samples_from_vcf_headers() const;
+  std::vector<std::string> get_all_samples_from_vcf_headers(
+      const uint64_t memory_budget = 10485760) const;
 
   std::shared_ptr<tiledb::Array> data_array() const;
 

--- a/libtiledbvcf/src/read/in_memory_exporter.h
+++ b/libtiledbvcf/src/read/in_memory_exporter.h
@@ -27,7 +27,6 @@
 #ifndef TILEDB_VCF_USER_BUFFER_EXPORTER_H
 #define TILEDB_VCF_USER_BUFFER_EXPORTER_H
 
-#include <stdint-gcc.h>
 #include "enums/attr_datatype.h"
 #include "read/exporter.h"
 #include "read_query_results.h"

--- a/libtiledbvcf/src/read/in_memory_exporter.h
+++ b/libtiledbvcf/src/read/in_memory_exporter.h
@@ -27,6 +27,7 @@
 #ifndef TILEDB_VCF_USER_BUFFER_EXPORTER_H
 #define TILEDB_VCF_USER_BUFFER_EXPORTER_H
 
+#include <stdint-gcc.h>
 #include "enums/attr_datatype.h"
 #include "read/exporter.h"
 #include "read_query_results.h"
@@ -276,7 +277,9 @@ class InMemoryExporter : public Exporter {
 
   /** Gets the datatype for a specific info_/fmt_ attribute. */
   static AttrDatatype get_info_fmt_datatype(
-      const TileDBVCFDataset* dataset, const std::string& attr);
+      const TileDBVCFDataset* dataset,
+      const std::string& attr,
+      const bcf_hdr_t* hdr);
 
   UserBuffer* get_buffer(const std::string& attribute);
 
@@ -285,14 +288,16 @@ class InMemoryExporter : public Exporter {
       UserBuffer* dest,
       const void* data,
       uint64_t nbytes,
-      uint64_t nelts) const;
+      uint64_t nelts,
+      const bcf_hdr_t* hdr) const;
 
   /** Copies the cell value, and updates the offsets for var-len attributes. */
   bool copy_cell_data(
       UserBuffer* dest,
       const void* data,
       uint64_t nbytes,
-      uint64_t nelts) const;
+      uint64_t nelts,
+      const bcf_hdr_t* hdr) const;
 
   /**
    * Updates the attribute list offsets and validity bitmap. This should be
@@ -321,7 +326,8 @@ class InMemoryExporter : public Exporter {
       const bcf_hdr_t* hdr, uint64_t cell_idx, UserBuffer* dest) const;
 
   /** Helper method to export an info_/fmt_ attribute. */
-  bool copy_info_fmt_value(uint64_t cell_idx, UserBuffer* dest) const;
+  bool copy_info_fmt_value(
+      uint64_t cell_idx, UserBuffer* dest, const bcf_hdr_t* hdr) const;
 
   /**
    * Gets a pointer to the variable-length attribute data in the given source

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -571,7 +571,9 @@ bool Reader::next_read_batch_v4() {
     // Fetch new headers for new sample batch
     read_state_.current_hdrs.clear();
     read_state_.current_hdrs = dataset_->fetch_vcf_headers_v4(
-        read_state_.current_sample_batches, &read_state_.current_hdrs_lookup);
+        read_state_.current_sample_batches,
+        &read_state_.current_hdrs_lookup,
+        params_.memory_budget_breakdown.buffers);
   }
 
   // Set up the TileDB query

--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -103,7 +103,7 @@ struct ExportParams {
   // Should we check that the sample names passed for export exist in the array
   // and error out if not This can add latency which might not be cared about
   // because we have to fetch the list of samples from the VCF header array
-  bool check_samples_exist = false;
+  bool check_samples_exist = true;
 };
 
 /* ********************************* */

--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -99,6 +99,11 @@ struct ExportParams {
 
   // Size in bytes at which if the buffers are larger we will double buffer
   uint64_t double_buffering_threshold = 200 * 1024 * 1024;
+
+  // Should we check that the sample names passed for export exist in the array
+  // and error out if not This can add latency which might not be cared about
+  // because we have to fetch the list of samples from the VCF header array
+  bool check_samples_exist = false;
 };
 
 /* ********************************* */
@@ -371,6 +376,13 @@ class Reader {
    * @param tile_cache_percentage
    */
   void set_tiledb_tile_cache_percentage(const float& tile_cache_percentage);
+
+  /**
+   * Set if the list of user passed samples should be validated to exist before
+   * running the query
+   * @param check_samples_exist
+   */
+  void set_check_samples_exist(const bool check_samples_exist);
 
  private:
   /* ********************************* */

--- a/libtiledbvcf/src/utils/rwlock.h
+++ b/libtiledbvcf/src/utils/rwlock.h
@@ -1,0 +1,142 @@
+/**
+ * @file   rwlock.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines and implements a write-preferring read-write lock.
+ */
+
+#ifndef TILEDB_VCF_RWLOCK_H
+#define TILEDB_VCF_RWLOCK_H
+
+#include <condition_variable>
+#include <mutex>
+
+namespace tiledb {
+namespace vcf {
+namespace utils {
+
+class RWLock {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /** Default constructor. */
+  RWLock()
+      : writer_(false)
+      , waiting_writers_(0)
+      , readers_(0) {
+  }
+
+  /** Default destructor. */
+  ~RWLock() = default;
+
+  RWLock(const RWLock&) = delete;
+
+  RWLock& operator=(const RWLock&) = delete;
+
+  RWLock(RWLock&&) = delete;
+
+  RWLock& operator=(RWLock&&) = delete;
+
+  /* ********************************* */
+  /*                API                */
+  /* ********************************* */
+
+  /** Blocks until acquiring a read lock. */
+  void read_lock() {
+    std::unique_lock<std::mutex> ul(mutex_);
+    while (waiting_writers_ > 0 || writer_)
+      cv_.wait(ul);
+    ++readers_;
+  }
+
+  /**
+   * Releases a read lock, must be called after
+   * `read_lock`.
+   */
+  void read_unlock() {
+    std::unique_lock<std::mutex> ul(mutex_);
+    if (--readers_ == 0)
+      cv_.notify_all();
+  }
+
+  /** Blocks until acquiring a write lock. */
+  void write_lock() {
+    std::unique_lock<std::mutex> ul(mutex_);
+    ++waiting_writers_;
+    while (writer_ || readers_ > 0)
+      cv_.wait(ul);
+    --waiting_writers_;
+    writer_ = true;
+  }
+
+  /**
+   * Releases a write lock, must be called after
+   * `write_lock`.
+   */
+  void write_unlock() {
+    std::unique_lock<std::mutex> ul(mutex_);
+    writer_ = false;
+    cv_.notify_all();
+  }
+
+  /** Synchronously downgrades a write lock to a read lock. */
+  void write_downgrade() {
+    std::unique_lock<std::mutex> ul(mutex_);
+    ++readers_;
+    writer_ = false;
+    cv_.notify_all();
+  }
+
+ private:
+  /* ********************************* */
+  /*         PRIVATE ATTRIBUTES        */
+  /* ********************************* */
+
+  /** Protects all member variables. */
+  std::mutex mutex_;
+
+  /** Conditional variable to signal lock activity. */
+  std::condition_variable cv_;
+
+  /** True if a write lock is held. */
+  bool writer_;
+
+  /** The number of writers waiting in `write_lock`. */
+  uint64_t waiting_writers_;
+
+  /** The number of outstanding read locks. */
+  uint64_t readers_;
+};
+
+}  // namespace utils
+}  // namespace vcf
+}  // namespace tiledb
+
+#endif  // TILEDB_VCF_RWLOCK_H

--- a/libtiledbvcf/src/utils/unique_rwlock.h
+++ b/libtiledbvcf/src/utils/unique_rwlock.h
@@ -1,0 +1,128 @@
+/**
+ * @file   unique_rwlock.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines and implements the UniqueRWLock<R> class and
+ * type-defintions for UniqueReadLock and UniqueWriteLock.
+ */
+
+#ifndef TILEDB_VCF_UNIQUE_RWLOCK_H
+#define TILEDB_VCF_UNIQUE_RWLOCK_H
+
+#include "utils/rwlock.h"
+
+namespace tiledb {
+namespace vcf {
+namespace utils {
+
+template <bool R>
+class UniqueRWLock final {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /*
+   * Value constructor. Locks `rwlock` and releases
+   * it in the destructor. If template-type `R` is
+   * true, this class performs read-locking. Otherwise,
+   * this performs write-locking.
+   *
+   * @param rwlock the read-write lock.
+   */
+  explicit UniqueRWLock(RWLock* const rwlock)
+      : rwlock_(rwlock)
+      , locked_(false) {
+    assert(rwlock_);
+
+    lock();
+  }
+
+  /** Destructor. Releases the read-write lock. */
+  ~UniqueRWLock() {
+    if (locked_)
+      unlock();
+  }
+
+  UniqueRWLock(const UniqueRWLock&) = delete;
+
+  UniqueRWLock& operator=(const UniqueRWLock&) = delete;
+
+  UniqueRWLock(UniqueRWLock&&) = delete;
+
+  UniqueRWLock& operator=(UniqueRWLock&&) = delete;
+
+  /* ********************************* */
+  /*                API                */
+  /* ********************************* */
+
+  /** Acquires the read-write lock. */
+  void lock() {
+    assert(!locked_);
+
+    if (R)
+      rwlock_->read_lock();
+    else
+      rwlock_->write_lock();
+
+    locked_ = true;
+  }
+
+  /** Releases the read-write lock. */
+  void unlock() {
+    assert(locked_);
+
+    if (R)
+      rwlock_->read_unlock();
+    else
+      rwlock_->write_unlock();
+
+    locked_ = false;
+  }
+
+ private:
+  /* ********************************* */
+  /*         PRIVATE ATTRIBUTES        */
+  /* ********************************* */
+
+  /** The read-write lock. */
+  RWLock* const rwlock_;
+
+  /** True if holding a lock on `rwlock_`. */
+  bool locked_;
+};
+
+// Type-define UniqueReadLock and UniqueWriteLock.
+using UniqueReadLock = UniqueRWLock<true>;
+using UniqueWriteLock = UniqueRWLock<false>;
+
+}  // namespace utils
+}  // namespace vcf
+}  // namespace tiledb
+
+#endif  // TILEDB_VCF_UNIQUE_RWLOCK_H

--- a/libtiledbvcf/test/src/unit-c-api-writer.cc
+++ b/libtiledbvcf/test/src/unit-c-api-writer.cc
@@ -139,8 +139,10 @@ TEST_CASE("C API: Writer store", "[capi][writer]") {
 
   tiledb::vcf::TileDBVCFDataset ds;
   REQUIRE_NOTHROW(ds.open(dataset_uri));
+  if (ds.metadata().version == tiledb::vcf::TileDBVCFDataset::Version::V4)
+    ds.load_sample_names_v4();
   REQUIRE_THAT(
-      ds.metadata().sample_names,
+      ds.metadata().sample_names_,
       Catch::Matchers::UnorderedEquals(
           std::vector<std::string>{"HG01762", "HG00280"}));
 
@@ -205,7 +207,9 @@ TEST_CASE(
 
   tiledb::vcf::TileDBVCFDataset ds;
   REQUIRE_NOTHROW(ds.open(dataset_uri));
-  REQUIRE(ds.metadata().sample_names == std::vector<std::string>{"HG00096"});
+  if (ds.metadata().version == tiledb::vcf::TileDBVCFDataset::Version::V4)
+    ds.load_sample_names_v4();
+  REQUIRE(ds.metadata().sample_names_ == std::vector<std::string>{"HG00096"});
 
   tiledb_vcf_writer_free(&writer);
   if (vfs.is_dir(dataset_uri))

--- a/libtiledbvcf/test/src/unit-vcf-store.cc
+++ b/libtiledbvcf/test/src/unit-vcf-store.cc
@@ -101,10 +101,12 @@ TEST_CASE("TileDB-VCF: Test register", "[tiledbvcf][ingest]") {
   {
     TileDBVCFDataset ds;
     ds.open(dataset_uri);
+    if (ds.metadata().version == tiledb::vcf::TileDBVCFDataset::Version::V4)
+      ds.load_sample_names_v4();
     REQUIRE(ds.metadata().all_samples == std::vector<std::string>{"HG01762"});
     REQUIRE(ds.metadata().sample_ids.count("HG01762") == 1);
     REQUIRE_THAT(
-        ds.metadata().sample_names,
+        ds.metadata().sample_names_,
         Catch::Matchers::VectorContains(std::string("HG01762")));
 
     auto hdrs = ds.fetch_vcf_headers_v4({{"HG01762", 0}}, nullptr);
@@ -130,6 +132,8 @@ TEST_CASE("TileDB-VCF: Test register", "[tiledbvcf][ingest]") {
   {
     TileDBVCFDataset ds;
     ds.open(dataset_uri);
+    if (ds.metadata().version == tiledb::vcf::TileDBVCFDataset::Version::V4)
+      ds.load_sample_names_v4();
     REQUIRE_THAT(
         ds.metadata().all_samples,
         Catch::Matchers::UnorderedEquals(
@@ -138,7 +142,7 @@ TEST_CASE("TileDB-VCF: Test register", "[tiledbvcf][ingest]") {
     REQUIRE(ds.metadata().sample_ids.count("HG00280") == 1);
     std::vector<std::string> samples = {"HG01762", "HG00280"};
     REQUIRE_THAT(
-        ds.metadata().sample_names, Catch::Matchers::Contains(samples));
+        ds.metadata().sample_names_, Catch::Matchers::Contains(samples));
 
     auto hdrs =
         ds.fetch_vcf_headers_v4({{"HG01762", 0}, {"HG00280", 1}}, nullptr);

--- a/libtiledbvcf/test/src/unit-vcf-store.cc
+++ b/libtiledbvcf/test/src/unit-vcf-store.cc
@@ -114,8 +114,9 @@ TEST_CASE("TileDB-VCF: Test register", "[tiledbvcf][ingest]") {
     REQUIRE(bcf_hdr_nsamples(hdrs.at(0)) == 1);
     REQUIRE(hdrs.at(0)->samples[0] == std::string("HG01762"));
 
-    REQUIRE(ds.fmt_field_type("GQ") == BCF_HT_INT);
-    REQUIRE(ds.info_field_type("BaseQRankSum") == BCF_HT_REAL);
+    REQUIRE(ds.fmt_field_type("GQ", hdrs.at(0).get()) == BCF_HT_INT);
+    REQUIRE(
+        ds.info_field_type("BaseQRankSum", hdrs.at(0).get()) == BCF_HT_REAL);
   }
 
   // Ingest the samples


### PR DESCRIPTION
This PR adjust the number of times we query the VCF header array. We now attempt to lazily load information and to use header data from the running VCF query instead of data from the underlying array. Lastly we no longer user est_result_size for the vcf array querying and instead use a % of the read query's memory budget.