### PR TITLE
Add support for query bed file line number export

### DIFF
--- a/apis/python/tests/test_tiledbvcf.py
+++ b/apis/python/tests/test_tiledbvcf.py
@@ -66,6 +66,7 @@ def test_retrieve_attributes(test_ds):
         "qual",
         "query_bed_end",
         "query_bed_start",
+        "query_bed_line",
     ]
     assert sorted(test_ds.attributes(attr_type="builtin")) == sorted(builtin_attrs)
 

--- a/apis/spark/src/main/java/io/tiledb/vcf/VCFSparkSchema.java
+++ b/apis/spark/src/main/java/io/tiledb/vcf/VCFSparkSchema.java
@@ -97,6 +97,8 @@ public class VCFSparkSchema implements Serializable {
         return "query_bed_start";
       case "queryBedEnd":
         return "query_bed_end";
+      case "queryBedLine":
+        return "query_bed_line";
       case "qual":
         return "qual";
       case "id":
@@ -140,6 +142,8 @@ public class VCFSparkSchema implements Serializable {
         return "queryBedStart";
       case "query_bed_end":
         return "queryBedEnd";
+      case "query_bed_line":
+        return "queryBedLine";
       case "qual":
         return "qual";
       case "id":
@@ -312,6 +316,7 @@ public class VCFSparkSchema implements Serializable {
       return fieldPart.toUpperCase() + " field in INFO block of BCF";
     } else if (field.equals("queryBedStart")) return "BED start position (0-based) of query";
     else if (field.equals("queryBedEnd")) return "BED end position (1-based) of query";
+    else if (field.equals("queryBedLine")) return "BED file line number of query";
 
     return field;
   }

--- a/apis/spark/src/test/java/io/tiledb/vcf/VCFDatasourceTest.java
+++ b/apis/spark/src/test/java/io/tiledb/vcf/VCFDatasourceTest.java
@@ -65,45 +65,47 @@ public class VCFDatasourceTest extends SharedJavaSparkSession {
     dfRead.createOrReplaceTempView("vcf");
 
     long numColumns = spark.sql("SHOW COLUMNS FROM vcf").count();
-    Assert.assertEquals(numColumns, 32l);
+    Assert.assertEquals(numColumns, 33l);
 
     List<Row> colNameList = spark.sql("SHOW COLUMNS FROM vcf").collectAsList();
-    List<String> colNames =
-        colNameList.stream().map(r -> r.getString(0)).collect(Collectors.toList());
+    Set<String> colNames =
+        colNameList.stream().map(r -> r.getString(0)).collect(Collectors.toSet());
     Assert.assertEquals(
-        Arrays.asList(
-            "fmt_SB",
-            "fmt_MIN_DP",
-            "info_DP",
-            "info_ClippingRankSum",
-            "info_ReadPosRankSum",
-            "fmt",
-            "queryBedStart",
-            "fmt_AD",
-            "posStart",
-            "info_BaseQRankSum",
-            "info_MLEAF",
-            "posEnd",
-            "fmt_GQ",
-            "info_MLEAC",
-            "genotype",
-            "id",
-            "alleles",
-            "info",
-            "sampleName",
-            "info_MQ",
-            "queryBedEnd",
-            "info_MQ0",
-            "fmt_PL",
-            "filter",
-            "info_HaplotypeScore",
-            "contig",
-            "info_DS",
-            "info_InbreedingCoeff",
-            "info_END",
-            "fmt_DP",
-            "info_MQRankSum",
-            "qual"),
+        new HashSet<>(
+            Arrays.asList(
+                "fmt_SB",
+                "fmt_MIN_DP",
+                "info_DP",
+                "info_ClippingRankSum",
+                "info_ReadPosRankSum",
+                "fmt",
+                "queryBedStart",
+                "fmt_AD",
+                "posStart",
+                "info_BaseQRankSum",
+                "info_MLEAF",
+                "posEnd",
+                "fmt_GQ",
+                "info_MLEAC",
+                "genotype",
+                "id",
+                "alleles",
+                "info",
+                "sampleName",
+                "info_MQ",
+                "queryBedEnd",
+                "queryBedLine",
+                "info_MQ0",
+                "fmt_PL",
+                "filter",
+                "info_HaplotypeScore",
+                "contig",
+                "info_DS",
+                "info_InbreedingCoeff",
+                "info_END",
+                "fmt_DP",
+                "info_MQRankSum",
+                "qual")),
         colNames);
   }
 
@@ -121,25 +123,27 @@ public class VCFDatasourceTest extends SharedJavaSparkSession {
     dfRead.createOrReplaceTempView("vcf");
 
     long numColumns = spark.sql("SHOW COLUMNS FROM vcf").count();
-    Assert.assertEquals(numColumns, 12l);
+    Assert.assertEquals(numColumns, 13l);
 
     List<Row> colNameList = spark.sql("SHOW COLUMNS FROM vcf").collectAsList();
-    List<String> colNames =
-        colNameList.stream().map(r -> r.getString(0)).collect(Collectors.toList());
+    Set<String> colNames =
+        colNameList.stream().map(r -> r.getString(0)).collect(Collectors.toSet());
     Assert.assertEquals(
-        Arrays.asList(
-            "queryBedStart",
-            "posStart",
-            "queryBedEnd",
-            "posEnd",
-            "qual",
-            "filter",
-            "id",
-            "fmt",
-            "alleles",
-            "contig",
-            "info",
-            "sampleName"),
+        new HashSet<>(
+            Arrays.asList(
+                "queryBedStart",
+                "posStart",
+                "queryBedEnd",
+                "queryBedLine",
+                "posEnd",
+                "qual",
+                "filter",
+                "id",
+                "fmt",
+                "alleles",
+                "contig",
+                "info",
+                "sampleName")),
         colNames);
   }
 
@@ -631,21 +635,25 @@ public class VCFDatasourceTest extends SharedJavaSparkSession {
   @Test
   public void testBedRanges() {
     Dataset<Row> dfRead = testSampleDataset();
-    List<Row> rows = dfRead.select("queryBedStart", "queryBedEnd").collectAsList();
+    List<Row> rows = dfRead.select("queryBedStart", "queryBedEnd", "queryBedLine").collectAsList();
     Assert.assertEquals(10, rows.size());
     int[] expectedStart =
         new int[] {12099, 12099, 12099, 12099, 12099, 12099, 13499, 13499, 13499, 13499};
     int[] expectedEnd =
         new int[] {13360, 13360, 13360, 13360, 13360, 13360, 17350, 17350, 17350, 17350};
+    int[] expectedLine = new int[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
     int[] resultStart = new int[rows.size()];
     int[] resultEnd = new int[rows.size()];
+    int[] resultLine = new int[rows.size()];
     for (int i = 0; i < rows.size(); i++) {
       resultStart[i] = rows.get(i).getInt(0);
       resultEnd[i] = rows.get(i).getInt(1);
+      resultLine[i] = rows.get(i).getInt(2);
     }
     Assert.assertArrayEquals(expectedStart, resultStart);
     Assert.assertArrayEquals(expectedEnd, resultEnd);
+    Assert.assertArrayEquals(expectedLine, resultLine);
   }
 
   // TODO(ttd) commenting out because AD is not in the default schema

--- a/libtiledbvcf/src/cli/tiledbvcf.cc
+++ b/libtiledbvcf/src/cli/tiledbvcf.cc
@@ -452,7 +452,8 @@ int main(int argc, char** argv) {
                "'ALT', 'QUAL', 'POS', 'CHR', 'FILTER'. Additionally, INFO "
                "fields can be specified by 'I:<name>' and FMT fields with "
                "'S:<name>'. To export the intersecting query region for each "
-               "row in the output, use the field names 'Q:POS' and 'Q:END'." &
+               "row in the output, use the field names 'Q:POS', 'Q:END' and "
+               "'Q:LINE'." &
            value("fields").call([&export_args](const std::string& s) {
              export_args.tsv_fields = utils::split(s, ',');
            }),

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -357,7 +357,11 @@ void TileDBVCFDataset::build_materialized_attributes() const {
     return;
   // Build queryable attribute and sample lists
   std::set<std::string> unique_queryable_attributes{
-      "sample_name", "query_bed_start", "query_bed_end", "contig"};
+      "sample_name",
+      "query_bed_start",
+      "query_bed_end",
+      "contig",
+      "query_bed_line"};
   for (auto s : this->all_attributes()) {
     if (s == "end_pos" || s == "real_end")
       s = "pos_end";
@@ -387,7 +391,11 @@ void TileDBVCFDataset::build_queryable_attributes() const {
     return;
   // Build queryable attribute and sample lists
   std::set<std::string> unique_queryable_attributes{
-      "sample_name", "query_bed_start", "query_bed_end", "contig"};
+      "sample_name",
+      "query_bed_start",
+      "query_bed_end",
+      "contig",
+      "query_bed_line"};
   for (auto s : this->all_attributes()) {
     if (s == "end_pos" || s == "real_end")
       s = "pos_end";

--- a/libtiledbvcf/src/read/in_memory_exporter.cc
+++ b/libtiledbvcf/src/read/in_memory_exporter.cc
@@ -248,6 +248,7 @@ std::set<std::string> InMemoryExporter::array_attributes_required() const {
         }
       case ExportableAttribute::QueryBedStart:
       case ExportableAttribute::QueryBedEnd:
+      case ExportableAttribute::QueryBedLine:
         // No attribute required
         break;
       default:
@@ -450,6 +451,11 @@ bool InMemoryExporter::export_record(
         overflow = !copy_cell(&user_buff, &end, sizeof(end), 1, hdr);
         break;
       }
+      case ExportableAttribute::QueryBedLine: {
+        overflow = !copy_cell(
+            &user_buff, &query_region.line, sizeof(query_region.line), 1, hdr);
+        break;
+      }
       case ExportableAttribute::Alleles: {
         overflow = !copy_alleles_list(cell_idx, &user_buff);
         break;
@@ -536,6 +542,7 @@ InMemoryExporter::ExportableAttribute InMemoryExporter::attr_name_to_enum(
       {"pos_end", ExportableAttribute::PosEnd},
       {"query_bed_start", ExportableAttribute::QueryBedStart},
       {"query_bed_end", ExportableAttribute::QueryBedEnd},
+      {"query_bed_line", ExportableAttribute::QueryBedLine},
       {"alleles", ExportableAttribute::Alleles},
       {"id", ExportableAttribute::Id},
       {"filters", ExportableAttribute::Filters},
@@ -557,6 +564,7 @@ bool InMemoryExporter::fixed_len_attr(const std::string& attr) {
       "pos_end",
       "query_bed_start",
       "query_bed_end",
+      "query_bed_line",
       "qual",
       "fmt_DP",
       "fmt_GQ",
@@ -612,8 +620,6 @@ void InMemoryExporter::attribute_datatype(
       *datatype = AttrDatatype::FLOAT32;
       break;
     case ExportableAttribute::Fmt:
-      *datatype = AttrDatatype::UINT8;
-      break;
     case ExportableAttribute::Info:
       *datatype = AttrDatatype::UINT8;
       break;
@@ -621,9 +627,8 @@ void InMemoryExporter::attribute_datatype(
       *datatype = AttrDatatype::CHAR;
       break;
     case ExportableAttribute::QueryBedStart:
-      *datatype = AttrDatatype::INT32;
-      break;
     case ExportableAttribute::QueryBedEnd:
+    case ExportableAttribute::QueryBedLine:
       *datatype = AttrDatatype::INT32;
       break;
     case ExportableAttribute::InfoOrFmt:

--- a/libtiledbvcf/src/read/in_memory_exporter.h
+++ b/libtiledbvcf/src/read/in_memory_exporter.h
@@ -165,6 +165,7 @@ class InMemoryExporter : public Exporter {
     Info,
     InfoOrFmt,
     Contig,
+    QueryBedLine,
   };
 
   /** Struct holding size info of user buffers. */

--- a/libtiledbvcf/src/read/tsv_exporter.cc
+++ b/libtiledbvcf/src/read/tsv_exporter.cc
@@ -228,6 +228,8 @@ bool TSVExporter::export_record(
           os << query_region.min + 1;
         } else if (field.name == "END") {
           os << query_region.max + 1;
+        } else if (field.name == "LINE") {
+          os << query_region.line;
         } else {
           throw std::runtime_error(
               "Error in TSV export: expected 'Q:' field to be 'POS' or 'END'; "

--- a/libtiledbvcf/src/vcf/region.h
+++ b/libtiledbvcf/src/vcf/region.h
@@ -55,7 +55,7 @@ struct Region {
 
   Region();
 
-  Region(const std::string& seq, unsigned min, unsigned max);
+  Region(const std::string& seq, unsigned min, unsigned max, uint64_t line = 0);
 
   Region(const std::string& str, Type parse_from);
 
@@ -122,6 +122,9 @@ struct Region {
 
   /** Optional field storing the global offset of the contig. */
   uint32_t seq_offset;
+
+  /** Optional line number from bed file. */
+  uint32_t line;
 };
 
 }  // namespace vcf

--- a/libtiledbvcf/test/src/unit-helpers.h
+++ b/libtiledbvcf/test/src/unit-helpers.h
@@ -60,6 +60,7 @@ struct record {
   uint32_t end_pos = 0;
   uint32_t query_bed_start = 0;
   uint32_t query_bed_end = 0;
+  uint32_t query_bed_line = 0;
   std::string contig;
   std::vector<std::string> alleles;
   std::vector<std::string> filters;
@@ -84,12 +85,14 @@ struct record {
       std::string fmt = "",
       std::vector<int32_t> fmt_GT = {},
       int fmt_DP = 0,
-      std::vector<int> fmt_PL = {})
+      std::vector<int> fmt_PL = {},
+      uint32_t query_bed_line = 0)
       : sample(std::move(sample))
       , start_pos(start_pos)
       , end_pos(end_pos)
       , query_bed_start(query_bed_start)
       , query_bed_end(query_bed_end)
+      , query_bed_line(query_bed_line)
       , contig(std::move(contig))
       , alleles(std::move(alleles))
       , filters(std::move(filters))
@@ -115,6 +118,9 @@ struct record {
       return false;
 
     if (query_bed_end != b.query_bed_end)
+      return false;
+
+    if (query_bed_line != b.query_bed_line)
       return false;
 
     if (contig != b.contig)
@@ -177,7 +183,7 @@ struct record {
     std::stringstream out;
     out << this->sample << "-" << this->contig << "-" << this->start_pos << "-"
         << this->end_pos << "-" << this->query_bed_start << "-"
-        << this->query_bed_end << "-";
+        << this->query_bed_end << "-" << this->query_bed_line << "-";
     for (size_t i = 0; i < this->alleles.size(); i++) {
       out << this->alleles[i];
       if (i < this->alleles.size() - 1)


### PR DESCRIPTION
Some users would like to know not just the matching range start/end but the row number of the bed file. This adds support for the new field of `Q:LINE` or `query_bed_line`/`queryBedLine`.