### PR TITLE
Set core sm.skip_est_size_partitioning config to 'true' by default

### DIFF
--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -312,6 +312,9 @@ void TileDBVCFDataset::open(
   // stats it'll be disabled in the reader or writer
   tiledb::Stats::enable();
 
+  // Disable estimated partition result size
+  cfg_.set("sm.skip_est_size_partitioning", "true");
+
   utils::set_tiledb_config(tiledb_config, &cfg_);
   ctx_ = Context(cfg_);
 

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -2064,6 +2064,9 @@ void Reader::init_tiledb() {
   cfg["sm.sm.compute_concurrency_level"] =
       uint64_t(std::thread::hardware_concurrency() * 1.5f);
 
+  // Disable estimated partition result size
+  cfg.set("sm.skip_est_size_partitioning", "true");
+
   // User overrides. We set it on the map and actual config
   utils::set_tiledb_config_map(
       params_.tiledb_config, &params_.tiledb_config_map);
@@ -2183,6 +2186,7 @@ void Reader::set_tiledb_query_config() {
   assert(buffers_a != nullptr);
 
   tiledb::Config cfg;
+  utils::set_tiledb_config(params_.tiledb_config, &cfg);
   if (params_.tiledb_config_map.find("sm.memory_budget") ==
       params_.tiledb_config_map.end())
     cfg["sm.memory_budget"] =
@@ -2194,6 +2198,10 @@ void Reader::set_tiledb_query_config() {
     cfg["sm.memory_budget_var"] =
         params_.memory_budget_breakdown.tiledb_memory_budget /
         buffers_a->nbuffers();
+
+  if (params_.tiledb_config_map.find("sm.skip_est_size_partitioning") ==
+      params_.tiledb_config_map.end())
+    cfg["sm.skip_est_size_partitioning"] = "true";
 
   read_state_.query->set_config(cfg);
 }


### PR DESCRIPTION
There is a new configuration parameter in the core library which will skip using the estimated result size for partitioning. For VCF this is important because there often can be a large number of ranges on each query and this results in performance degradation due to the time it takes to compute the estimated result sizes.