### PR TITLE
No need to run tests when building libs for jars

### DIFF
--- a/ci/native_libs-linux_osx.yml
+++ b/ci/native_libs-linux_osx.yml
@@ -46,7 +46,6 @@ steps:
 
         make -j4
         make -j4 -C libtiledbvcf tiledb_vcf_unit
-        make check
 
         make install-libtiledbvcf
 


### PR DESCRIPTION
No need to run tests when building libs for jars