### PR TITLE
 Avoid unnecessary fetching of sample list for v4

### DIFF
--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -295,6 +295,8 @@ class TileDBVCFDataset {
   std::unordered_map<uint32_t, SafeBCFHdr> fetch_vcf_headers_v4(
       const std::vector<SampleAndId>& samples,
       std::unordered_map<std::string, size_t>* lookup_map,
+      bool all_samples,
+      bool first_sample,
       uint64_t memory_budget = 10485760) const;
 
   /**

--- a/libtiledbvcf/src/read/bcf_exporter.cc
+++ b/libtiledbvcf/src/read/bcf_exporter.cc
@@ -95,7 +95,7 @@ void BCFExporter::finalize_export(
     record_buffers_v4_.erase(buff_map_it);
   }
 
-  auto file_it = file_info_.find(sample.sample_id);
+  auto file_it = file_info_.find(sample.sample_name);
   if (file_it != file_info_.end())
     file_info_.erase(file_it);
 }
@@ -145,7 +145,7 @@ void BCFExporter::flush_record_buffer(
 
 void BCFExporter::init_export_for_sample(
     const SampleAndId& sample, const bcf_hdr_t* hdr) {
-  if (file_info_.count(sample.sample_id) > 0)
+  if (file_info_.count(sample.sample_name) > 0)
     return;
 
   std::string path = output_path(sample);
@@ -164,7 +164,7 @@ void BCFExporter::init_export_for_sample(
         "Error creating BCF output file '" + path +
         "'; error writing header: ");
 
-  file_info_[sample.sample_id] = path;
+  file_info_[sample.sample_name] = path;
   all_exported_files_.push_back(path);
 }
 

--- a/libtiledbvcf/src/read/bcf_exporter.h
+++ b/libtiledbvcf/src/read/bcf_exporter.h
@@ -56,7 +56,7 @@ class BCFExporter : public Exporter {
   /** Number of records to buffer for a file before flushing to disk. */
   const unsigned RECORD_BUFFER_LIMIT = 10000;
 
-  std::map<uint32_t, std::string> file_info_;
+  std::map<std::string, std::string> file_info_;
   std::unordered_map<std::string, Buffer> record_buffers_v4_;
   std::string extension_;
   std::string fmt_code_;

--- a/libtiledbvcf/test/src/unit-c-api-reader.cc
+++ b/libtiledbvcf/test/src/unit-c-api-reader.cc
@@ -3824,6 +3824,16 @@ TEST_CASE("C API: Reader submit (partitioned samples)", "[capi][reader]") {
   REQUIRE(tiledb_vcf_reader_read(reader0) == TILEDB_VCF_OK);
   REQUIRE(tiledb_vcf_reader_read(reader1) == TILEDB_VCF_OK);
 
+  // Check result size
+  REQUIRE(
+      tiledb_vcf_reader_get_result_num_records(reader0, &num_records) ==
+      TILEDB_VCF_OK);
+  REQUIRE(num_records == 8);
+  REQUIRE(
+      tiledb_vcf_reader_get_result_num_records(reader1, &num_records) ==
+      TILEDB_VCF_OK);
+  REQUIRE(num_records == 3);
+
   // Check status
   REQUIRE(tiledb_vcf_reader_get_status(reader0, &status) == TILEDB_VCF_OK);
   REQUIRE(status == TILEDB_VCF_COMPLETED);

--- a/libtiledbvcf/test/src/unit-vcf-store.cc
+++ b/libtiledbvcf/test/src/unit-vcf-store.cc
@@ -109,7 +109,8 @@ TEST_CASE("TileDB-VCF: Test register", "[tiledbvcf][ingest]") {
         ds.metadata().sample_names_,
         Catch::Matchers::VectorContains(std::string("HG01762")));
 
-    auto hdrs = ds.fetch_vcf_headers_v4({{"HG01762", 0}}, nullptr);
+    auto hdrs =
+        ds.fetch_vcf_headers_v4({{"HG01762", 0}}, nullptr, false, false);
     REQUIRE(hdrs.size() == 1);
     REQUIRE(bcf_hdr_nsamples(hdrs.at(0)) == 1);
     REQUIRE(hdrs.at(0)->samples[0] == std::string("HG01762"));
@@ -145,8 +146,8 @@ TEST_CASE("TileDB-VCF: Test register", "[tiledbvcf][ingest]") {
     REQUIRE_THAT(
         ds.metadata().sample_names_, Catch::Matchers::Contains(samples));
 
-    auto hdrs =
-        ds.fetch_vcf_headers_v4({{"HG01762", 0}, {"HG00280", 1}}, nullptr);
+    auto hdrs = ds.fetch_vcf_headers_v4(
+        {{"HG01762", 0}, {"HG00280", 1}}, nullptr, false, false);
     REQUIRE(hdrs.size() == 2);
     std::vector<std::string> expected_samples = {"HG01762", "HG00280"};
     std::vector<std::string> result_samples = {


### PR DESCRIPTION
If the user is exporting all samples, we can avoid actually getting the full list of samples names in most cases. This removes a query to the vcf_header array.

Depends on #285 