### PR TITLE
Remove extra tab in TSV export

### DIFF
--- a/libtiledbvcf/src/read/tsv_exporter.cc
+++ b/libtiledbvcf/src/read/tsv_exporter.cc
@@ -95,6 +95,10 @@ bool TSVExporter::export_record(
   std::ostream& os = output_file_.empty() ? std::cout : os_;
   os << sample.sample_name;
   for (auto& field : output_fields_) {
+    // skip SAMPLE since it is included by default
+    if (field.name == "SAMPLE") {
+      continue;
+    }
     os << '\t';
     switch (field.type) {
       case OutputField::Type::Regular: {

--- a/libtiledbvcf/test/run-cli-tests.sh
+++ b/libtiledbvcf/test/run-cli-tests.sh
@@ -379,12 +379,12 @@ EOF
 ) || exit 1
 
 # check tsv output with SAMPLE in tsv-fields
-diff -u <($tilevcf export -u ingested_1 -Ot --tsv-fields "SAMPLE") <(
+diff -u <($tilevcf export -u ingested_1 -Ot --tsv-fields "SAMPLE,CHR") <(
 cat <<EOF
-SAMPLE
-HG01762	
-HG01762	
-HG01762	
+SAMPLE	CHR
+HG01762	1
+HG01762	1
+HG01762	1
 EOF
 ) || exit 1
 


### PR DESCRIPTION
Remove extra tab in records of TSV export when SAMPLE is specified in the --tsv-fields. Improved the test to cover this case.