### PR TITLE
Support disabling progress estimation w/verbose

### DIFF
--- a/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.c
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.c
@@ -792,3 +792,16 @@ JNIEXPORT jstring JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1
     jstring result = (*env)->NewStringUTF(env, version);
     return result;
 }
+
+JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1set_1disable_1progress_1estimation
+  (JNIEnv* env, jclass self, jlong readerPtr, jboolean disableProgressEstimation) {
+    (void)self;
+    tiledb_vcf_reader_t* reader = (tiledb_vcf_reader_t*)readerPtr;
+    if (reader == 0) {
+      return TILEDB_VCF_ERR;
+    }
+
+    int32_t rc = tiledb_vcf_reader_set_disable_progress_estimation(reader, disableProgressEstimation);
+
+    return rc;
+}

--- a/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.h
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.h
@@ -319,6 +319,14 @@ JNIEXPORT jstring JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1
 JNIEXPORT jstring JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1version
   (JNIEnv *, jclass);
 
+/*
+ * Class:     io_tiledb_libvcfnative_LibVCFNative
+ * Method:    tiledb_vcf_reader_set_disable_progress_estimation
+ * Signature: (JZ)I
+ */
+JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1set_1disable_1progress_1estimation
+  (JNIEnv *, jclass, jlong, jboolean);
+
 #ifdef __cplusplus
 }
 #endif

--- a/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.java
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.java
@@ -127,4 +127,7 @@ public class LibVCFNative {
   public static final native String tiledb_vcf_reader_tiledb_stats(long readerPtr);
 
   public static final native String tiledb_vcf_version();
+
+  public static final native int tiledb_vcf_reader_set_disable_progress_estimation(
+      long readerPtr, boolean disable_progress_estimation);
 }

--- a/apis/java/src/main/java/io/tiledb/libvcfnative/VCFReader.java
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/VCFReader.java
@@ -560,6 +560,17 @@ public class VCFReader implements AutoCloseable {
     return LibVCFNative.tiledb_vcf_version();
   }
 
+  public VCFReader setDisableProgressEstimation(boolean disableProgressEstimation) {
+    int rc =
+        LibVCFNative.tiledb_vcf_reader_set_disable_progress_estimation(
+            this.readerPtr, disableProgressEstimation);
+    if (rc != 0) {
+      String msg = getLastErrorMessage();
+      throw new RuntimeException("Error setting disableProgressEstimation: " + msg);
+    }
+    return this;
+  }
+
   public VCFReader resetBuffers() {
     Iterator it = buffers.entrySet().iterator();
     while (it.hasNext()) {

--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -47,7 +47,8 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("set_buffer_percentage", &Reader::set_buffer_percentage)
       .def("set_tiledb_tile_cache_percentage", &Reader::set_tiledb_tile_cache_percentage)
       .def("set_check_samples_exist", &Reader::set_check_samples_exist)
-      .def("version", &Reader::version);
+      .def("version", &Reader::version)
+      .def("set_disable_progress_estimation", &Reader::set_disable_progress_estimation);
 
   py::class_<Writer>(m, "Writer")
       .def(py::init())

--- a/apis/python/src/tiledbvcf/binding/reader.cc
+++ b/apis/python/src/tiledbvcf/binding/reader.cc
@@ -580,4 +580,9 @@ std::string Reader::version() {
     tiledb_vcf_version(&version_str);
     return version_str;
 }
+
+void Reader::set_disable_progress_estimation(const bool& disable_progress_estimation) {
+  auto reader = ptr.get();
+  check_error(reader, tiledb_vcf_reader_set_disable_progress_estimation(reader, disable_progress_estimation));
+}
 }  // namespace tiledbvcfpy

--- a/apis/python/src/tiledbvcf/binding/reader.h
+++ b/apis/python/src/tiledbvcf/binding/reader.h
@@ -150,6 +150,9 @@ class Reader {
   /** Get Version info for TileDB VCF and TileDB. */
   std::string version();
 
+  /** Set disable progress estimation */
+  void set_disable_progress_estimation(const bool& disable_progress_estimation);
+
  private:
   /** Buffer struct to hold attribute data read from the dataset. */
   struct BufferInfo {

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -140,6 +140,7 @@ class Dataset(object):
         samples_file=None,
         bed_file=None,
         skip_check_samples=False,
+        disable_progress_estimation=False,
     ):
         """Reads data from a TileDB-VCF dataset into Arrow table.
 
@@ -157,6 +158,7 @@ class Dataset(object):
             one per line.
         :param str bed_file: URI of a BED file of genomic regions to be read.
         :param bool skip_check_samples: Should checking the samples requested exist in the array
+        :param bool disable_progress_estimation: Should we skip estimating the progress in verbose mode? Estimating progress can have performance or memory impacts in some cases.
         :return: Pandas DataFrame or PyArrow Array containing results.
         """
         if self.mode != "r":
@@ -169,6 +171,7 @@ class Dataset(object):
         self.reader.set_regions(",".join(regions))
         self.reader.set_attributes(attrs)
         self.reader.set_check_samples_exist(not skip_check_samples)
+        self.reader.set_disable_progress_estimation(disable_progress_estimation)
 
         if bed_file is not None:
             self.reader.set_bed_file(bed_file)
@@ -183,6 +186,7 @@ class Dataset(object):
         samples_file=None,
         bed_file=None,
         skip_check_samples=False,
+        disable_progress_estimation=False,
     ):
         """Reads data from a TileDB-VCF dataset into Pandas dataframe.
 
@@ -200,6 +204,7 @@ class Dataset(object):
             one per line.
         :param str bed_file: URI of a BED file of genomic regions to be read.
         :param bool skip_check_samples: Should checking the samples requested exist in the array
+        :param bool disable_progress_estimation: Should we skip estimating the progress in verbose mode? Estimating progress can have performance or memory impacts in some cases.
         :return: Pandas DataFrame or PyArrow Array containing results.
         """
         if self.mode != "r":
@@ -212,6 +217,7 @@ class Dataset(object):
         self.reader.set_regions(",".join(regions))
         self.reader.set_attributes(attrs)
         self.reader.set_check_samples_exist(not skip_check_samples)
+        self.reader.set_disable_progress_estimation(disable_progress_estimation)
 
         if bed_file is not None:
             self.reader.set_bed_file(bed_file)

--- a/apis/spark/src/main/java/io/tiledb/vcf/VCFDataSourceOptions.java
+++ b/apis/spark/src/main/java/io/tiledb/vcf/VCFDataSourceOptions.java
@@ -161,6 +161,14 @@ public class VCFDataSourceOptions implements Serializable {
     return Optional.empty();
   }
 
+  /** @return If progress estimation in verbose mode should be disabled */
+  public Optional<Boolean> getDisableProgressEstimation() {
+    if (options.containsKey("disable_progress_estimation")) {
+      return Optional.of(Boolean.parseBoolean(options.get("disable_progress_estimation")));
+    }
+    return Optional.empty();
+  }
+
   /** @return Optional CSV String of config parameters */
   public Optional<String> getConfigCSV() {
     return getConfigCSV(options);

--- a/apis/spark/src/main/java/io/tiledb/vcf/VCFInputPartitionReader.java
+++ b/apis/spark/src/main/java/io/tiledb/vcf/VCFInputPartitionReader.java
@@ -304,6 +304,12 @@ public class VCFInputPartitionReader implements InputPartitionReader<ColumnarBat
       vcfReader.setVerbose(verbose.get());
     }
 
+    // Set DisableProgressEstimation
+    Optional<Boolean> disableProgressEstimation = options.getDisableProgressEstimation();
+    if (disableProgressEstimation.isPresent()) {
+      vcfReader.setDisableProgressEstimation(disableProgressEstimation.get());
+    }
+
     // Set TileDB buffer percentage
     Optional<Float> tiledbBufferPercentage = options.getTileDBBufferPercentage();
     if (tiledbBufferPercentage.isPresent()) {

--- a/libtiledbvcf/src/c_api/tiledbvcf.cc
+++ b/libtiledbvcf/src/c_api/tiledbvcf.cc
@@ -750,6 +750,20 @@ int32_t tiledb_vcf_reader_set_verbose(
   return TILEDB_VCF_OK;
 }
 
+int32_t tiledb_vcf_reader_set_disable_progress_estimation(
+    tiledb_vcf_reader_t* reader, bool disable_progress_estimation) {
+  if (sanity_check(reader) == TILEDB_VCF_ERR)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          reader,
+          reader->reader_->set_disable_progress_estimation(
+              disable_progress_estimation)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
 int32_t tiledb_vcf_reader_set_buffer_percentage(
     tiledb_vcf_reader_t* reader, const float buffer_percentage) {
   if (sanity_check(reader) == TILEDB_VCF_ERR)

--- a/libtiledbvcf/src/c_api/tiledbvcf.h
+++ b/libtiledbvcf/src/c_api/tiledbvcf.h
@@ -863,6 +863,14 @@ TILEDBVCF_EXPORT int32_t
 tiledb_vcf_reader_set_verbose(tiledb_vcf_reader_t* reader, bool verbose);
 
 /**
+ * Sets verbose mode on or off
+ * @param reader VCF reader object
+ * @param verbose setting
+ */
+TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_set_disable_progress_estimation(
+    tiledb_vcf_reader_t* reader, bool disable_progress_estimation);
+
+/**
  * Sets the percentage of buffer size to tiledb memory budget
  * @param reader VCF reader object
  * @param buffer_percentage setting

--- a/libtiledbvcf/src/cli/tiledbvcf.cc
+++ b/libtiledbvcf/src/cli/tiledbvcf.cc
@@ -540,7 +540,11 @@ int main(int argc, char** argv) {
                .set(export_args.check_samples_exist, false) %
            "Disable validating that sample passed exist in dataset before "
            "executing "
-           "query and error if any sample requested is not in the dataset");
+           "query and error if any sample requested is not in the dataset",
+       option("--disable-progress-estimation")
+               .set(export_args.disable_progress_estimation) %
+           "Disable progress estimation in verbose mode. Progress estimation "
+           "can sometimes cause a performance impact.");
 
   ListParams list_args;
   auto list_mode =

--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -104,6 +104,11 @@ struct ExportParams {
   // and error out if not This can add latency which might not be cared about
   // because we have to fetch the list of samples from the VCF header array
   bool check_samples_exist = true;
+
+  // Should we skip trying to estimate the number of records and percent
+  // complete? This is useful when you want verbose but not the performance
+  // impact.
+  bool disable_progress_estimation = false;
 };
 
 /* ********************************* */
@@ -364,6 +369,12 @@ class Reader {
    * @param verbose setting
    */
   void set_verbose(const bool& verbose);
+
+  /**
+   * Sets disabling of progress estimation in verbose mode
+   * @param disable_progress_estimation setting
+   */
+  void set_disable_progress_estimation(const bool& disable_progress_estimation);
 
   /**
    * Percentage of buffer size to tiledb memory budget


### PR DESCRIPTION
Progress estimation relies on estimated result size which can have a performance and memory impact in some scenarios. This lets users use verbose mode but skip the impact if they don't require the progress update.