### PR TITLE
Fix for building python package on macOS outside conda

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -235,6 +235,7 @@ class BuildExtCmd(build_ext):
             ext.extra_link_args = link_opts
 
             import pyarrow
+
             # Strip version from pyarrow lib to avoid:
             # https://issues.apache.org/jira/browse/ARROW-5980
             ext.include_dirs.append(pyarrow.get_include())

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -235,9 +235,13 @@ class BuildExtCmd(build_ext):
             ext.extra_link_args = link_opts
 
             import pyarrow
-
+            # Strip version from pyarrow lib to avoid:
+            # https://issues.apache.org/jira/browse/ARROW-5980
             ext.include_dirs.append(pyarrow.get_include())
-            ext.libraries.extend(pyarrow.get_libraries())
+            arrow_version = pyarrow.__version__.replace(".", "")
+            arrow_libs = [f"{lib}.{arrow_version}" for lib in pyarrow.get_libraries()]
+            ext.libraries.extend(arrow_libs)
+
             # don't overlink the arrow core library
             if "arrow" in ext.libraries:
                 ext.libraries.remove("arrow")


### PR DESCRIPTION
Fixes issue #305.
See https://issues.apache.org/jira/browse/ARROW-5980.
