### PR TITLE
RFC/WIP Arrow ownership fixes

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -74,6 +74,16 @@ class get_pybind_include(object):
 
         return pybind11.get_include(self.user)
 
+class get_numpy_include(object):
+    """Helper class to determine the numpy include path
+    The purpose of this class is to postpone importing numpy
+    until it is actually installed, so that the ``get_include()``
+    method can be invoked."""
+
+    def __str__(self):
+        import numpy
+
+        return numpy.get_include()
 
 class PathConfig(object):
     """Helper class with some path information."""
@@ -210,7 +220,7 @@ def get_ext_modules():
         Extension(
             "tiledbvcf.libtiledbvcf",
             src_files,
-            include_dirs=[get_pybind_include(), get_pybind_include(user=True)],
+            include_dirs=[get_pybind_include(), get_pybind_include(user=True), get_numpy_include()],
             libraries=["tiledbvcf"],
             library_dirs=[],
             language="c++",

--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -47,7 +47,8 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("get_sample_names", &Reader::get_sample_names)
       .def("set_buffer_percentage", &Reader::set_buffer_percentage)
       .def("set_tiledb_tile_cache_percentage", &Reader::set_tiledb_tile_cache_percentage)
-      .def("set_check_samples_exist", &Reader::set_check_samples_exist);
+      .def("set_check_samples_exist", &Reader::set_check_samples_exist)
+      .def("_release_buffers", &Reader::release_buffers);
 
   py::class_<Writer>(m, "Writer")
       .def(py::init())

--- a/apis/python/src/tiledbvcf/binding/reader.h
+++ b/apis/python/src/tiledbvcf/binding/reader.h
@@ -152,6 +152,9 @@ class Reader {
   /** Set to check if samples requested exist and error if not. */
   void set_check_samples_exist(bool check_samples_exist);
 
+  /** Releases references on allocated buffers and clears the buffers list. */
+  void release_buffers();
+
  private:
   /** Buffer struct to hold attribute data read from the dataset. */
   struct BufferInfo {
@@ -191,8 +194,6 @@ class Reader {
   /** Sets the allocated buffers on the reader object. */
   void set_buffers();
 
-  /** Releases references on allocated buffers and clears the buffers list. */
-  void release_buffers();
 };
 
 }  // namespace tiledbvcfpy

--- a/apis/python/src/tiledbvcf/binding/reader.h
+++ b/apis/python/src/tiledbvcf/binding/reader.h
@@ -95,7 +95,9 @@ class Reader {
    * Returns a map of attribute name -> (offsets_buff, data_buff) containing the
    * data from the last read operation.
    */
-  std::map<std::string, std::pair<py::array, py::array>> get_buffers();
+  std::map<std::string, std::tuple<py::array, py::array, py::array, py::array>> get_buffers();
+
+  void* numpy_callback(void*);
 
   /**
    * Returns a PyArrow table containing the results from the last read

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -239,7 +239,7 @@ class Dataset(object):
         # Grab buffers and hold reference on the pandas dataframe so they are not gc'ed when the reader goes out of scope
         table_buffers = self.reader.get_buffers()
         df = table.to_pandas()
-        df.attrs["_vcf_buffers"] = table_buffers
+        #df.attrs["_vcf_buffers"] = table_buffers
         return df
 
     def continue_read_arrow(self, release_buffers=True):

--- a/apis/python/tests/test_tiledbvcf.py
+++ b/apis/python/tests/test_tiledbvcf.py
@@ -243,6 +243,27 @@ def test_basic_reads(test_ds):
         expected_df, df.sort_values(ignore_index=True, by=["sample_name", "pos_start"])
     )
 
+def test_arrow_ownership(test_ds):
+    # Sample only
+    table = test_ds.read_arrow(
+        attrs=["sample_name", "pos_start", "pos_end"], samples=["HG01762"]
+    )
+
+    test_ds.reader._release_buffers()
+
+    df = table.to_pandas()
+
+    expected_df = pd.DataFrame(
+        {
+            "sample_name": pd.Series(["HG01762", "HG01762", "HG01762"]),
+            "pos_start": pd.Series([12141, 12546, 13354], dtype=np.int32),
+            "pos_end": pd.Series([12277, 12771, 13389], dtype=np.int32),
+        }
+    ).sort_values(ignore_index=True, by=["sample_name", "pos_start"])
+    _check_dfs(
+        expected_df, df.sort_values(ignore_index=True, by=["sample_name", "pos_start"])
+    )
+
 
 def test_multiple_counts(test_ds):
     assert test_ds.count() == 14
@@ -940,3 +961,4 @@ def test_incremental_ingest(tmp_path):
     assert ds.count() == 14
     assert ds.count(regions=["1:12700-13400"]) == 6
     assert ds.count(samples=["HG00280"], regions=["1:12700-13400"]) == 4
+


### PR DESCRIPTION
@Shelnutt2 may have a better fix for this issue, but posting the parallel approach I developed, at least for the test

- change arrow exporter `to_arrow` to take a map of numpy buffer pyobject to data address
- use arrow NumPyBuffer to wrap the PyObjects
- add a test for ownership (plus exposing the release function) -- the test segfaults before the fix and passes after