### PR TITLE
Switch python API to build and own arrow table and buffers

### DIFF
--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -32,7 +32,7 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("set_tiledb_stats_enabled", &Reader::set_tiledb_stats_enabled)
       .def("set_verbose", &Reader::set_verbose)
       .def("read", &Reader::read, py::arg("release_buffs")=true)
-      .def("get_buffers", &Reader::get_buffers)
+//      .def("get_buffers", &Reader::get_buffers)
       .def("get_results_arrow", &Reader::get_results_arrow)
       .def("completed", &Reader::completed)
       .def("result_num_records", &Reader::result_num_records)

--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -32,7 +32,6 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("set_tiledb_stats_enabled", &Reader::set_tiledb_stats_enabled)
       .def("set_verbose", &Reader::set_verbose)
       .def("read", &Reader::read, py::arg("release_buffs")=true)
-//      .def("get_buffers", &Reader::get_buffers)
       .def("get_results_arrow", &Reader::get_results_arrow)
       .def("completed", &Reader::completed)
       .def("result_num_records", &Reader::result_num_records)

--- a/apis/python/src/tiledbvcf/binding/reader.cc
+++ b/apis/python/src/tiledbvcf/binding/reader.cc
@@ -348,29 +348,8 @@ void Reader::release_buffers() {
   buffers_.clear();
 }
 
-//std::map<std::string, std::pair<py::array, py::array>> Reader::get_buffers() {
-//  std::map<std::string, std::pair<py::array, py::array>> result;
-//  for (auto& buff : buffers_) {
-//    const auto& attr = buff.attr_name;
-//    result[attr] = {buff.offsets, buff.data};
-//  }
-//  return result;
-//}
-
 py::object Reader::get_results_arrow() {
   auto reader = ptr.get();
-//  std::shared_ptr<arrow::Table> table = tiledb::vcf::Arrow::to_arrow(reader);
-//  if (table == nullptr)
-//    throw std::runtime_error(
-//        "TileDB-VCF-Py: Error converting to Arrow; null Array.");
-//  PyObject* obj = arrow::py::wrap_table(table);
-//  if (obj == nullptr) {
-//    PyErr_PrintEx(1);
-//    throw std::runtime_error(
-//        "TileDB-VCF-Py: Error converting to Arrow; null Python object.");
-//  }
-//  return py::reinterpret_steal<py::object>(obj);
-
 
     std::vector<std::shared_ptr<arrow::Field>> fields;
     std::vector<std::shared_ptr<arrow::Array>> arrays;

--- a/apis/python/src/tiledbvcf/binding/reader.h
+++ b/apis/python/src/tiledbvcf/binding/reader.h
@@ -26,6 +26,7 @@
  * THE SOFTWARE.
  */
 
+#include <arrow/api.h>
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -95,7 +96,7 @@ class Reader {
    * Returns a map of attribute name -> (offsets_buff, data_buff) containing the
    * data from the last read operation.
    */
-  std::map<std::string, std::pair<py::array, py::array>> get_buffers();
+//  std::map<std::string, std::pair<py::array, py::array>> get_buffers();
 
   /**
    * Returns a PyArrow table containing the results from the last read
@@ -158,13 +159,15 @@ class Reader {
     /** Name of attribute. */
     std::string attr_name;
     /** Offsets buffer, for var-len attributes. */
-    py::array offsets;
+    std::shared_ptr<arrow::Buffer> offsets;
     /** List offsets buffer, for list var-len attributes. */
-    py::array list_offsets;
+    std::shared_ptr<arrow::Buffer> list_offsets;
     /** Data buffer. */
-    py::array data;
+    std::shared_ptr<arrow::Buffer> data;
     /** Null-value bitmap, for nullable attributes. */
-    py::array bitmap;
+    std::shared_ptr<arrow::Buffer> bitmap;
+
+    std::shared_ptr<arrow::Array> array;
   };
 
   /** Helper function to free a C reader instance */
@@ -172,6 +175,9 @@ class Reader {
 
   /** Convert the given datatype to a numpy dtype */
   static py::dtype to_numpy_dtype(tiledb_vcf_attr_datatype_t datatype);
+
+  /** Convert the given datatype to a arrow datatype */
+  static std::shared_ptr<arrow::DataType> to_arrow_datatype(tiledb_vcf_attr_datatype_t datatype);
 
   /** The underlying C reader object. */
   std::unique_ptr<tiledb_vcf_reader_t, decltype(&deleter)> ptr;
@@ -193,6 +199,33 @@ class Reader {
 
   /** Releases references on allocated buffers and clears the buffers list. */
   void release_buffers();
+
+  template <typename T>
+  std::shared_ptr<arrow::Array> build_arrow_array(std::shared_ptr<arrow::DataType> arrow_datatype, const BufferInfo& buffer, const uint64_t count) {
+    std::shared_ptr<arrow::Array> array;
+    std::shared_ptr<arrow::Array> data_array;
+    bool var_len = buffer.offsets != nullptr;
+    bool list = buffer.list_offsets != nullptr;
+    bool nullable = buffer.bitmap != nullptr;
+
+    if(list) {
+      if (var_len) {
+        auto real_data_array = std::make_shared<T>(count, buffer.data);
+        data_array = std::make_shared<arrow::ListArray>(arrow::list(arrow_datatype), count, buffer.offsets, real_data_array);
+      } else {
+        data_array = std::make_shared<T>(count, buffer.data);
+      }
+      array = std::make_shared<arrow::ListArray>(arrow::list(arrow::list(arrow_datatype)), count, buffer.list_offsets, data_array, buffer.bitmap);
+    } else if (var_len) {
+      data_array = std::make_shared<T>(count, buffer.data);
+      array = std::make_shared<arrow::ListArray>(arrow::list(arrow_datatype), count, buffer.offsets, data_array, buffer.bitmap);
+    } else {
+      // fixed length
+      array = std::make_shared<T>(count, buffer.data, buffer.bitmap);
+    }
+
+    return array;
+  }
 };
 
 }  // namespace tiledbvcfpy

--- a/apis/python/src/tiledbvcf/binding/reader.h
+++ b/apis/python/src/tiledbvcf/binding/reader.h
@@ -93,12 +93,6 @@ class Reader {
   void read(const bool release_buffs=true);
 
   /**
-   * Returns a map of attribute name -> (offsets_buff, data_buff) containing the
-   * data from the last read operation.
-   */
-//  std::map<std::string, std::pair<py::array, py::array>> get_buffers();
-
-  /**
    * Returns a PyArrow table containing the results from the last read
    * operation.
    */

--- a/apis/python/src/tiledbvcf/dask_functions.py
+++ b/apis/python/src/tiledbvcf/dask_functions.py
@@ -46,7 +46,7 @@ def _read_partition(read_args):
     table_fragments.append(pyar)
 
     while not ds.read_completed():
-        table_fragments.append(ds.continue_read_arrow(release_buffers=False))
+        table_fragments.append(ds.continue_read_arrow(release_buffers=True))
 
     table = pa.concat_tables(table_fragments, promote=False)
 

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -237,9 +237,9 @@ class Dataset(object):
         table = self.continue_read_arrow(release_buffers=release_buffers)
 
         # Grab buffers and hold reference on the pandas dataframe so they are not gc'ed when the reader goes out of scope
-        table_buffers = self.reader.get_buffers()
+        # table_buffers = self.reader.get_buffers()
         df = table.to_pandas()
-        df.attrs["_vcf_buffers"] = table_buffers
+        # df.attrs["_vcf_buffers"] = table_buffers
         return df
 
     def continue_read_arrow(self, release_buffers=True):

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -236,11 +236,7 @@ class Dataset(object):
         """
         table = self.continue_read_arrow(release_buffers=release_buffers)
 
-        # Grab buffers and hold reference on the pandas dataframe so they are not gc'ed when the reader goes out of scope
-        # table_buffers = self.reader.get_buffers()
-        df = table.to_pandas()
-        # df.attrs["_vcf_buffers"] = table_buffers
-        return df
+        return table.to_pandas()
 
     def continue_read_arrow(self, release_buffers=True):
         """


### PR DESCRIPTION
This change reworks the python api to build arrow buffers and array table directly. Previously it used numpy arrays and then used the `libtiledbvcf` arrow functionality to build the arrow table. The problem we've been encountering is that the arrow table did not own the underlying buffers. This meant that when the python `Dataset` class went out of scope and was GC'ed the underlying numpy arrays were gc'ed. This leads to segfaults as the arrow table referenced no-longer-existing data.