### PR TITLE
TileDB Cloud Arrays should use memory for buffers

### DIFF
--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -1656,8 +1656,12 @@ std::string TileDBVCFDataset::vcf_headers_uri(
   return utils::uri_join(grp, "vcf_headers", delimiter);
 }
 
-bool TileDBVCFDataset::cloud_dataset(std::string root_uri) {
+bool TileDBVCFDataset::cloud_dataset(const std::string& root_uri) {
   return utils::starts_with(root_uri, "tiledb://");
+}
+
+bool TileDBVCFDataset::tiledb_cloud_dataset() const {
+  return cloud_dataset(root_uri_);
 }
 
 std::map<std::string, int> TileDBVCFDataset::info_field_types() const {

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -552,6 +552,9 @@ class TileDBVCFDataset {
    */
   bool is_fmt_field(const std::string& attr) const;
 
+  /** Returns true if the dataset is tiledb cloud URI. */
+  bool tiledb_cloud_dataset() const;
+
  private:
   /* ********************************* */
   /*          PRIVATE ATTRIBUTES       */
@@ -751,7 +754,7 @@ class TileDBVCFDataset {
       const std::string& root_uri, bool check_for_cloud = true);
 
   /** Returns true if the array starts with the tiledb:// URI **/
-  static bool cloud_dataset(std::string root_uri);
+  static bool cloud_dataset(const std::string& root_uri);
 
   /* ********************************* */
   /*          PRIVATE METHODS          */

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -2218,6 +2218,21 @@ void Reader::compute_memory_budget_details() {
   // 25/75 split between buffers and memory budget
   params_.memory_budget_breakdown.tiledb_memory_budget = memory_budget;
 
+  // TileDB Cloud datasets use all the memory for buffers
+  if (dataset_ != nullptr && dataset_->tiledb_cloud_dataset()) {
+    if (params_.verbose) {
+      std::cout << "Overrode memory budgets because array is TileDB Cloud "
+                   "array. All memory will be given to buffers."
+                << std::endl;
+    }
+    params_.memory_budget_breakdown.tiledb_tile_cache = 0;
+    // Set the budget to non-zero but its effectively ignored
+    params_.memory_budget_breakdown.tiledb_memory_budget = 1024;
+    // Set the buffers to the full budget
+    params_.memory_budget_breakdown.buffers =
+        params_.memory_budget_mb * 1024 * 1024;
+  }
+
   if (params_.verbose) {
     std::cout << "Set memory budgets as follows: "
               << "starting budget: " << params_.memory_budget_mb * 1024 * 1024


### PR DESCRIPTION
Tile cache and the TileDB `sm.memory_budget` and `sm.memory_budget_var` parameters are not effective with TileDB Cloud arrays since all computations happen in the remote server.