### PR TITLE
Support for merging contigs into single fragments

### DIFF
--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -78,5 +78,8 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("get_tiledb_stats_enabled", &Writer::get_tiledb_stats_enabled)
       .def("get_tiledb_stats", &Writer::get_tiledb_stats)
       .def("version", &Writer::version)
-      .def("set_resume", &Writer::set_resume);
+      .def("set_resume", &Writer::set_resume)
+      .def("set_contig_fragment_merging", &Writer::set_contig_fragment_merging)
+      .def("set_contigs_to_keep_separate", &Writer::set_contigs_to_keep_separate)
+      .def("set_contigs_to_allow_merging", &Writer::set_contigs_to_allow_merging);
 }

--- a/apis/python/src/tiledbvcf/binding/writer.cc
+++ b/apis/python/src/tiledbvcf/binding/writer.cc
@@ -217,4 +217,33 @@ void Writer::set_resume(const bool resume) {
   check_error(writer, tiledb_vcf_writer_set_resume_sample_partial_ingestion(writer, resume));
 }
 
+void Writer::set_contig_fragment_merging(const bool contig_fragment_merging) {
+  auto writer = ptr.get();
+  check_error(writer, tiledb_vcf_writer_set_contig_fragment_merging(writer, contig_fragment_merging));
+}
+
+void Writer::set_contigs_to_keep_separate(const std::vector<std::string>& contigs_to_keep_separate) {
+  auto writer = ptr.get();
+
+  // Convert vector to char**
+  std::vector<const char*> contigs;
+
+  for (const auto& contig : contigs_to_keep_separate)
+    contigs.push_back(contig.c_str());
+
+  check_error(writer, tiledb_vcf_writer_set_contigs_to_keep_separate(writer, contigs.data(), contigs.size()));
+}
+
+void Writer::set_contigs_to_allow_merging(const std::vector<std::string>& contigs_to_allow_merging) {
+  auto writer = ptr.get();
+
+  // Convert vector to char**
+  std::vector<const char*> contigs;
+
+  for (const auto& contig : contigs_to_allow_merging)
+    contigs.push_back(contig.c_str());
+
+  check_error(writer, tiledb_vcf_writer_set_contigs_to_allow_merging(writer, contigs.data(), contigs.size()));
+}
+
 }  // namespace tiledbvcfpy

--- a/apis/python/src/tiledbvcf/binding/writer.h
+++ b/apis/python/src/tiledbvcf/binding/writer.h
@@ -148,6 +148,21 @@ class Writer {
   */
   void set_resume(const bool resume);
 
+  /**
+    [Store only] Sets whether to enable merging of contigs into super fragments
+  */
+  void set_contig_fragment_merging(const bool contig_fragment_merging);
+
+  /**
+    [Store only] Set list of contigs to keep separate and not merge
+  */
+  void set_contigs_to_keep_separate(const std::vector<std::string>& contigs_to_keep_separate);
+
+  /**
+    [Store only] Set list of contigs to allow merging into super fragments
+  */
+  void set_contigs_to_allow_merging(const std::vector<std::string>& contigs_to_allow_merging);
+
  private:
   /** Helper function to free a C writer instance */
   static void deleter(tiledb_vcf_writer_t* w);

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -342,6 +342,9 @@ class Dataset(object):
         record_limit=None,
         sample_batch_size=None,
         resume=False,
+        contig_fragment_merging=True,
+        contigs_to_keep_separate=None,
+        contigs_to_allow_merging=None,
     ):
         """Ingest samples
 
@@ -360,6 +363,9 @@ class Dataset(object):
         :param int record_limit: Limit the number of VCF records read into memory
             per file (default 50000)
         :param bool resume: Whether to check and attempt to resume a partial completed ingestion
+        :param bool contig_fragment_merging: Whether to enable merging of contigs into fragments. This overrides the contigs-to-keep-separate/contigs-to-allow-mering options. Generally contig fragment merging is good, this is a performance optimization to reduce the prefixes on a s3/azure/gcs bucket when there is a large number of pseduo contigs which are small in size.
+        :param list contigs_to_keep_separate: List of contigs that should not be merged into combined fragments. The default list includes all standard human chromosomes in both UCSC (e.g., chr1) and Ensembl (e.g., 1) formats.
+        :param list contigs_to_allow_merging: List of contigs that should be allowed to be merged into combined fragments.
         """
 
         if self.mode != "w":
@@ -392,6 +398,20 @@ class Dataset(object):
 
         # set whether to attempt partial sample ingestion resumption
         self.writer.set_resume(resume)
+
+        self.writer.set_contig_fragment_merging(contig_fragment_merging)
+
+        if contigs_to_keep_separate is not None:
+            if not isinstance(contigs_to_keep_separate, list):
+                raise Exception("contigs_to_keep_separate must be a list")
+
+            self.writer.set_contigs_to_keep_separate(contigs_to_keep_separate)
+
+        if contigs_to_allow_merging is not None:
+            if not isinstance(contigs_to_allow_merging, list):
+                raise Exception("contigs_to_allow_merging must be a list")
+
+            self.writer.set_contigs_to_allow_merging(contigs_to_allow_merging)
 
         self.writer.set_samples(",".join(sample_uris))
 

--- a/libtiledbvcf/src/c_api/tiledbvcf.cc
+++ b/libtiledbvcf/src/c_api/tiledbvcf.cc
@@ -1192,6 +1192,54 @@ int32_t tiledb_vcf_writer_set_resume_sample_partial_ingestion(
   return TILEDB_VCF_OK;
 }
 
+int32_t tiledb_vcf_writer_set_contig_fragment_merging(
+    tiledb_vcf_writer_t* writer, const bool contig_fragment_merging) {
+  if (sanity_check(writer) == TILEDB_VCF_ERR)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          writer,
+          writer->writer_->set_contig_fragment_merging(
+              contig_fragment_merging)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
+int32_t tiledb_vcf_writer_set_contigs_to_keep_separate(
+    tiledb_vcf_writer_t* writer, const char** contigs, const uint64_t len) {
+  if (sanity_check(writer) == TILEDB_VCF_ERR)
+    return TILEDB_VCF_ERR;
+
+  // Build set from c-style string array
+  std::set<std::string> contig_set;
+  for (uint64_t i = 0; i < len; i++)
+    contig_set.emplace(contigs[i]);
+
+  if (SAVE_ERROR_CATCH(
+          writer, writer->writer_->set_contigs_to_keep_separate(contig_set)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
+int32_t tiledb_vcf_writer_set_contigs_to_allow_merging(
+    tiledb_vcf_writer_t* writer, const char** contigs, const uint64_t len) {
+  if (sanity_check(writer) == TILEDB_VCF_ERR)
+    return TILEDB_VCF_ERR;
+
+  // Build set from c-style string array
+  std::set<std::string> contig_set;
+  for (uint64_t i = 0; i < len; i++)
+    contig_set.emplace(contigs[i]);
+
+  if (SAVE_ERROR_CATCH(
+          writer, writer->writer_->set_contigs_to_allow_merging(contig_set)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
 /* ********************************* */
 /*               ERROR               */
 /* ********************************* */

--- a/libtiledbvcf/src/c_api/tiledbvcf.h
+++ b/libtiledbvcf/src/c_api/tiledbvcf.h
@@ -1262,6 +1262,44 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_set_sample_batch_size(
 TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_set_resume_sample_partial_ingestion(
     tiledb_vcf_writer_t* writer, const bool resume);
 
+/**
+ * Set contig fragment merging enabled or not
+ *
+ * @param writer VCF writer object
+ * @param contig_fragment_merging whether to enable contig merging or not on
+ * ingestion
+ * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
+ */
+TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_set_contig_fragment_merging(
+    tiledb_vcf_writer_t* writer, const bool contig_fragment_merging);
+
+/**
+ * Set list of contigs to force keeping separate and not allow merging. If none
+ * are set, then the merging is based on only including those from
+ * "set_contigs_to_allow_merging". If neither option is set, all contigs will be
+ * considered for merging.
+ *
+ * @param writer VCF writer object
+ * @param contigs array of contig strings
+ * @param len length of array
+ * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
+ */
+TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_set_contigs_to_keep_separate(
+    tiledb_vcf_writer_t* writer, const char** contigs, const uint64_t len);
+
+/**
+ * Set list of contigs to allow merging. If none are set, then the merging is
+ * based on only restricting those from "contigs_to_keep_separate". If neither
+ * option is set, all contigs will be considered for merging.
+ *
+ * @param writer VCF writer object
+ * @param contigs array of contig strings
+ * @param len length of array
+ * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
+ */
+TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_set_contigs_to_allow_merging(
+    tiledb_vcf_writer_t* writer, const char** contigs, const uint64_t len);
+
 /* ********************************* */
 /*               ERROR               */
 /* ********************************* */

--- a/libtiledbvcf/src/cli/tiledbvcf.cc
+++ b/libtiledbvcf/src/cli/tiledbvcf.cc
@@ -422,7 +422,30 @@ int main(int argc, char** argv) {
                .set(store_args.tiledb_stats_enabled_vcf_header_array) %
            "Enable TileDB stats for vcf header array usage",
        option("--resume").set(store_args.resume_sample_partial_ingestion) %
-           "Resume incomplete ingestion of sample batch");
+           "Resume incomplete ingestion of sample batch",
+       one_of(
+           option("--disable-contig-fragment-merging")
+                   .set(store_args.contig_fragment_merging, false) %
+               "Disable merging of contigs into fragments. This overrides the "
+               "contigs-to-keep-separate/contigs-to-allow-mering options. "
+               "Generally contig fragment merging "
+               "is good, this is a performance optimization to reduce the "
+               "prefixes on a s3/azure/gcs bucket when there is a large number "
+               "of pseduo contigs which are small in size.",
+           option("--contigs-to-keep-separate") %
+                   "comma-separated list of contigs that should not be merged "
+                   "into combined fragments. The default list includes all "
+                   "standard human chromosomes in both UCSC (e.g., chr1) and "
+                   "Ensembl (e.g., 1) formats." &
+               value("params").call([&store_args](const std::string& s) {
+                 store_args.contigs_to_keep_separate = utils::split_set(s, ',');
+               }),
+           option("--contigs-to-allow-merging") %
+                   "comma-separated list of contigs that should be allowed to "
+                   "be merged into combined fragments." &
+               value("params").call([&store_args](const std::string& s) {
+                 store_args.contigs_to_allow_merging = utils::split_set(s, ',');
+               })));
 
   ExportParams export_args;
   export_args.export_to_disk = true;

--- a/libtiledbvcf/src/utils/utils.cc
+++ b/libtiledbvcf/src/utils/utils.cc
@@ -75,6 +75,15 @@ std::vector<std::string> split(const std::string& s, char delim) {
   return split(s, std::string(1, delim));
 }
 
+std::set<std::string> split_set(const std::string& s, char delim) {
+  std::set<std::string> results;
+  for (const auto& string : split(s, std::string(1, delim))) {
+    results.emplace(string);
+  }
+
+  return results;
+}
+
 bool starts_with(const std::string& value, const std::string& prefix) {
   if (prefix.size() > value.size())
     return false;

--- a/libtiledbvcf/src/utils/utils.h
+++ b/libtiledbvcf/src/utils/utils.h
@@ -198,6 +198,16 @@ std::vector<std::string> split(
 
 /**
  * @brief
+ * Split a string into tokens with any delimiter in delims.
+ * @param str String to split
+ * @param delims List of delimiters to split by
+ * @param skip_empty Skip empty elements
+ * @return set of tokens
+ */
+std::set<std::string> split_set(const std::string& s, char delim);
+
+/**
+ * @brief
  * Splits a string into a vector given some character delimiter.
  * @param s string to split
  * @param delim split string at delim, discarding the delim

--- a/libtiledbvcf/src/write/writer.h
+++ b/libtiledbvcf/src/write/writer.h
@@ -84,6 +84,29 @@ struct IngestionParams {
   // Should we check if the samples have been partial ingested?
   // This might have a significant performance penalty on large arrays
   bool resume_sample_partial_ingestion = false;
+
+  // Enable merging of contigs into fragments which contain multiple. This is an
+  // optimization to reduce fragment count when the list of contigs is very
+  // large. This can improve performance due to slow s3/azure/gcs listings when
+  // there is hundreds of thousands of prefixes.
+  bool contig_fragment_merging = true;
+
+  // These are the contig that will not be merged so they are guaranteed to be
+  // there own fragments The user can override this default list, we default to
+  // human contigs in UCSC and ensembl formats
+  std::set<std::string> contigs_to_keep_separate = {
+      "chr1",  "chr2",  "chr3",  "chr4",  "chr5",  "chr6",  "chr7",  "chr8",
+      "chr9",  "chr10", "chr11", "chr12", "chr13", "chr14", "chr15", "chr16",
+      "chr17", "chr18", "chr19", "chr20", "chr21", "chr22", "chrY",  "chrX",
+      "chrM",  "1",     "2",     "3",     "4",     "5",     "6",     "7",
+      "8",     "9",     "10",    "11",    "12",    "13",    "14",    "15",
+      "16",    "17",    "18",    "19",    "20",    "21",    "22",    "X",
+      "Y",     "MT"};
+
+  // These are the contigs which will be forced to be merged into combined
+  // fragments By default we use the blacklist since usually there are less
+  // non-mergeable contigs
+  std::set<std::string> contigs_to_allow_merging = {};
 };
 
 /* ********************************* */
@@ -238,6 +261,17 @@ class Writer {
   /** Set resume support for partial ingestion. */
   void set_resume_sample_partial_ingestion(const bool);
 
+  /** Set contig fragment merging. */
+  void set_contig_fragment_merging(const bool contig_fragment_merging);
+
+  /** Set list of contigs to keep separate. */
+  void set_contigs_to_keep_separate(
+      const std::set<std::string>& contigs_to_keep_separate);
+
+  /** Set list of contigs to allow to be merged. */
+  void set_contigs_to_allow_merging(
+      const std::set<std::string>& contigs_to_allow_merging);
+
  private:
   /* ********************************* */
   /*          PRIVATE ATTRIBUTES       */
@@ -333,6 +367,13 @@ class Writer {
           pair_hash> map);
 
   static void finalize_query(std::unique_ptr<tiledb::Query> query);
+
+  /**
+   *
+   * @param contig to check mergability on
+   * @return true if contig is allowed to be merged based on whitelist/blacklist
+   */
+  bool check_contig_mergeable(const std::string& contig);
 };
 
 }  // namespace vcf


### PR DESCRIPTION
This is a (large) performance optimization in cases where the samples have a large number of pseudo configs which are small. These small contigs create a large number of fragments which can cause slower listing of the array on S3/GCS/Azure Blob Store object stores. This makes opening the array take significantly longer in certain scenarios. The change here allows the user to set two list (keep separate and mergeable) of contigs which are allowed to be merged into a single fragment in the sample batch.

The default `keep-as-separate` list will keep human contigs in USCS or ensembl format from being merged. For performance of reads, it is desirable to keep contigs which are going to read frequently or are large in size separate and not merged.

Further merge takes into account (automatically) lexicographical ordering. That is in the event of chromsomes `chr1`, `chr1_x`, `chr1_y`, `chr2`, and `chr2_x`, we will merge `chr1_x` and `chr1_y` together but not merge `chr2_x` with `chr1_y` because we must avoid overlapping the fragment's non empty domain with `chr2`.


Depends on #316  #329  #328 