### PR TITLE
Add support for time traveling

### DIFF
--- a/apis/spark/src/test/java/io/tiledb/vcf/VCFDatasourceTest.java
+++ b/apis/spark/src/test/java/io/tiledb/vcf/VCFDatasourceTest.java
@@ -3,6 +3,7 @@ package io.tiledb.vcf;
 import static org.apache.spark.sql.functions.*;
 import static org.apache.spark.sql.functions.callUDF;
 
+import java.text.*;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.file.Path;
@@ -764,6 +765,34 @@ public class VCFDatasourceTest extends SharedJavaSparkSession {
             .option("debug.print_vcf_regions", true)
             .option("debug.print_sample_list", true)
             .option("debug.print_tiledb_query_ranges", true)
+            .load();
+    dfRead.createOrReplaceTempView("vcf");
+    List<Row> rows =
+        sparkSession
+            .sql("SELECT sampleName FROM vcf WHERE vcf.sampleName='HG01762'")
+            .collectAsList();
+    Assert.assertEquals(3, rows.size());
+    Assert.assertEquals(rows.get(0).getString(0), "HG01762");
+    Assert.assertEquals(rows.get(1).getString(0), "HG01762");
+    Assert.assertEquals(rows.get(2).getString(0), "HG01762");
+  }
+
+  @Test
+  public void testTimeTravel() throws java.text.ParseException {
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-M-dd hh:mm:ss");
+    Long start_ms = sdf.parse("2000-08-01 12:00:00").getTime();
+    Long end_ms = sdf.parse("2030-08-01 16:00:00").getTime();
+
+    Dataset<Row> dfRead =
+        session()
+            .read()
+            .format("io.tiledb.vcf")
+            .option("uri", testSampleGroupURI("ingested_2samples"))
+            .option("ranges", "1:12100-13360,1:13500-17350")
+            .option("tiledb.vfs.num_threads", 1)
+            .option("tiledb.vcf.start_timestamp", start_ms)
+            .option("tiledb.vcf.end_timestamp", end_ms)
+            .option("tiledb.vcf.log_level", "INFO")
             .load();
     dfRead.createOrReplaceTempView("vcf");
     List<Row> rows =

--- a/apis/spark/src/test/java/io/tiledb/vcf/VCFDatasourceTest.java
+++ b/apis/spark/src/test/java/io/tiledb/vcf/VCFDatasourceTest.java
@@ -3,11 +3,11 @@ package io.tiledb.vcf;
 import static org.apache.spark.sql.functions.*;
 import static org.apache.spark.sql.functions.callUDF;
 
-import java.text.*;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.text.*;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.apache.log4j.Level;

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -389,21 +389,28 @@ void TileDBVCFDataset::open(
         cfg_.get("vcf.end_timestamp"));
   }
 
+  if (reopen) {
+    data_array_->reopen();
+    vcf_header_array_->reopen();
+  }
+
   auto start_ms = data_array_->open_timestamp_start();
   auto end_ms = data_array_->open_timestamp_end();
 
   if (reopen) {
-    data_array_->reopen();
-    vcf_header_array_->reopen();
     LOG_INFO(
-        "start_timestamp = {:13d} = {} UTC", start_ms, asc_timestamp(start_ms));
+        "start_timestamp = {:013d} = {} UTC",
+        start_ms,
+        asc_timestamp(start_ms));
     LOG_INFO(
-        "end_timestamp   = {:13d} = {} UTC", end_ms, asc_timestamp(end_ms));
+        "end_timestamp   = {:013d} = {} UTC", end_ms, asc_timestamp(end_ms));
   } else {
     LOG_TRACE(
-        "start_timestamp = {:13d} = {} UTC", start_ms, asc_timestamp(start_ms));
+        "start_timestamp = {:013d} = {} UTC",
+        start_ms,
+        asc_timestamp(start_ms));
     LOG_TRACE(
-        "end_timestamp   = {:13d} = {} UTC", end_ms, asc_timestamp(end_ms));
+        "end_timestamp   = {:013d} = {} UTC", end_ms, asc_timestamp(end_ms));
   }
 
   open_ = true;

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -349,6 +349,47 @@ void TileDBVCFDataset::open(
         std::to_string(metadata_.version) +
         " but only versions 2, 3 and 4 are supported.");
 
+  bool reopen = false;
+
+  // TODO: uncomment log messages when logging is available
+  // look for vcf.start_timestamp in cfg
+  try {
+    uint64_t start_timestamp = std::stoull(cfg_.get("vcf.start_timestamp"));
+    data_array_->set_open_timestamp_start(start_timestamp);
+    vcf_header_array_->set_open_timestamp_start(start_timestamp);
+    reopen = true;
+  } catch (const tiledb::TileDBError& ex) {
+    //    LOG_TRACE("'vcf.start_timestamp' not specified in config, using
+    //    default");
+  } catch (...) {
+    // LOG_WARN(
+    //"Invalid vcf.start_timestamp '{}', using default",
+    // cfg_.get("vcf.start_timestamp"));
+  }
+
+  // look for vcf.end_timestamp in cfg
+  try {
+    uint16_t end_timestamp = std::stoull(cfg_.get("vcf.end_timestamp"));
+    data_array_->set_open_timestamp_end(end_timestamp);
+    vcf_header_array_->set_open_timestamp_end(end_timestamp);
+    reopen = true;
+  } catch (const tiledb::TileDBError& ex) {
+    // LOG_TRACE("'vcf.end_timestamp' not specified in config, using default");
+  } catch (...) {
+    // LOG_WARN(
+    //"Invalid vcf.end_timestamp '{}', using default",
+    // cfg_.get("vcf.end_timestamp"));
+  }
+
+  // reopen arrays if start or end timestamp were provided
+  if (reopen) {
+    data_array_->reopen();
+    vcf_header_array_->reopen();
+  }
+
+  // LOG_TRACE("start_timestamp = {}", data_array_->open_timestamp_start());
+  // LOG_TRACE("end_timestamp = {}", data_array_->open_timestamp_end());
+
   open_ = true;
 
   // Preloading runs on a background stl thread

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -412,18 +412,12 @@ void TileDBVCFDataset::open(
 
   if (reopen) {
     LOG_INFO(
-        "start_timestamp = {:013d} = {} UTC",
-        start_ms,
-        asc_timestamp(start_ms));
-    LOG_INFO(
-        "end_timestamp   = {:013d} = {} UTC", end_ms, asc_timestamp(end_ms));
+        "start_timestamp = {:013d} = {}", start_ms, asc_timestamp(start_ms));
+    LOG_INFO("end_timestamp   = {:013d} = {}", end_ms, asc_timestamp(end_ms));
   } else {
     LOG_TRACE(
-        "start_timestamp = {:013d} = {} UTC",
-        start_ms,
-        asc_timestamp(start_ms));
-    LOG_TRACE(
-        "end_timestamp   = {:013d} = {} UTC", end_ms, asc_timestamp(end_ms));
+        "start_timestamp = {:013d} = {}", start_ms, asc_timestamp(start_ms));
+    LOG_TRACE("end_timestamp   = {:013d} = {}", end_ms, asc_timestamp(end_ms));
   }
 
   open_ = true;

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -356,8 +356,6 @@ void TileDBVCFDataset::open(
         std::to_string(metadata_.version) +
         " but only versions 2, 3 and 4 are supported.");
 
-  bool reopen = false;
-
   // Handle time traveling by looking for 'vcf.start_timestamp' and
   // 'vcf.end_timestamp' in tiledb_config. If either timestamp is provided,
   // reopen the arrays.

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -2250,6 +2250,13 @@ void Reader::init_tiledb() {
   // Set htslib global config and context based on user passed TileDB config
   // options
   utils::set_htslib_tiledb_context(params_.tiledb_config);
+
+  // set log level if specified in cfg
+  try {
+    auto log_level = cfg.get("vcf.log_level");
+    LOG_CONFIG(log_level);
+  } catch (...) {
+  }
 }
 
 void Reader::check_partitioning(

--- a/libtiledbvcf/src/utils/logger.cc
+++ b/libtiledbvcf/src/utils/logger.cc
@@ -207,6 +207,7 @@ std::string asc_timestamp(uint64_t timestamp_ms) {
   auto time_sec = static_cast<time_t>(timestamp_ms) / 1000;
   std::string time_str = asctime(gmtime(&time_sec));
   time_str.pop_back();  // remove newline
+  time_str += " UTC";
   return time_str;
 }
 

--- a/libtiledbvcf/src/utils/logger.cc
+++ b/libtiledbvcf/src/utils/logger.cc
@@ -201,4 +201,12 @@ void LOG_FATAL(const std::string& msg) {
   exit(1);
 }
 
+/** Convert TileDB timestamp (in ms) to human readable timestamp. */
+std::string asc_timestamp(uint64_t timestamp_ms) {
+  auto time_sec = static_cast<time_t>(timestamp_ms) / 1000;
+  std::string time_str = asctime(gmtime(&time_sec));
+  time_str.pop_back();  // remove newline
+  return time_str;
+}
+
 }  // namespace tiledb::vcf

--- a/libtiledbvcf/src/utils/logger.h
+++ b/libtiledbvcf/src/utils/logger.h
@@ -239,6 +239,9 @@ Logger& global_logger();
 
 }  // namespace tiledb::vcf
 
+/** Convert TileDB timestamp (in ms) to human readable timestamp. */
+std::string asc_timestamp(uint64_t timestamp_ms);
+
 // Also include the public-permissible logger functions here.
 #include "utils/logger_public.h"
 

--- a/libtiledbvcf/src/utils/logger_public.h
+++ b/libtiledbvcf/src/utils/logger_public.h
@@ -101,6 +101,9 @@ void LOG_FATAL(const char* fmt, const Arg1& arg1, const Args&... args) {
   exit(1);
 }
 
+/** Convert TileDB timestamp (in ms) to human readable timestamp. */
+std::string asc_timestamp(uint64_t timestamp_ms);
+
 }  // namespace tiledb::vcf
 
 #endif  // TILEDB_LOGGER_PUBLIC_H

--- a/libtiledbvcf/test/CMakeLists.txt
+++ b/libtiledbvcf/test/CMakeLists.txt
@@ -41,6 +41,7 @@ add_executable(tiledb_vcf_unit EXCLUDE_FROM_ALL
   ${CMAKE_CURRENT_SOURCE_DIR}/src/unit-vcf-iter.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/src/unit-vcf-store.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/src/unit-vcf-utils.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/unit-vcf-time-travel.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/src/unit.cc
 )
 

--- a/libtiledbvcf/test/src/unit-vcf-time-travel.cc
+++ b/libtiledbvcf/test/src/unit-vcf-time-travel.cc
@@ -1,0 +1,286 @@
+/**
+ * @file   unit-vcf-time-travel.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2019-2021 TileDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests for VCF time travel.
+ */
+
+#include "catch.hpp"
+
+#include "dataset/tiledbvcfdataset.h"
+#include "read/reader.h"
+#include "utils/logger_public.h"
+#include "write/writer.h"
+
+#include <cstring>
+#include <fstream>
+#include <iostream>
+
+using namespace tiledb::vcf;
+
+static const std::string input_dir = TILEDB_VCF_TEST_INPUT_DIR;
+
+std::string now_ms_str() {
+  return std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(
+                            std::chrono::system_clock::now().time_since_epoch())
+                            .count());
+}
+
+TEST_CASE("TileDB-VCF: Test time travel", "[tiledbvcf][time-travel]") {
+  tiledb::Context ctx;
+  tiledb::VFS vfs(ctx);
+
+  std::string dataset_uri = "test_dataset";
+  if (vfs.is_dir(dataset_uri))
+    vfs.remove_dir(dataset_uri);
+
+  CreationParams create_args;
+  create_args.uri = dataset_uri;
+  create_args.tile_capacity = 10000;
+  create_args.allow_duplicates = false;
+  TileDBVCFDataset::create(create_args);
+
+  auto t0 = now_ms_str();
+
+  // Ingest
+  {
+    LOG_TRACE("Ingest at t0");
+    Writer writer;
+    IngestionParams params;
+    params.uri = dataset_uri;
+    params.sample_uris = {input_dir + "/small.vcf.gz"};
+    params.max_record_buffer_size = 1;
+    writer.set_all_params(params);
+    writer.ingest_samples();
+  }
+
+  auto t1 = now_ms_str();
+
+  // Ingest
+  {
+    LOG_TRACE("Ingest at t1");
+    Writer writer;
+    IngestionParams params;
+    params.uri = dataset_uri;
+    params.sample_uris = {input_dir + "/small2.vcf.gz"};
+    params.max_record_buffer_size = 1;
+    writer.set_all_params(params);
+    writer.ingest_samples();
+  }
+
+  auto t2 = now_ms_str();
+
+  // Ingest
+  {
+    LOG_TRACE("Ingest at t2");
+    Writer writer;
+    IngestionParams params;
+    params.uri = dataset_uri;
+    params.sample_uris = {input_dir + "/dupeEndPos.vcf.gz"};
+    params.max_record_buffer_size = 1;
+    writer.set_all_params(params);
+    writer.ingest_samples();
+  }
+
+  auto t3 = now_ms_str();
+
+  // Check sample count ingested between (t0, MAX)
+  {
+    LOG_TRACE("Check count");
+    Reader reader;
+    ExportParams params;
+    params.uri = dataset_uri;
+    params.tiledb_config.push_back(fmt::format("vcf.start_timestamp={}", t0));
+    reader.set_all_params(params);
+    reader.open_dataset(dataset_uri);
+    reader.read();
+    REQUIRE(reader.read_status() == ReadStatus::COMPLETED);
+    int sample_count;
+    reader.sample_count(&sample_count);
+    LOG_TRACE("sample count = {}", sample_count);
+    REQUIRE(sample_count == 3);
+  }
+
+  // Check sample count ingested between (t1, MAX)
+  {
+    LOG_TRACE("Check count");
+    Reader reader;
+    ExportParams params;
+    params.uri = dataset_uri;
+    params.tiledb_config.push_back(fmt::format("vcf.start_timestamp={}", t1));
+    reader.set_all_params(params);
+    reader.open_dataset(dataset_uri);
+    reader.read();
+    REQUIRE(reader.read_status() == ReadStatus::COMPLETED);
+    int sample_count;
+    reader.sample_count(&sample_count);
+    LOG_TRACE("sample count = {}", sample_count);
+    REQUIRE(sample_count == 2);
+  }
+
+  // Check sample count ingested between (t2, MAX)
+  {
+    LOG_TRACE("Check count");
+    Reader reader;
+    ExportParams params;
+    params.uri = dataset_uri;
+    params.tiledb_config.push_back(fmt::format("vcf.start_timestamp={}", t2));
+    reader.set_all_params(params);
+    reader.open_dataset(dataset_uri);
+    reader.read();
+    REQUIRE(reader.read_status() == ReadStatus::COMPLETED);
+    int sample_count;
+    reader.sample_count(&sample_count);
+    LOG_TRACE("sample count = {}", sample_count);
+    REQUIRE(sample_count == 1);
+  }
+
+  // Check sample count ingested between (t3, MAX)
+  {
+    LOG_TRACE("Check count");
+    Reader reader;
+    ExportParams params;
+    params.uri = dataset_uri;
+    params.tiledb_config.push_back(fmt::format("vcf.start_timestamp={}", t3));
+    reader.set_all_params(params);
+    reader.open_dataset(dataset_uri);
+    reader.read();
+    REQUIRE(reader.read_status() == ReadStatus::COMPLETED);
+    int sample_count;
+    reader.sample_count(&sample_count);
+    LOG_TRACE("sample count = {}", sample_count);
+    REQUIRE(sample_count == 0);
+  }
+
+  // Check sample count ingested between (0, t0)
+  {
+    LOG_TRACE("Check count");
+    Reader reader;
+    ExportParams params;
+    params.uri = dataset_uri;
+    params.tiledb_config.push_back(fmt::format("vcf.end_timestamp={}", t0));
+    reader.set_all_params(params);
+    reader.open_dataset(dataset_uri);
+    reader.read();
+    REQUIRE(reader.read_status() == ReadStatus::COMPLETED);
+    int sample_count;
+    reader.sample_count(&sample_count);
+    LOG_TRACE("sample count = {}", sample_count);
+    REQUIRE(sample_count == 0);
+  }
+
+  // Check sample count ingested between (0, t1)
+  {
+    LOG_TRACE("Check count");
+    Reader reader;
+    ExportParams params;
+    params.uri = dataset_uri;
+    params.tiledb_config.push_back(fmt::format("vcf.end_timestamp={}", t1));
+    reader.set_all_params(params);
+    reader.open_dataset(dataset_uri);
+    reader.read();
+    REQUIRE(reader.read_status() == ReadStatus::COMPLETED);
+    int sample_count;
+    reader.sample_count(&sample_count);
+    LOG_TRACE("sample count = {}", sample_count);
+    REQUIRE(sample_count == 1);
+  }
+
+  // Check sample count ingested between (0, t2)
+  {
+    LOG_TRACE("Check count");
+    Reader reader;
+    ExportParams params;
+    params.uri = dataset_uri;
+    params.tiledb_config.push_back(fmt::format("vcf.end_timestamp={}", t2));
+    reader.set_all_params(params);
+    reader.open_dataset(dataset_uri);
+    reader.read();
+    REQUIRE(reader.read_status() == ReadStatus::COMPLETED);
+    int sample_count;
+    reader.sample_count(&sample_count);
+    LOG_TRACE("sample count = {}", sample_count);
+    REQUIRE(sample_count == 2);
+  }
+
+  // Check sample count ingested between (0, t3)
+  {
+    LOG_TRACE("Check count");
+    Reader reader;
+    ExportParams params;
+    params.uri = dataset_uri;
+    params.tiledb_config.push_back(fmt::format("vcf.end_timestamp={}", t3));
+    reader.set_all_params(params);
+    reader.open_dataset(dataset_uri);
+    reader.read();
+    REQUIRE(reader.read_status() == ReadStatus::COMPLETED);
+    int sample_count;
+    reader.sample_count(&sample_count);
+    LOG_TRACE("sample count = {}", sample_count);
+    REQUIRE(sample_count == 3);
+  }
+
+  // Check sample count ingested between (t2, t1)
+  {
+    LOG_TRACE("Check count");
+    Reader reader;
+    ExportParams params;
+    params.uri = dataset_uri;
+    params.tiledb_config.push_back(fmt::format("vcf.start_timestamp={}", t2));
+    params.tiledb_config.push_back(fmt::format("vcf.end_timestamp={}", t1));
+    reader.set_all_params(params);
+    reader.open_dataset(dataset_uri);
+    reader.read();
+    REQUIRE(reader.read_status() == ReadStatus::COMPLETED);
+    int sample_count;
+    reader.sample_count(&sample_count);
+    LOG_TRACE("sample count = {}", sample_count);
+    REQUIRE(sample_count == 0);
+  }
+
+  // Check sample count ingested between (t1, t2)
+  {
+    LOG_TRACE("Check count");
+    Reader reader;
+    ExportParams params;
+    params.uri = dataset_uri;
+    params.tiledb_config.push_back(fmt::format("vcf.start_timestamp={}", t1));
+    params.tiledb_config.push_back(fmt::format("vcf.end_timestamp={}", t2));
+    reader.set_all_params(params);
+    reader.open_dataset(dataset_uri);
+    reader.read();
+    REQUIRE(reader.read_status() == ReadStatus::COMPLETED);
+    int sample_count;
+    reader.sample_count(&sample_count);
+    LOG_TRACE("sample count = {}", sample_count);
+    REQUIRE(sample_count == 1);
+  }
+
+  if (vfs.is_dir(dataset_uri))
+    vfs.remove_dir(dataset_uri);
+}


### PR DESCRIPTION
Add support for time traveling reads. The start and/or end timestamp of the read operation can be specified with the `tiledb-config` parameters: `vcf.start_timestamp` and `vcf.end_timestamp`.

### CLI Example
```shell
# create timestamps in milliseconds
$ start=$(date -d 2021/8/1 +%s000)
$ end=$(date -d 2021/8/7 +%s000)

# run export with time traveling
$ tiledbvcf export --uri small_dataset \
   --regions 1:1-50000,2:1-50000,3:1-50000 \
   --sample-names G1,G2,G3 \
   --output-dir data/exported-subsets \
   --tiledb-config "vcf.start_timestamp=$start,vcf.end_timestamp=$end" \
   --log-level INFO
[2021-08-16 16:13:52.717] [tiledb-vcf] [Process: 262730] [Thread: 262730] [info] Using vcf.start_timestamp from config: 1627790400000
[2021-08-16 16:13:52.717] [tiledb-vcf] [Process: 262730] [Thread: 262730] [info] Using vcf.end_timestamp from config: 1628308800000
[2021-08-16 16:13:52.719] [tiledb-vcf] [Process: 262730] [Thread: 262730] [info] start_timestamp = 1627790400000 = Sun Aug  1 04:00:00 2021 UTC
[2021-08-16 16:13:52.719] [tiledb-vcf] [Process: 262730] [Thread: 262730] [info] end_timestamp   = 1628308800000 = Sat Aug  7 04:00:00 2021 UTC
[2021-08-16 16:13:52.767] [tiledb-vcf] [Process: 262730] [Thread: 262730] [info] Initialized TileDB query with 1 start_pos ranges, 3 for contig 1 (contig batch 1/3, sample batch 1/1).
[2021-08-16 16:13:52.768] [tiledb-vcf] [Process: 262730] [Thread: 262730] [info] Processed 0 cells in 3.78e-07 sec. Reported 0 cells.
[2021-08-16 16:13:52.768] [tiledb-vcf] [Process: 262730] [Thread: 262730] [info] Initialized TileDB query with 1 start_pos ranges, 3 for contig 2 (contig batch 2/3, sample batch 1/1).
[2021-08-16 16:13:52.768] [tiledb-vcf] [Process: 262730] [Thread: 262730] [info] Processed 0 cells in 7.1e-08 sec. Reported 0 cells.
[2021-08-16 16:13:52.768] [tiledb-vcf] [Process: 262730] [Thread: 262730] [info] Initialized TileDB query with 1 start_pos ranges, 3 for contig 3 (contig batch 3/3, sample batch 1/1).
[2021-08-16 16:13:52.769] [tiledb-vcf] [Process: 262730] [Thread: 262730] [info] Processed 0 cells in 4.8e-08 sec. Reported 0 cells.
[2021-08-16 16:13:52.769] [tiledb-vcf] [Process: 262730] [Thread: 262730] [info] Done. Exported 0 records in 0.049461662 seconds.

```

### Python API Example
```python
start = datetime.datetime(2021, 8, 1).timestamp() * 1000
end = datetime.datetime(2021, 8, 7).timestamp() * 1000
cfg = tiledbvcf.ReadConfig(tiledb_config={'vcf.start_timestamp':start, 'vcf.end_timestamp':end})
```

### Spark API Example
Include `tiledb.vcf.log_level` to enable TileDB-VCF log messages and verify the timestamps are correct (see `Log Example` below).

```java
SimpleDateFormat sdf = new SimpleDateFormat("yyyy-M-dd hh:mm:ss");
Long start_ms = sdf.parse("2000-08-01 12:00:00").getTime();
Long end_ms = sdf.parse("2030-08-01 16:00:00").getTime();

Dataset<Row> dfRead =
    session()
        .read()
        .format("io.tiledb.vcf")
        .option("uri", testSampleGroupURI("ingested_2samples"))
        .option("ranges", "1:12100-13360,1:13500-17350")
        .option("tiledb.vfs.num_threads", 1)
        .option("tiledb.vcf.start_timestamp", start_ms)
        .option("tiledb.vcf.end_timestamp", end_ms)
        .option("tiledb.vcf.log_level", "INFO")
        .load();
```
### Log Example

```
[2021-08-19 23:21:36.156] [tiledb-vcf] [Process: 275812] [Thread: 275842] [info] Using vcf.start_timestamp from config: 965102400000
[2021-08-19 23:21:36.156] [tiledb-vcf] [Process: 275812] [Thread: 275842] [info] Using vcf.end_timestamp from config: 1911844800000
[2021-08-19 23:21:36.157] [tiledb-vcf] [Process: 275812] [Thread: 275842] [info] start_timestamp = 0965102400000 = Tue Aug  1 04:00:00 2000 UTC
[2021-08-19 23:21:36.157] [tiledb-vcf] [Process: 275812] [Thread: 275842] [info] end_timestamp   = 1911844800000 = Thu Aug  1 20:00:00 2030 UTC

```