### PR TITLE
Adjust where Java verion info is printed

### DIFF
--- a/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.java
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.java
@@ -6,16 +6,21 @@ import static io.tiledb.libvcfnative.NativeLibLoader.loadNativeTileDBVCF;
 import static io.tiledb.libvcfnative.NativeLibLoader.loadNativeTileDBVCFJNI;
 
 import java.nio.ByteBuffer;
+import java.util.logging.Logger;
 
 public class LibVCFNative {
 
   static {
     try {
+      final Logger logger = Logger.getLogger(LibVCFNative.class.getName());
+
       // Load native libraries in order
       loadNativeTileDB();
       loadNativeHTSLib();
       loadNativeTileDBVCF();
       loadNativeTileDBVCFJNI();
+      String tiledbVCFVersion = LibVCFNative.tiledb_vcf_version();
+      logger.info("Loaded libtiledbvcf library: " + tiledbVCFVersion);
     } catch (Exception e) {
       System.err.println("Native code library failed to load. \n");
       e.printStackTrace();

--- a/apis/java/src/main/java/io/tiledb/libvcfnative/NativeLibLoader.java
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/NativeLibLoader.java
@@ -70,7 +70,6 @@ public class NativeLibLoader {
   static void loadNativeTileDBVCF() {
     try {
       loadNativeLib("tiledbvcf", true);
-      logger.info("Loaded libtiledbvcf library: " + LibVCFNative.tiledb_vcf_version());
     } catch (java.lang.UnsatisfiedLinkError e) {
       // If a native library fails to link, we fall back to depending on the system
       // dynamic linker to satisfy the requirement. Therefore, we do nothing here


### PR DESCRIPTION
This prints only after all libs are loaded from the jar, to ensure it will be successful.