### PR TITLE
Fix attribute_is_fixed_len for v4 sample

### DIFF
--- a/libtiledbvcf/src/dataset/attribute_buffer_set.cc
+++ b/libtiledbvcf/src/dataset/attribute_buffer_set.cc
@@ -138,7 +138,7 @@ void AttributeBufferSet::allocate_fixed(
   // Get count of number of query buffers being allocated
   number_of_buffers_ = 0;
   for (const auto& s : attr_names) {
-    bool fixed_len = TileDBVCFDataset::attribute_is_fixed_len(s);
+    bool fixed_len = dataset->attribute_is_fixed_len(s);
     number_of_buffers_ += fixed_len ? 1 : 2;
   }
 

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -1494,10 +1494,15 @@ std::set<std::string> TileDBVCFDataset::builtin_attributes_v2() {
 }
 
 bool TileDBVCFDataset::attribute_is_fixed_len(const std::string& attr) {
+  if (metadata_.version == Version::V2 || metadata_.version == Version::V3) {
+    if (attr == DimensionNames::V3::sample ||
+        attr == DimensionNames::V2::sample) {
+      return true;
+    }
+  }
+
   return attr == DimensionNames::V4::start_pos ||
-         attr == DimensionNames::V3::sample ||
          attr == DimensionNames::V3::start_pos ||
-         attr == DimensionNames::V2::sample ||
          attr == DimensionNames::V2::end_pos ||
          attr == AttrNames::V4::real_start_pos ||
          attr == AttrNames::V4::end_pos || attr == AttrNames::V4::qual ||

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -356,7 +356,7 @@ class TileDBVCFDataset {
   static std::set<std::string> builtin_attributes_v2();
 
   /** Returns true if the builtin attribute is fixed-len in the schema. */
-  static bool attribute_is_fixed_len(const std::string& attr);
+  bool attribute_is_fixed_len(const std::string& attr);
 
   /** Returns a set of all the attribute names in the dataset. This is a set as
    * we rely on the order for the attribute_index function */


### PR DESCRIPTION
The `attribute_is_fixed_len` function previously was returning fixed length for `sample` even for v4 arrays because the name is the same between v2/v3 and v4. This adjusts this to check for v2/v3 cases.

This only effected the buffer size building, and caused us to be off by missing 1 set of offsets in the calculations for max sizes we could use.