### PR TITLE
Remove unused variable in pybind11

### DIFF
--- a/apis/python/.gitignore
+++ b/apis/python/.gitignore
@@ -1,2 +1,3 @@
 src/tiledbvcf/version.py
 src/tiledbvcf/libhts.so.1.8
+src/tiledbvcf/libhts.so.1.*

--- a/apis/python/src/tiledbvcf/binding/reader.h
+++ b/apis/python/src/tiledbvcf/binding/reader.h
@@ -209,7 +209,6 @@ class Reader {
     std::shared_ptr<arrow::Array> data_array;
     bool var_len = buffer.offsets != nullptr;
     bool list = buffer.list_offsets != nullptr;
-    bool nullable = buffer.bitmap != nullptr;
 
     if(list) {
       if (var_len) {


### PR DESCRIPTION
Remove unused variable in pybind11, this fixes a warning from CI.