### PR TITLE
Fix partitioning logic for uneven division

### DIFF
--- a/libtiledbvcf/src/utils/utils.cc
+++ b/libtiledbvcf/src/utils/utils.cc
@@ -342,6 +342,18 @@ uint64_t ceil(uint64_t x, uint64_t y) {
   return x / y + (x % y != 0);
 }
 
+uint32_t floor(uint32_t x, uint32_t y) {
+  if (y == 0)
+    return 0;
+  return x / y;
+}
+
+uint64_t floor(uint64_t x, uint64_t y) {
+  if (y == 0)
+    return 0;
+  return x / y;
+}
+
 // Mutexs to make htslib plugin initialization thread-safe
 std::mutex cfg_mutex;
 std::mutex init_mutex;

--- a/libtiledbvcf/src/utils/utils.h
+++ b/libtiledbvcf/src/utils/utils.h
@@ -50,6 +50,12 @@ uint32_t ceil(uint32_t x, uint32_t y);
 /** Returns the value of x/y (integer division) rounded up. */
 uint64_t ceil(uint64_t x, uint64_t y);
 
+/** Returns the value of x/y (integer division) rounded down. */
+uint32_t floor(uint32_t x, uint32_t y);
+
+/** Returns the value of x/y (integer division) rounded down. */
+uint64_t floor(uint64_t x, uint64_t y);
+
 /**
  * Apply binary_op to each token in [in_begin,in_end], split by any element in
  * [d_begin, d_end]. Adapted from
@@ -149,11 +155,23 @@ void partition_vector(
         "Error partitioning vector; partition index " +
         std::to_string(partition_idx) + " >= num partitions " +
         std::to_string(num_partitions) + ".");
-  uint64_t elts_per_partition = utils::ceil(num_elements, num_partitions);
-  uint64_t idx_min =
-      std::min<uint64_t>(partition_idx * elts_per_partition, num_elements);
-  uint64_t idx_max =
-      std::min<uint64_t>(idx_min + elts_per_partition, num_elements);
+  uint64_t elts_per_partition = utils::floor(num_elements, num_partitions);
+
+  // Handle any left overs by giving them to the first n partitions
+  uint64_t left_overs = num_elements % num_partitions;
+  uint64_t start_offset = 0;
+  uint64_t end_offset = 0;
+  if (partition_idx < left_overs) {
+    if (partition_idx > 0)
+      start_offset = 1;
+
+    end_offset = 1;
+  }
+
+  uint64_t idx_min = std::min<uint64_t>(
+      (partition_idx * elts_per_partition + start_offset), num_elements);
+  uint64_t idx_max = std::min<uint64_t>(
+      idx_min + elts_per_partition + end_offset, num_elements);
 
   // Check for empty partition assignment.
   if (idx_min == idx_max) {

--- a/libtiledbvcf/src/utils/utils.h
+++ b/libtiledbvcf/src/utils/utils.h
@@ -156,22 +156,15 @@ void partition_vector(
         std::to_string(partition_idx) + " >= num partitions " +
         std::to_string(num_partitions) + ".");
   uint64_t elts_per_partition = utils::floor(num_elements, num_partitions);
+  uint64_t idx_min =
+      std::min<uint64_t>(partition_idx * elts_per_partition, num_elements);
+  uint64_t idx_max =
+      std::min<uint64_t>(idx_min + elts_per_partition, num_elements);
 
   // Handle any left overs by giving them to the first n partitions
   uint64_t left_overs = num_elements % num_partitions;
-  uint64_t start_offset = 0;
-  uint64_t end_offset = 0;
-  if (partition_idx < left_overs) {
-    if (partition_idx > 0)
-      start_offset = 1;
-
-    end_offset = 1;
-  }
-
-  uint64_t idx_min = std::min<uint64_t>(
-      (partition_idx * elts_per_partition + start_offset), num_elements);
-  uint64_t idx_max = std::min<uint64_t>(
-      idx_min + elts_per_partition + end_offset, num_elements);
+  idx_min += std::min<uint64_t>(partition_idx, left_overs);
+  idx_max += std::min<uint64_t>(partition_idx + 1, left_overs);
 
   // Check for empty partition assignment.
   if (idx_min == idx_max) {

--- a/libtiledbvcf/test/run-cli-tests.sh
+++ b/libtiledbvcf/test/run-cli-tests.sh
@@ -18,7 +18,8 @@ upload_dir=/tmp/tilevcf-upload-dir-$$
 # Clean up test outputs
 function clean_up {
     rm -rf ingested_1 ingested_2 ingested_3 ingested_3_attrs \
-           ingested_1_2 ingested_1_2_vcf ingested_3_samples ingested_comb ingested_append \
+           ingested_1_2 ingested_1_2_vcf ingested_3_samples ingested_10_samples \
+           ingested_comb ingested_append \
            ingested_from_file ingested_diff_order ingested_buffered \
            ingested_sep_indexes ingested_dupe_end_pos \
            ingested_dupe_start_pos errored_dupe_start_pos \
@@ -48,6 +49,7 @@ create_register_ingest ingested_3 ${input_dir}/small3.bcf
 create_register_ingest ingested_1_2 ${input_dir}/small2.bcf ${input_dir}/small.bcf
 create_register_ingest ingested_1_2_vcf ${input_dir}/small2.bcf ${input_dir}/small.vcf.gz
 create_register_ingest ingested_3_samples ${input_dir}/random_synthetic/G{1,2,3}.bcf
+create_register_ingest ingested_10_samples ${input_dir}/random_synthetic/G{1..10}.bcf
 create_register_ingest ingested_dupe_end_pos ${input_dir}/dupeEndPos.vcf.gz
 create_register_ingest ingested_dupe_start_pos ${input_dir}/dupeStartPos.vcf.gz
 
@@ -178,6 +180,11 @@ $tilevcf export -u ingested_1_2 -r $region -v -s HG01762,HG00280 -O v --sample-p
 test -e HG00280.vcf && exit 1
 diff -u <(bcftools view --no-version -r $region ${input_dir}/small.bcf) HG01762.vcf || exit 1
 
+# uneven division doesn't produce empty partitions
+$tilevcf export -u ingested_10_samples -Ov -fingested_10_samples.txt --sample-partition 5:6
+numvcfs=$(ls *.vcf | wc -l)
+test $numvcfs -eq 10 && exit 1
+rm *.vcf
 # Region export checks with output dir
 rm -f HG00280.vcf HG01762.vcf
 rm -f /tmp/HG00280.vcf /tmp/HG01762.vcf

--- a/libtiledbvcf/test/run-cli-tests.sh
+++ b/libtiledbvcf/test/run-cli-tests.sh
@@ -185,6 +185,18 @@ $tilevcf export -u ingested_10_samples -Ov -fingested_10_samples.txt --sample-pa
 numvcfs=$(ls *.vcf | wc -l)
 test $numvcfs -eq 10 && exit 1
 rm *.vcf
+
+# each sample is uniquely assigned to a partition
+for i in {0..5}; do
+  $tilevcf export -u ingested_10_samples -Ov --sample-partition $i:6
+  ls *.vcf >> exported_samples.txt
+  rm *.vcf
+done
+
+numsamples=$(uniq exported_samples.txt | wc -l)
+test $numsamples -eq 10 || exit 1
+rm exported_samples.txt
+
 # Region export checks with output dir
 rm -f HG00280.vcf HG01762.vcf
 rm -f /tmp/HG00280.vcf /tmp/HG01762.vcf


### PR DESCRIPTION
There was a bug in the logic of partitioning in that we used ceil not floor when computing the number of element per partition. This meant that if we rounded up and used up all the elements before the requested user partitioning count we would run out of samples/regions and end up with empty partitions. The empty partitions were not handled gracefully and caused the library to incorrectly fetch all headers. Depending on the exact scenario it might have also resulted in a segfault when attempting to set empty ranges on the core library due to accessing non-existent vector elements.

The fix for this issue is to use floor when computing element per partition and to just assign the left overs to the first N partitions,
where one is given to each partition until we run out of "left over" elements.