### PR TITLE
Fix concurrent issues with dataset destructor

### DIFF
--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -660,6 +660,18 @@ class TileDBVCFDataset {
   /** flag for if materialized attributes have been computed or not */
   mutable bool materialized_attribute_loaded_;
 
+  /** RWLock for data array to prevent destruction if in use */
+  utils::RWLock data_array_lock_;
+
+  /** RWLock for vcf header array to prevent destruction if in use */
+  utils::RWLock vcf_header_array_lock_;
+
+  /** Thread for preloading non_empty_domain of data array */
+  std::thread data_array_preload_non_empty_domain_thread_;
+
+  /** Thread for preloading non_empty_domain of vcf header array */
+  std::thread vcf_header_array_preload_non_empty_domain_thread_;
+
   /* ********************************* */
   /*          STATIC METHODS           */
   /* ********************************* */
@@ -852,17 +864,17 @@ class TileDBVCFDataset {
    * Preload the non empty domain async so that its available when needed later
    * @return
    */
-  std::future<void> preload_data_array_non_empty_domain();
-  std::future<void> preload_data_array_non_empty_domain_v2_v3();
-  std::future<void> preload_data_array_non_empty_domain_v4();
+  void preload_data_array_non_empty_domain();
+  void preload_data_array_non_empty_domain_v2_v3();
+  void preload_data_array_non_empty_domain_v4();
 
   /**
    * Preload the non empty domain async so that its available when needed later
    * @return
    */
-  std::future<void> preload_vcf_header_array_non_empty_domain();
-  std::future<void> preload_vcf_header_array_non_empty_domain_v2_v3();
-  std::future<void> preload_vcf_header_array_non_empty_domain_v4();
+  void preload_vcf_header_array_non_empty_domain();
+  void preload_vcf_header_array_non_empty_domain_v2_v3();
+  void preload_vcf_header_array_non_empty_domain_v4();
 };
 
 }  // namespace vcf


### PR DESCRIPTION
This introduces a new rwlock and thread TileDBVCFDataset attribute to handle race conditions when destroying the dataset class. If the preloading of the non empty domains had not completed by the time the destructor was called this could cause a segfault.

Similarly we now also grab read locks of the data array or vcf header array rwlock in order to block the destructor if another thread was making use of the array objects. No where in the c++ code do we currently access in parallel to destruction, however in order to be thread-safe in the c-api this is needed.