### PR TITLE
Always reset metadata array buffers on reads

### DIFF
--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -728,10 +728,12 @@ std::unordered_map<uint32_t, SafeBCFHdr> TileDBVCFDataset::fetch_vcf_headers_v4(
   Query::Status status;
   uint32_t sample_idx = 0;
 
-  query.set_buffer("header", offsets, data);
-  query.set_buffer("sample", sample_offsets, sample_data);
-
   do {
+    // Always reset buffer to avoid issue with core library and REST not using
+    // original buffer sizes
+    query.set_buffer("header", offsets, data);
+    query.set_buffer("sample", sample_offsets, sample_data);
+
     status = query.submit();
 
     auto result_el = query.result_buffer_elements();
@@ -758,8 +760,6 @@ std::unordered_map<uint32_t, SafeBCFHdr> TileDBVCFDataset::fetch_vcf_headers_v4(
       if (num_samples_offsets == 0)
         sample_offsets.resize(sample_offsets.size() * 2);
 
-      query.set_buffer("header", offsets, data);
-      query.set_buffer("sample", sample_offsets, sample_data);
     } else if (has_results) {
       // Parse the samples.
 
@@ -852,10 +852,12 @@ std::unordered_map<uint32_t, SafeBCFHdr> TileDBVCFDataset::fetch_vcf_headers(
 
   Query::Status status;
 
-  query.set_buffer("header", offsets, data);
-  query.set_buffer("sample", sample_data);
-
   do {
+    // Always reset buffer to avoid issue with core library and REST not using
+    // original buffer sizes
+    query.set_buffer("header", offsets, data);
+    query.set_buffer("sample", sample_data);
+
     status = query.submit();
 
     auto result_el = query.result_buffer_elements();
@@ -878,8 +880,6 @@ std::unordered_map<uint32_t, SafeBCFHdr> TileDBVCFDataset::fetch_vcf_headers(
       if (num_samples == 0)
         sample_data.resize(sample_data.size() * 2);
 
-      query.set_buffer("header", offsets, data);
-      query.set_buffer("sample", sample_data);
     } else if (has_results) {
       // Parse the samples.
 
@@ -1694,9 +1694,12 @@ std::vector<std::string> TileDBVCFDataset::get_all_samples_from_vcf_headers(
   std::vector<char> sample_data(sample_data_element);
 
   Query::Status status;
-  query.set_buffer("sample", sample_offsets, sample_data);
 
   do {
+    // Always reset buffer to avoid issue with core library and REST not using
+    // original buffer sizes
+    query.set_buffer("sample", sample_offsets, sample_data);
+
     status = query.submit();
 
     auto result_el = query.result_buffer_elements();
@@ -1715,7 +1718,6 @@ std::vector<std::string> TileDBVCFDataset::get_all_samples_from_vcf_headers(
       if (num_offsets == 0)
         sample_offsets.resize(sample_offsets.size() * 2);
 
-      query.set_buffer("sample", sample_offsets, sample_data);
     } else if (has_results) {
       // Parse the samples.
 

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -296,8 +296,7 @@ class TileDBVCFDataset {
       const std::vector<SampleAndId>& samples,
       std::unordered_map<std::string, size_t>* lookup_map,
       bool all_samples,
-      bool first_sample,
-      uint64_t memory_budget = 10485760) const;
+      bool first_sample) const;
 
   /**
    * Returns a list of regions, one per contig (spanning the entire contig),
@@ -425,8 +424,7 @@ class TileDBVCFDataset {
    *
    * @return vector of all sample names
    */
-  std::vector<std::string> get_all_samples_from_vcf_headers(
-      const uint64_t memory_budget = 10485760) const;
+  std::vector<std::string> get_all_samples_from_vcf_headers() const;
 
   std::shared_ptr<tiledb::Array> data_array() const;
 

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -573,10 +573,10 @@ class TileDBVCFDataset {
   mutable std::map<std::string, int> fmt_field_types_;
 
   /** List of all attributes of vcf for querying */
-  mutable std::vector<std::string> vcf_attributes_;
+  mutable std::vector<std::vector<char>> vcf_attributes_;
 
   /** List of all materialzied attributes of vcf for querying */
-  mutable std::vector<std::string> materialized_vcf_attributes_;
+  mutable std::vector<std::vector<char>> materialized_vcf_attributes_;
 
   /** List of sample names for exporting */
   mutable std::vector<std::vector<char>> sample_names_;

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -611,8 +611,7 @@ bool Reader::next_read_batch_v4() {
           read_state_.current_sample_batches,
           &read_state_.current_hdrs_lookup,
           read_state_.all_samples,
-          false,
-          params_.memory_budget_breakdown.buffers);
+          false);
     }
   }
 


### PR DESCRIPTION
This avoid an issue in the core library with REST arrays and reducing buffer sizes. This is harmless for all arrays and has no practical effect in most cases, but avoids a bug in one set of circumstances.