### PR TITLE
Only fetch headers if needed in export

### DIFF
--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -1538,6 +1538,17 @@ const char* TileDBVCFDataset::materialized_attribute_name(
   return this->materialized_vcf_attributes_[index].data();
 }
 
+bool TileDBVCFDataset::is_attribute_materialized(
+    const std::string& attr) const {
+  for (const auto& materialized_attr_name :
+       this->materialized_vcf_attributes_) {
+    if (std::string(materialized_attr_name.data()) == attr)
+      return true;
+  }
+
+  return false;
+}
+
 const char* TileDBVCFDataset::sample_name(const int32_t index) const {
   if (!sample_names_loaded_ && metadata_.version == Version::V4)
     load_sample_names_v4();
@@ -1830,6 +1841,14 @@ std::vector<std::vector<char>> TileDBVCFDataset::sample_names() const {
   }
 
   return sample_names_;
+}
+
+bool TileDBVCFDataset::is_info_field(const std::string& attr) const {
+  return attr.substr(0, 5) == "info_";
+}
+
+bool TileDBVCFDataset::is_fmt_field(const std::string& attr) const {
+  return attr.substr(0, 4) == "fmt_";
 }
 }  // namespace vcf
 }  // namespace tiledb

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -398,6 +398,8 @@ class TileDBVCFDataset {
    */
   const char* materialized_attribute_name(int32_t index) const;
 
+  bool is_attribute_materialized(const std::string& attr) const;
+
   /**
    * Get sample name by index
    * @param index
@@ -535,6 +537,20 @@ class TileDBVCFDataset {
    * Load sample names
    */
   void load_sample_names_v4() const;
+
+  /**
+   * Check if a attr is an info field or not
+   * @param attr
+   * @return true if "info_" prefixed
+   */
+  bool is_info_field(const std::string& attr) const;
+
+  /**
+   * Check if a attr is an fmt field or not
+   * @param attr
+   * @return true if "fmt_" prefixed
+   */
+  bool is_fmt_field(const std::string& attr) const;
 
  private:
   /* ********************************* */

--- a/libtiledbvcf/src/read/bcf_exporter.cc
+++ b/libtiledbvcf/src/read/bcf_exporter.cc
@@ -34,6 +34,7 @@ namespace tiledb {
 namespace vcf {
 
 BCFExporter::BCFExporter(ExportFormat fmt) {
+  need_headers_ = true;
   switch (fmt) {
     case ExportFormat::CompressedBCF:
       extension_ = ".bcf";

--- a/libtiledbvcf/src/read/exporter.cc
+++ b/libtiledbvcf/src/read/exporter.cc
@@ -238,5 +238,9 @@ void Exporter::recover_record(
   }
 }
 
+bool Exporter::need_headers() const {
+  return need_headers_;
+}
+
 }  // namespace vcf
 }  // namespace tiledb

--- a/libtiledbvcf/src/read/exporter.h
+++ b/libtiledbvcf/src/read/exporter.h
@@ -97,6 +97,8 @@ class Exporter {
    */
   virtual std::set<std::string> array_attributes_required() const = 0;
 
+  bool need_headers() const;
+
  protected:
   /** The dataset. */
   const TileDBVCFDataset* dataset_;
@@ -109,6 +111,9 @@ class Exporter {
 
   /** Reusable htslib record struct. */
   SafeBCFRec reusable_rec_;
+
+  /** Does the exporter need headers */
+  bool need_headers_ = false;
 
   /**
    * Given the TileDB query results, populates the htslib record struct with

--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -489,7 +489,10 @@ class Reader {
 
     /** indicates if the user is querying all samples in the array, this cause
      * some special case optimizations. */
-    bool all_samples;
+    bool all_samples = false;
+
+    /** Does the export need headers to be fetched. */
+    bool need_headers = false;
   };
 
   /* ********************************* */

--- a/libtiledbvcf/src/read/tsv_exporter.cc
+++ b/libtiledbvcf/src/read/tsv_exporter.cc
@@ -35,6 +35,7 @@ TSVExporter::TSVExporter(
     const std::vector<std::string>& output_fields)
     : output_initialized_(false)
     , output_file_(output_file) {
+  need_headers_ = true;
   for (const auto& f : output_fields) {
     auto parts = utils::split(f, ':');
     if (parts.size() < 2) {
@@ -48,8 +49,10 @@ TSVExporter::TSVExporter(
     } else {
       std::string name = parts[1];
       if (utils::starts_with(f, "I:")) {
+        need_headers_ = true;
         output_fields_.emplace_back(OutputField::Type::Info, name);
       } else if (utils::starts_with(f, "S:")) {
+        need_headers_ = true;
         output_fields_.emplace_back(OutputField::Type::Fmt, name);
       } else if (utils::starts_with(f, "Q:")) {
         output_fields_.emplace_back(OutputField::Type::Query, name);


### PR DESCRIPTION
We now only fetch headers for TSV or VCF exports or in-memory when exporting a fmt/info field which is not materialized.