### PR TITLE
Add debugging options for printing query details

### DIFF
--- a/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.c
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.c
@@ -805,3 +805,42 @@ JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1rea
 
     return rc;
 }
+
+JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1set_1debug_1print_1vcf_1regions
+  (JNIEnv* env, jclass self, jlong readerPtr, jboolean printVCFRegions) {
+    (void)self;
+    tiledb_vcf_reader_t* reader = (tiledb_vcf_reader_t*)readerPtr;
+    if (reader == 0) {
+      return TILEDB_VCF_ERR;
+    }
+
+    int32_t rc = tiledb_vcf_reader_set_debug_print_vcf_regions(reader, printVCFRegions);
+
+    return rc;
+}
+
+JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1set_1debug_1print_1sample_1list
+  (JNIEnv* env, jclass self, jlong readerPtr, jboolean printSampleList) {
+    (void)self;
+    tiledb_vcf_reader_t* reader = (tiledb_vcf_reader_t*)readerPtr;
+    if (reader == 0) {
+      return TILEDB_VCF_ERR;
+    }
+
+    int32_t rc = tiledb_vcf_reader_set_debug_print_sample_list(reader, printSampleList);
+
+    return rc;
+}
+
+JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1set_1debug_1print_1tiledb_1query_1ranges
+  (JNIEnv* env, jclass self, jlong readerPtr, jboolean printTileDBQueryRanges) {
+    (void)self;
+    tiledb_vcf_reader_t* reader = (tiledb_vcf_reader_t*)readerPtr;
+    if (reader == 0) {
+      return TILEDB_VCF_ERR;
+    }
+
+    int32_t rc = tiledb_vcf_reader_set_debug_print_tiledb_query_ranges(reader, printTileDBQueryRanges);
+
+    return rc;
+}

--- a/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.h
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.h
@@ -327,6 +327,30 @@ JNIEXPORT jstring JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1
 JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1set_1enable_1progress_1estimation
   (JNIEnv *, jclass, jlong, jboolean);
 
+/*
+ * Class:     io_tiledb_libvcfnative_LibVCFNative
+ * Method:    tiledb_vcf_reader_set_debug_print_vcf_regions
+ * Signature: (JZ)I
+ */
+JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1set_1debug_1print_1vcf_1regions
+  (JNIEnv *, jclass, jlong, jboolean);
+
+/*
+ * Class:     io_tiledb_libvcfnative_LibVCFNative
+ * Method:    tiledb_vcf_reader_set_debug_print_sample_list
+ * Signature: (JZ)I
+ */
+JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1set_1debug_1print_1sample_1list
+  (JNIEnv *, jclass, jlong, jboolean);
+
+/*
+ * Class:     io_tiledb_libvcfnative_LibVCFNative
+ * Method:    tiledb_vcf_reader_set_debug_print_tiledb_query_ranges
+ * Signature: (JZ)I
+ */
+JNIEXPORT jint JNICALL Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1set_1debug_1print_1tiledb_1query_1ranges
+  (JNIEnv *, jclass, jlong, jboolean);
+
 #ifdef __cplusplus
 }
 #endif

--- a/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.java
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.java
@@ -134,5 +134,14 @@ public class LibVCFNative {
   public static final native String tiledb_vcf_version();
 
   public static final native int tiledb_vcf_reader_set_enable_progress_estimation(
-      long readerPtr, boolean enable_progress_estimation);
+      long readerPtr, boolean enableProgressEstimation);
+
+  public static final native int tiledb_vcf_reader_set_debug_print_vcf_regions(
+      long readerPtr, boolean printVCFRegions);
+
+  public static final native int tiledb_vcf_reader_set_debug_print_sample_list(
+      long readerPtr, boolean printSampleList);
+
+  public static final native int tiledb_vcf_reader_set_debug_print_tiledb_query_ranges(
+      long readerPtr, boolean printTileDBQueryRanges);
 }

--- a/apis/java/src/main/java/io/tiledb/libvcfnative/VCFReader.java
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/VCFReader.java
@@ -571,6 +571,38 @@ public class VCFReader implements AutoCloseable {
     return this;
   }
 
+  public VCFReader setDebugPrintVCFRegions(boolean debugPrintVCFRegions) {
+    int rc =
+        LibVCFNative.tiledb_vcf_reader_set_debug_print_vcf_regions(
+            this.readerPtr, debugPrintVCFRegions);
+    if (rc != 0) {
+      String msg = getLastErrorMessage();
+      throw new RuntimeException("Error setting debugPrintVCFRegions: " + msg);
+    }
+    return this;
+  }
+
+  public VCFReader setDebugPrintSampleList(boolean printSampleList) {
+    int rc =
+        LibVCFNative.tiledb_vcf_reader_set_debug_print_sample_list(this.readerPtr, printSampleList);
+    if (rc != 0) {
+      String msg = getLastErrorMessage();
+      throw new RuntimeException("Error setting printSampleList: " + msg);
+    }
+    return this;
+  }
+
+  public VCFReader setDebugPrintTileDBQueryRanges(boolean printTileDBQueryRanges) {
+    int rc =
+        LibVCFNative.tiledb_vcf_reader_set_debug_print_tiledb_query_ranges(
+            this.readerPtr, printTileDBQueryRanges);
+    if (rc != 0) {
+      String msg = getLastErrorMessage();
+      throw new RuntimeException("Error setting printTileDBQueryRanges: " + msg);
+    }
+    return this;
+  }
+
   public VCFReader resetBuffers() {
     Iterator it = buffers.entrySet().iterator();
     while (it.hasNext()) {

--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -48,7 +48,10 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("set_tiledb_tile_cache_percentage", &Reader::set_tiledb_tile_cache_percentage)
       .def("set_check_samples_exist", &Reader::set_check_samples_exist)
       .def("version", &Reader::version)
-      .def("set_enable_progress_estimation", &Reader::set_enable_progress_estimation);
+      .def("set_enable_progress_estimation", &Reader::set_enable_progress_estimation)
+      .def("set_debug_print_vcf_regions", &Reader::set_debug_print_vcf_regions)
+      .def("set_debug_print_sample_list", &Reader::set_debug_print_sample_list)
+      .def("set_debug_print_tiledb_query_ranges", &Reader::set_debug_print_tiledb_query_ranges);
 
   py::class_<Writer>(m, "Writer")
       .def(py::init())

--- a/apis/python/src/tiledbvcf/binding/reader.cc
+++ b/apis/python/src/tiledbvcf/binding/reader.cc
@@ -585,4 +585,19 @@ void Reader::set_enable_progress_estimation(const bool& enable_progress_estimati
   auto reader = ptr.get();
   check_error(reader, tiledb_vcf_reader_set_enable_progress_estimation(reader, enable_progress_estimation));
 }
+
+void Reader::set_debug_print_vcf_regions(const bool& print_vcf_regions) {
+  auto reader = ptr.get();
+  check_error(reader, tiledb_vcf_reader_set_debug_print_vcf_regions(reader, print_vcf_regions));
+}
+
+void Reader::set_debug_print_sample_list(const bool& print_sample_list) {
+  auto reader = ptr.get();
+  check_error(reader, tiledb_vcf_reader_set_debug_print_sample_list(reader, print_sample_list));
+}
+
+void Reader::set_debug_print_tiledb_query_ranges(const bool& tiledb_query_ranges) {
+  auto reader = ptr.get();
+  check_error(reader, tiledb_vcf_reader_set_debug_print_tiledb_query_ranges(reader, tiledb_query_ranges));
+}
 }  // namespace tiledbvcfpy

--- a/apis/python/src/tiledbvcf/binding/reader.h
+++ b/apis/python/src/tiledbvcf/binding/reader.h
@@ -153,6 +153,15 @@ class Reader {
   /** Set disable progress estimation */
   void set_enable_progress_estimation(const bool& enable_progress_estimation);
 
+  /** Set print vcf regions in verbose mode */
+  void set_debug_print_vcf_regions(const bool& print_vcf_regions);
+
+  /** Set print sample list in verbose mode */
+  void set_debug_print_sample_list(const bool& print_sample_list);
+
+  /** Set print TileDB query ranges in verbose mode */
+  void set_debug_print_tiledb_query_ranges(const bool& tiledb_query_ranges);
+
  private:
   /** Buffer struct to hold attribute data read from the dataset. */
   struct BufferInfo {

--- a/apis/spark/src/main/java/io/tiledb/vcf/VCFDataSourceOptions.java
+++ b/apis/spark/src/main/java/io/tiledb/vcf/VCFDataSourceOptions.java
@@ -161,10 +161,34 @@ public class VCFDataSourceOptions implements Serializable {
     return Optional.empty();
   }
 
-  /** @return If progress estimation in verbose mode should be disabled */
+  /** @return If progress estimation in verbose mode should be enabled */
   public Optional<Boolean> getEnableProgressEstimation() {
     if (options.containsKey("enable_progress_estimation")) {
       return Optional.of(Boolean.parseBoolean(options.get("enable_progress_estimation")));
+    }
+    return Optional.empty();
+  }
+
+  /** @return If reader should print vcf regions in verbose mode */
+  public Optional<Boolean> getDebugPrintVCFRegions() {
+    if (options.containsKey("debug.print_vcf_regions")) {
+      return Optional.of(Boolean.parseBoolean(options.get("debug.print_vcf_regions")));
+    }
+    return Optional.empty();
+  }
+
+  /** @return If reader should print vcf sample list in verbose mode */
+  public Optional<Boolean> getDebugPrintSampleList() {
+    if (options.containsKey("debug.print_sample_list")) {
+      return Optional.of(Boolean.parseBoolean(options.get("debug.print_sample_list")));
+    }
+    return Optional.empty();
+  }
+
+  /** @return If reader should print TileDB query ranges in verbose mode */
+  public Optional<Boolean> getDebugPrintTileDBQueryRanges() {
+    if (options.containsKey("debug.print_tiledb_query_ranges")) {
+      return Optional.of(Boolean.parseBoolean(options.get("debug.print_tiledb_query_ranges")));
     }
     return Optional.empty();
   }

--- a/apis/spark/src/main/java/io/tiledb/vcf/VCFInputPartitionReader.java
+++ b/apis/spark/src/main/java/io/tiledb/vcf/VCFInputPartitionReader.java
@@ -306,7 +306,7 @@ public class VCFInputPartitionReader implements InputPartitionReader<ColumnarBat
       vcfReader.setVerbose(verbose.get());
     }
 
-    // Set eableProgressEstimation
+    // Set enableProgressEstimation
     Optional<Boolean> enableProgressEstimation = options.getEnableProgressEstimation();
     if (enableProgressEstimation.isPresent()) {
       vcfReader.setEnableProgressEstimation(enableProgressEstimation.get());
@@ -322,6 +322,24 @@ public class VCFInputPartitionReader implements InputPartitionReader<ColumnarBat
     Optional<Float> tiledbTileCachePercentage = options.getTileDBTileCachePercentage();
     if (tiledbTileCachePercentage.isPresent()) {
       vcfReader.setTileDBTileCachePercentage(tiledbTileCachePercentage.get());
+    }
+
+    // Set debugPrintVCFRegions
+    Optional<Boolean> debugPrintVCFRegions = options.getDebugPrintVCFRegions();
+    if (debugPrintVCFRegions.isPresent()) {
+      vcfReader.setDebugPrintVCFRegions(debugPrintVCFRegions.get());
+    }
+
+    // Set debugPrintSampleList
+    Optional<Boolean> debugPrintSampleList = options.getDebugPrintSampleList();
+    if (debugPrintSampleList.isPresent()) {
+      vcfReader.setDebugPrintSampleList(debugPrintSampleList.get());
+    }
+
+    // Set debugPrintTileDBQueryRanges
+    Optional<Boolean> debugPrintTileDBQueryRanges = options.getDebugPrintTileDBQueryRanges();
+    if (debugPrintTileDBQueryRanges.isPresent()) {
+      vcfReader.setDebugPrintTileDBQueryRanges(debugPrintTileDBQueryRanges.get());
     }
 
     // Enable VCFReader stats

--- a/libtiledbvcf/src/c_api/tiledbvcf.cc
+++ b/libtiledbvcf/src/c_api/tiledbvcf.cc
@@ -802,6 +802,46 @@ int32_t tiledb_vcf_reader_set_check_samples_exist(
   return TILEDB_VCF_OK;
 }
 
+int32_t tiledb_vcf_reader_set_debug_print_vcf_regions(
+    tiledb_vcf_reader_t* reader, const bool print_vcf_regions) {
+  if (sanity_check(reader) == TILEDB_VCF_ERR)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          reader,
+          reader->reader_->set_debug_print_vcf_regions(print_vcf_regions)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
+int32_t tiledb_vcf_reader_set_debug_print_sample_list(
+    tiledb_vcf_reader_t* reader, const bool print_sample_list) {
+  if (sanity_check(reader) == TILEDB_VCF_ERR)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          reader,
+          reader->reader_->set_debug_print_sample_list(print_sample_list)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
+int32_t tiledb_vcf_reader_set_debug_print_tiledb_query_ranges(
+    tiledb_vcf_reader_t* reader, const bool print_tiledb_query_ranges) {
+  if (sanity_check(reader) == TILEDB_VCF_ERR)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          reader,
+          reader->reader_->set_debug_print_tiledb_query_ranges(
+              print_tiledb_query_ranges)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
 /* ********************************* */
 /*              WRITER               */
 /* ********************************* */

--- a/libtiledbvcf/src/c_api/tiledbvcf.h
+++ b/libtiledbvcf/src/c_api/tiledbvcf.h
@@ -928,6 +928,30 @@ TILEDBVCF_EXPORT int32_t
 tiledb_vcf_reader_reset_buffers(tiledb_vcf_reader_t* reader);
 
 /**
+ * Sets if the reader print vcf regions in verbose mode
+ * @param reader VCF reader object
+ * @param print_vcf_regions setting
+ */
+TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_set_debug_print_vcf_regions(
+    tiledb_vcf_reader_t* reader, bool print_vcf_regions);
+
+/**
+ * Sets if the reader print sample list in verbose mode
+ * @param reader VCF reader object
+ * @param print_sample_list setting
+ */
+TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_set_debug_print_sample_list(
+    tiledb_vcf_reader_t* reader, bool print_sample_list);
+
+/**
+ * Sets if the reader print TileDB query ranges in verbose mode
+ * @param reader VCF reader object
+ * @param print_vcf_regions setting
+ */
+TILEDBVCF_EXPORT int32_t tiledb_vcf_reader_set_debug_print_tiledb_query_ranges(
+    tiledb_vcf_reader_t* reader, bool print_tiledb_query_ranges);
+
+/**
  * Gets the last error from the reader object. Don't forget to free the error
  * object.
  *

--- a/libtiledbvcf/src/cli/tiledbvcf.cc
+++ b/libtiledbvcf/src/cli/tiledbvcf.cc
@@ -548,7 +548,19 @@ int main(int argc, char** argv) {
                .set(export_args.enable_progress_estimation) %
            "Enable progress estimation in verbose mode. Progress estimation "
            "can sometimes cause a performance impact, so enable this with "
-           "consideration.");
+           "consideration.",
+       option("--debug-print-vcf-regions")
+               .set(export_args.debug_params.print_vcf_regions) %
+           "Enable debug printing of vcf region passed by user or bed file. "
+           "Requires verbose mode",
+       option("--debug-print-sample-list")
+               .set(export_args.debug_params.print_sample_list) %
+           "Enable debug printing of sample list used in read. Requires "
+           "verbose mode",
+       option("--debug-print-tiledb-query-ranges")
+               .set(export_args.debug_params.print_tiledb_query_ranges) %
+           "Enable debug printing of tiledb query ranges used in read. "
+           "Requires verbose mode");
 
   ListParams list_args;
   auto list_mode =

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -408,6 +408,45 @@ void Reader::init_for_reads_v2() {
   prepare_regions_v2(&read_state_.regions, &read_state_.query_regions);
 
   prepare_attribute_buffers();
+
+  if (params_.verbose) {
+    if (params_.debug_params.print_vcf_regions) {
+      std::stringstream debug_region_list;
+      debug_region_list << "[";
+      for (uint64_t i = 0; i < read_state_.regions.size(); i++) {
+        const auto& region = read_state_.regions[i];
+        debug_region_list << '"' << region.seq_name << ":" << region.min << "-"
+                          << region.max << '"';
+        if (i < read_state_.regions.size() - 1)
+          debug_region_list << ", ";
+      }
+      debug_region_list << "]";
+      std::cout << "vcf regions:" << std::endl
+                << debug_region_list.str() << std::endl;
+    }
+    // If debug build json list of list of samples batches
+    if (params_.debug_params.print_sample_list) {
+      std::stringstream debug_sample_list;
+      debug_sample_list << "[";
+      for (unsigned i = 0; i < read_state_.sample_batches.size(); i++) {
+        std::stringstream val_strstr;
+        val_strstr << "[";
+        for (unsigned j = 0; j < read_state_.sample_batches[i].size(); j++) {
+          val_strstr << '"' << read_state_.sample_batches[i][j].sample_id
+                     << '"';
+          if (i < read_state_.sample_batches[i].size() - 1)
+            val_strstr << ", ";
+        }
+        val_strstr << "]";
+        debug_sample_list << val_strstr.str();
+        if (i < read_state_.sample_batches.size() - 1)
+          debug_sample_list << ", ";
+      }
+      debug_sample_list << "]";
+      std::cout << "sample list:" << std::endl
+                << debug_sample_list.str() << std::endl;
+    }
+  }
 }
 
 void Reader::init_for_reads_v3() {
@@ -421,6 +460,45 @@ void Reader::init_for_reads_v3() {
   prepare_regions_v3(&read_state_.regions, &read_state_.query_regions);
 
   prepare_attribute_buffers();
+
+  if (params_.verbose) {
+    if (params_.debug_params.print_vcf_regions) {
+      std::stringstream debug_region_list;
+      debug_region_list << "[";
+      for (uint64_t i = 0; i < read_state_.regions.size(); i++) {
+        const auto& region = read_state_.regions[i];
+        debug_region_list << '"' << region.seq_name << ":" << region.min << "-"
+                          << region.max << '"';
+        if (i < read_state_.regions.size() - 1)
+          debug_region_list << ", ";
+      }
+      debug_region_list << "]";
+      std::cout << "vcf regions:" << std::endl
+                << debug_region_list.str() << std::endl;
+    }
+    // If debug build json list of list of samples batches
+    if (params_.debug_params.print_sample_list) {
+      std::stringstream debug_sample_list;
+      debug_sample_list << "[";
+      for (unsigned i = 0; i < read_state_.sample_batches.size(); i++) {
+        std::stringstream val_strstr;
+        val_strstr << "[";
+        for (unsigned j = 0; j < read_state_.sample_batches[i].size(); j++) {
+          val_strstr << '"' << read_state_.sample_batches[i][j].sample_id
+                     << '"';
+          if (i < read_state_.sample_batches[i].size() - 1)
+            val_strstr << ", ";
+        }
+        val_strstr << "]";
+        debug_sample_list << val_strstr.str();
+        if (i < read_state_.sample_batches.size() - 1)
+          debug_sample_list << ", ";
+      }
+      debug_sample_list << "]";
+      std::cout << "sample list:" << std::endl
+                << debug_sample_list.str() << std::endl;
+    }
+  }
 }
 
 void Reader::init_for_reads_v4() {
@@ -437,6 +515,45 @@ void Reader::init_for_reads_v4() {
       &read_state_.regions_index_per_contig,
       &read_state_.query_regions_v4);
   prepare_attribute_buffers();
+
+  if (params_.verbose) {
+    if (params_.debug_params.print_vcf_regions) {
+      std::stringstream debug_region_list;
+      debug_region_list << "[";
+      for (uint64_t i = 0; i < read_state_.regions.size(); i++) {
+        const auto& region = read_state_.regions[i];
+        debug_region_list << '"' << region.seq_name << ":" << region.min << "-"
+                          << region.max << '"';
+        if (i < read_state_.regions.size() - 1)
+          debug_region_list << ", ";
+      }
+      debug_region_list << "]";
+      std::cout << "vcf regions:" << std::endl
+                << debug_region_list.str() << std::endl;
+    }
+    // If debug build json list of list of samples batches
+    if (params_.debug_params.print_sample_list) {
+      std::stringstream debug_sample_list;
+      debug_sample_list << "[";
+      for (unsigned i = 0; i < read_state_.sample_batches.size(); i++) {
+        std::stringstream val_strstr;
+        val_strstr << "[";
+        for (unsigned j = 0; j < read_state_.sample_batches[i].size(); j++) {
+          val_strstr << '"' << read_state_.sample_batches[i][j].sample_name
+                     << '"';
+          if (i < read_state_.sample_batches[i].size() - 1)
+            val_strstr << ',';
+        }
+        val_strstr << "]";
+        debug_sample_list << val_strstr.str();
+        if (i < read_state_.sample_batches.size() - 1)
+          debug_sample_list << ", ";
+      }
+      debug_sample_list << "]";
+      std::cout << "sample list:" << std::endl
+                << debug_sample_list.str() << std::endl;
+    }
+  }
 }
 
 bool Reader::next_read_batch() {
@@ -507,12 +624,34 @@ bool Reader::next_read_batch_v2_v3() {
   set_tiledb_query_config();
 
   // Set ranges
-  for (const auto& sample : read_state_.current_sample_batches)
+  std::stringstream debug_ranges;
+  if (params_.debug_params.print_tiledb_query_ranges && params_.verbose) {
+    debug_ranges << std::endl << "sample ids:" << std::endl;
+  }
+  for (const auto& sample : read_state_.current_sample_batches) {
     read_state_.query->add_range(0, sample.sample_id, sample.sample_id);
-  for (const auto& query_region : read_state_.query_regions)
+    if (params_.debug_params.print_tiledb_query_ranges && params_.verbose) {
+      debug_ranges << "[" << sample.sample_id << ", " << sample.sample_id << "]"
+                   << std::endl;
+    }
+  }
+  if (params_.debug_params.print_tiledb_query_ranges && params_.verbose) {
+    debug_ranges << std::endl << "regions:" << std::endl;
+  }
+  for (const auto& query_region : read_state_.query_regions) {
     read_state_.query->add_range(1, query_region.col_min, query_region.col_max);
+    if (params_.debug_params.print_tiledb_query_ranges && params_.verbose) {
+      debug_ranges << "[" << query_region.col_min << ", "
+                   << query_region.col_max << "]" << std::endl;
+    }
+  }
+
   read_state_.query->set_layout(TILEDB_UNORDERED);
   if (params_.verbose) {
+    if (params_.debug_params.print_tiledb_query_ranges) {
+      std::cout << "query_ranges:" << std::endl
+                << debug_ranges.str() << std::endl;
+    }
     std::cout << "Initialized TileDB query with "
               << read_state_.query_regions.size() << " start_pos ranges, "
               << read_state_.current_sample_batches.size() << " sample ranges."
@@ -631,6 +770,11 @@ bool Reader::next_read_batch_v4() {
   set_tiledb_query_config();
 
   // Set ranges
+  std::stringstream debug_ranges;
+  if (params_.debug_params.print_tiledb_query_ranges && params_.verbose) {
+    debug_ranges << std::endl << "samples:" << std::endl;
+  }
+
   // For samples we special case when we are looking at all samples. If so we
   // just need to set one range with the start/end sample id
   if (read_state_.all_samples) {
@@ -639,6 +783,10 @@ bool Reader::next_read_batch_v4() {
           TileDBVCFDataset::DimensionNames::V4::sample);
       read_state_.query->add_range(
           2, non_empty_domain.first, non_empty_domain.second);
+      if (params_.debug_params.print_tiledb_query_ranges && params_.verbose) {
+        debug_ranges << "[" << non_empty_domain.first << ", "
+                     << non_empty_domain.second << "]" << std::endl;
+      }
     } else {
       // if we have all samples but are partitioning we need to only use the
       // first/last sample of the partition partitions are sorted both globally
@@ -650,25 +798,65 @@ bool Reader::next_read_batch_v4() {
               .current_sample_batches
                   [read_state_.current_sample_batches.size() - 1]
               .sample_name);
+      if (params_.debug_params.print_tiledb_query_ranges && params_.verbose) {
+        debug_ranges << "[" << read_state_.current_sample_batches[0].sample_name
+                     << ", "
+                     << read_state_
+                            .current_sample_batches
+                                [read_state_.current_sample_batches.size() - 1]
+                            .sample_name
+                     << "]" << std::endl;
+      }
     }
   } else {
     // If we are not exporting all samples add the current partition/batch's
     // list
-    for (const auto& sample : read_state_.current_sample_batches)
+    for (const auto& sample : read_state_.current_sample_batches) {
       read_state_.query->add_range(2, sample.sample_name, sample.sample_name);
+      if (params_.debug_params.print_tiledb_query_ranges && params_.verbose) {
+        debug_ranges << "[" << sample.sample_name << ", " << sample.sample_name
+                     << "]" << std::endl;
+      }
+    }
   }
 
+  if (params_.debug_params.print_tiledb_query_ranges && params_.verbose) {
+    debug_ranges << std::endl << "regions:" << std::endl;
+  }
   for (const auto& query_region :
-       read_state_.query_regions_v4[read_state_.query_contig_batch_idx].second)
+       read_state_.query_regions_v4[read_state_.query_contig_batch_idx]
+           .second) {
     read_state_.query->add_range(1, query_region.col_min, query_region.col_max);
+    if (params_.debug_params.print_tiledb_query_ranges && params_.verbose) {
+      debug_ranges << "[" << query_region.col_min << ", "
+                   << query_region.col_max << "]" << std::endl;
+    }
+  }
 
   read_state_.query->add_range(
       0,
       read_state_.query_regions_v4[read_state_.query_contig_batch_idx].first,
       read_state_.query_regions_v4[read_state_.query_contig_batch_idx].first);
+  if (params_.debug_params.print_tiledb_query_ranges && params_.verbose) {
+    debug_ranges << std::endl << "contigs:" << std::endl;
+    debug_ranges << "["
+                 << read_state_
+                        .query_regions_v4[read_state_.query_contig_batch_idx]
+                        .first
+                 << ", "
+                 << read_state_
+                        .query_regions_v4[read_state_.query_contig_batch_idx]
+                        .first
+                 << "]" << std::endl;
+  }
 
   read_state_.query->set_layout(TILEDB_UNORDERED);
   if (params_.verbose) {
+    if (params_.debug_params.print_tiledb_query_ranges) {
+      std::cout << "query_ranges:" << std::endl
+                << debug_ranges.str() << std::endl;
+    }
+
     std::stringstream ss;
     ss << "Initialized TileDB query with "
        << read_state_.query_regions_v4[read_state_.query_contig_batch_idx]
@@ -2288,6 +2476,19 @@ void Reader::set_enable_progress_estimation(
   std::cout << "setting enable_progress_estimation to "
             << enable_progress_estimation << std::endl;
   params_.enable_progress_estimation = enable_progress_estimation;
+}
+
+void Reader::set_debug_print_vcf_regions(const bool print_vcf_regions) {
+  params_.debug_params.print_vcf_regions = print_vcf_regions;
+}
+
+void Reader::set_debug_print_sample_list(const bool print_sample_list) {
+  params_.debug_params.print_sample_list = print_sample_list;
+}
+
+void Reader::set_debug_print_tiledb_query_ranges(
+    const bool print_tiledb_query_ranges) {
+  params_.debug_params.print_tiledb_query_ranges = print_tiledb_query_ranges;
 }
 
 }  // namespace vcf

--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -67,6 +67,17 @@ struct MemoryBudgetBreakdown {
   float tile_cache_percentage = 10;
 };
 
+struct DebugParams {
+  // Print out tiledb query range
+  bool print_tiledb_query_ranges = false;
+
+  // Print regions from bedfile or user passed
+  bool print_vcf_regions = false;
+
+  // Print user set sample list
+  bool print_sample_list = false;
+};
+
 /** Arguments/params for export. */
 struct ExportParams {
   // Basic export params:
@@ -109,6 +120,9 @@ struct ExportParams {
   // complete? This is useful when you want verbose but not the performance
   // impact.
   bool enable_progress_estimation = false;
+
+  // Debug parameters for optional debug information
+  struct DebugParams debug_params;
 };
 
 /* ********************************* */
@@ -394,6 +408,24 @@ class Reader {
    * @param check_samples_exist
    */
   void set_check_samples_exist(const bool check_samples_exist);
+
+  /**
+   * Set if vcf regions should be printed in verbose mode
+   * @param print_vcf_regions
+   */
+  void set_debug_print_vcf_regions(bool print_vcf_regions);
+
+  /**
+   * Set if sample list should be printed in verbose mode
+   * @param print_sample_list
+   */
+  void set_debug_print_sample_list(bool print_sample_list);
+
+  /**
+   * Set if TileDB query ranges should be printed in verbose mode
+   * @param print_tiledb_query_ranges
+   */
+  void set_debug_print_tiledb_query_ranges(bool print_tiledb_query_ranges);
 
  private:
   /* ********************************* */


### PR DESCRIPTION
This adds three new reader options for printing the read details including the sample list used, the vcf regions passed and the actual TileDB query ranges performed.

Three new CLI options are added:
```
    --debug-print-vcf-regions
                         Enable debug printing of vcf region passed by user or bed file. Requires verbose mode

    --debug-print-sample-list
                         Enable debug printing of sample list used in read. Requires verbose mode

    --debug-print-tiledb-query-ranges
                         Enable debug printing of tiledb query ranges used in read. Requires verbose mode
```

Three spark options where added:

`debug.print_vcf_regions`
`debug.print_sample_list`
`debug.print_tiledb_query_ranges`

Python is implemented in pybind11 but the user interface is not defined yet. This will be a followup with change to how we can more easily pass all the various debug options we want to set.