### PR TITLE
Update miniconda3 image

### DIFF
--- a/docker/Dockerfile-py
+++ b/docker/Dockerfile-py
@@ -1,4 +1,4 @@
-FROM continuumio/miniconda3:4.8.2
+FROM continuumio/miniconda3:4.10.3
 ENV CFLAGS "-march=haswell"
 ENV CPPFLAGS "-march=haswell"
 


### PR DESCRIPTION
Bumps the miniconda3 image used by tiledbvcf-py to 4.10.3.