### PR TITLE
Pin homebrew autoconf to 2.69 to fix htslib build

### DIFF
--- a/ci/azure-linux_mac.yml
+++ b/ci/azure-linux_mac.yml
@@ -32,7 +32,7 @@ steps:
         sudo make install
         popd
     else
-        brew install bcftools
+        brew install bcftools gettext
     fi
 
     # Install autoconf/automake (required for htslib)

--- a/ci/azure-linux_mac.yml
+++ b/ci/azure-linux_mac.yml
@@ -32,7 +32,10 @@ steps:
         sudo make install
         popd
     else
-        brew install bcftools gettext
+        # autoconf@2.69 pin is due to changes in autoconf 2.70, compat for which is fixed
+        #   in htlslib here: https://github.com/samtools/htslib/pull/1198
+        #   remove after updating to htslib>=1.12
+        brew install bcftools autoconf@2.69
     fi
 
     # Install autoconf/automake (required for htslib)


### PR DESCRIPTION
Unclear what changed, but it appears to be missing which probably is the cause for this build error:
```
 2021-04-28T12:13:53.2766550Z configure: error: cannot find required auxiliary files: config.guess config.sub
2021-04-28T12:13:53.2767920Z CMake Error at /Users/runner/work/1/s/libtiledbvcf/build/externals/src/ep_htslib-stamp/ep_htslib-configure-Debug-impl.cmake:29 (message):
2021-04-28T12:13:53.2768790Z   Command failed (1):
2021-04-28T12:13:53.2769120Z 
2021-04-28T12:13:53.2770310Z    './configure' '--prefix=/Users/runner/work/1/s/libtiledbvcf/build/externals/install' 'LDFLAGS=-Wl,-install_name,@rpath/libhts.1.10.dylib' 'CFLAGS=-g'
2021-04-28T12:13:53.2770920Z 
```