### PR TITLE
Add hueristic to size query buffers

### DIFF
--- a/libtiledbvcf/src/dataset/attribute_buffer_set.h
+++ b/libtiledbvcf/src/dataset/attribute_buffer_set.h
@@ -43,6 +43,32 @@ namespace vcf {
  * what is exported for in-memory.
  */
 class AttributeBufferSet {
+  struct BufferSizeByType {
+    BufferSizeByType(
+        const uint64_t& char_buffer_size,
+        const uint64_t& uint8_buffer_size,
+        const uint64_t& int32_buffer_size,
+        const uint64_t& uint64_buffer_size,
+        const uint64_t& float32_buffer_size,
+        const uint64_t& var_length_uint8_buffer_size) {
+      this->char_buffer_size = char_buffer_size;
+      this->uint8_buffer_size = uint8_buffer_size;
+      this->int32_buffer_size = int32_buffer_size;
+      this->uint64_buffer_size = uint64_buffer_size;
+      this->float32_buffer_size = float32_buffer_size;
+      this->var_length_uint8_buffer_size = var_length_uint8_buffer_size;
+    }
+
+    BufferSizeByType() = default;
+
+    uint64_t char_buffer_size = 0;
+    uint64_t uint8_buffer_size = 0;
+    uint64_t int32_buffer_size = 0;
+    uint64_t uint64_buffer_size = 0;
+    uint64_t float32_buffer_size = 0;
+    uint64_t var_length_uint8_buffer_size = 0;
+  };
+
  public:
   explicit AttributeBufferSet(bool verbose = false);
 
@@ -53,8 +79,10 @@ class AttributeBufferSet {
    * @param mem_budget
    * @return size of buffers in bytes
    */
-  static uint64_t compute_buffer_size(
-      const std::unordered_set<std::string>& attr_names, uint64_t mem_budget);
+  static BufferSizeByType compute_buffer_size(
+      const std::unordered_set<std::string>& attr_names,
+      uint64_t mem_budget,
+      TileDBVCFDataset* dataset);
 
   /**
    * Resize buffers for the given set of attributes using the given allocation
@@ -70,7 +98,7 @@ class AttributeBufferSet {
   void allocate_fixed(
       const std::unordered_set<std::string>& attr_names,
       uint64_t memory_budget,
-      unsigned version);
+      TileDBVCFDataset* dataset);
 
   /**
    * Returns the sum of sizes of all buffers (in bytes). This includes the size
@@ -191,7 +219,7 @@ class AttributeBufferSet {
    * all buffers see total_size()
    * @return size
    */
-  uint64_t size_per_buffer() const;
+  BufferSizeByType sizes_per_buffer() const;
 
   /**
    * Number of buffers allocated
@@ -255,7 +283,7 @@ class AttributeBufferSet {
   bool verbose_;
 
   /** size of allocated buffers in bytes */
-  uint64_t buffer_size_bytes_;
+  AttributeBufferSet::BufferSizeByType buffer_size_by_type_;
 
   /** Total number of buffers allocated */
   uint64_t number_of_buffers_;

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -1496,6 +1496,16 @@ bool TileDBVCFDataset::attribute_is_fixed_len(const std::string& attr) {
          attr == AttrNames::V2::qual;
 }
 
+bool TileDBVCFDataset::attribute_is_nullable(const std::string& attr) {
+  // Nulls are not included in schema yet
+  return false;
+}
+
+bool TileDBVCFDataset::attribute_is_list(const std::string& attr) {
+  // Lists are not included in schema yet
+  return false;
+}
+
 std::set<std::string> TileDBVCFDataset::all_attributes() const {
   if (!open_)
     throw std::invalid_argument(
@@ -1942,6 +1952,30 @@ bool TileDBVCFDataset::is_info_field(const std::string& attr) const {
 
 bool TileDBVCFDataset::is_fmt_field(const std::string& attr) const {
   return attr.substr(0, 4) == "fmt_";
+}
+
+void TileDBVCFDataset::attribute_datatype_non_fmt_info(
+    const std::string& attribute,
+    tiledb_datatype_t* datatype,
+    bool* var_len,
+    bool* nullable,
+    bool* list) {
+  bool fixed_len = attribute_is_fixed_len(attribute);
+  *var_len = !fixed_len;
+  *var_len = !fixed_len;
+
+  *nullable = attribute_is_nullable(attribute);
+  *list = attribute_is_list(attribute);
+  *var_len = !fixed_len;
+
+  auto schema = data_array_->schema();
+  if (schema.has_attribute(attribute)) {
+    auto attr = schema.attribute(attribute);
+    *datatype = attr.type();
+  } else {
+    auto dimension = schema.domain().dimension(attribute);
+    *datatype = dimension.type();
+  }
 }
 }  // namespace vcf
 }  // namespace tiledb

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -555,6 +555,40 @@ class TileDBVCFDataset {
   /** Returns true if the dataset is tiledb cloud URI. */
   bool tiledb_cloud_dataset() const;
 
+  /**
+   * Gets the datatype of a particular exportable attribute that is not fmt or
+   * info
+   *
+   * @param dataset Dataset (for metadata)
+   * @param attribute Attribute name
+   * @param datatype Set to the datatype of the attribute
+   * @param var_len Set to true if the attribute is variable-length
+   * @param nullable Set to true if the attribute is nullable
+   * @param nullable Set to true if the attribute is var-len list
+   */
+  void attribute_datatype_non_fmt_info(
+      const std::string& attribute,
+      tiledb_datatype_t* datatype,
+      bool* var_len,
+      bool* nullable,
+      bool* list);
+
+  /**
+   * Gets if the attribute is nullable. Nulls are not currently included in
+   * schema but will be eventually
+   * @param attr
+   * @return true if nullable
+   */
+  static bool attribute_is_nullable(const std::string& attr);
+
+  /**
+   * Gets if the attribute is list. Lists are not currently included in schema
+   * but will be eventually
+   * @param attr
+   * @return true if a list
+   */
+  static bool attribute_is_list(const std::string& attr);
+
  private:
   /* ********************************* */
   /*          PRIVATE ATTRIBUTES       */

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -2030,22 +2030,20 @@ void Reader::prepare_attribute_buffers() {
   uint64_t alloc_budget = params_.memory_budget_breakdown.buffers;
 
   // If the query buffers would be less than 100MB don't double buffer
-  if (AttributeBufferSet::compute_buffer_size(attrs, alloc_budget) >
-      params_.double_buffering_threshold) {
+  if (AttributeBufferSet::compute_buffer_size(
+          attrs, alloc_budget, dataset_.get())
+          .uint64_buffer_size > params_.double_buffering_threshold) {
     // If we are double buffering allocate half to each set of buffers
     alloc_budget = params_.memory_budget_breakdown.buffers / 2;
-    buffers_a->allocate_fixed(
-        attrs, alloc_budget, dataset_->metadata().version);
-    buffers_b->allocate_fixed(
-        attrs, alloc_budget, dataset_->metadata().version);
+    buffers_a->allocate_fixed(attrs, alloc_budget, dataset_.get());
+    buffers_b->allocate_fixed(attrs, alloc_budget, dataset_.get());
     double_buffering_ = true;
     if (params_.verbose)
       std::cout << "double buffering enabled because buffers are above "
                    "threshold size of "
                 << params_.double_buffering_threshold << std::endl;
   } else {
-    buffers_a->allocate_fixed(
-        attrs, alloc_budget, dataset_->metadata().version);
+    buffers_a->allocate_fixed(attrs, alloc_budget, dataset_.get());
     buffers_b.reset(nullptr);
     double_buffering_ = false;
     if (params_.verbose)


### PR DESCRIPTION
This adjusts the TileDB query buffers sizes based on datatypes. This allows us to better allocated the buffers by reducing the size of smaller datatypes so that we attempt to have a more equal element count and not leave some buffers over half empty.