### PR TITLE
Remove duplicate sample field in TSV header

### DIFF
--- a/libtiledbvcf/src/read/tsv_exporter.cc
+++ b/libtiledbvcf/src/read/tsv_exporter.cc
@@ -3,7 +3,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2019 TileDB, Inc.
+ * @copyright Copyright (c) 2019-2021 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -270,6 +270,10 @@ void TSVExporter::init_output_stream() {
   std::ostream& os = output_file_.empty() ? std::cout : os_;
   os << "SAMPLE";
   for (auto& t : output_fields_) {
+    // skip SAMPLE since it is included by default
+    if (t.name == "SAMPLE") {
+      continue;
+    }
     os << "\t";
     switch (t.type) {
       case OutputField::Type::Info:

--- a/libtiledbvcf/test/run-cli-tests.sh
+++ b/libtiledbvcf/test/run-cli-tests.sh
@@ -378,6 +378,16 @@ Statistics for dataset 'ingested_1_2':
 EOF
 ) || exit 1
 
+# check tsv output with SAMPLE in tsv-fields
+diff -u <($tilevcf export -u ingested_1 -Ot --tsv-fields "SAMPLE") <(
+cat <<EOF
+SAMPLE
+HG01762	
+HG01762	
+HG01762	
+EOF
+) || exit 1
+
 # Expected failures
 echo ""
 echo "** Expected failure error messages follow:"


### PR DESCRIPTION
Remove duplicate `SAMPLE` column name in TSV export when `SAMPLE` is specified in the `--tsv-fields`.