### PR TITLE
Verbose mode should be set first in Python

### DIFF
--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -47,16 +47,16 @@ class Dataset(object):
         self.cfg = cfg
         if self.mode == "r":
             self.reader = libtiledbvcf.Reader()
+            self.reader.set_verbose(verbose)
             self._set_read_cfg(cfg)
             self.reader.init(uri)
             self.reader.set_tiledb_stats_enabled(stats)
-            self.reader.set_verbose(verbose)
         elif self.mode == "w":
             self.writer = libtiledbvcf.Writer()
+            self.writer.set_verbose(verbose)
             self._set_write_cfg(cfg)
             self.writer.init(uri)
             self.writer.set_tiledb_stats_enabled(stats)
-            self.writer.set_verbose(verbose)
         else:
             raise Exception("Unsupported dataset mode {}".format(mode))
 


### PR DESCRIPTION
This solves a problem were some options are not properly printed out when verbose is enabled because the verbose mode has not been set.