### PR TITLE
Add spark option to setting specific partition idx

### DIFF
--- a/apis/spark/src/main/java/io/tiledb/vcf/VCFDataSourceOptions.java
+++ b/apis/spark/src/main/java/io/tiledb/vcf/VCFDataSourceOptions.java
@@ -100,10 +100,26 @@ public class VCFDataSourceOptions implements Serializable {
     return Optional.empty();
   }
 
+  /** @return Optional range partition index for running single partition */
+  public Optional<Integer> getRangePartitionIndex() {
+    if (options.containsKey("range_partition_index")) {
+      return Optional.of(Integer.parseInt(options.get("range_partition_index")));
+    }
+    return Optional.empty();
+  }
+
   /** @return Optional number of sample partitions */
   public Optional<Integer> getSamplePartitions() {
     if (options.containsKey("sample_partitions")) {
       return Optional.of(Integer.parseInt(options.get("sample_partitions")));
+    }
+    return Optional.empty();
+  }
+
+  /** @return Optional sample partition index for running single partition */
+  public Optional<Integer> getSamplePartitionIndex() {
+    if (options.containsKey("sample_partition_index")) {
+      return Optional.of(Integer.parseInt(options.get("sample_partition_index")));
     }
     return Optional.empty();
   }


### PR DESCRIPTION
This allows the user to set a single partition or partition index for ranges/samples like is supported in other APIs. This is helpful when debugging.