### PR TITLE
Fix spdlog cmake and remove nested namespaces

### DIFF
--- a/libtiledbvcf/cmake/Modules/FindSpdlog_EP.cmake
+++ b/libtiledbvcf/cmake/Modules/FindSpdlog_EP.cmake
@@ -52,6 +52,13 @@ if (NOT SPDLOG_FOUND)
       set(CONDITIONAL_PATCH patch -N -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/cmake/patches/spdlog.patch)
     endif()
 
+    # if building ep_tiledb, make spdlog depend on ep_tiledb, so tiledb finds its required version of spdlog
+    if (TARGET ep_tiledb)
+      SET(SPDLOG_DEPENDS ep_tiledb)
+    else()
+      SET(SPDLOG_DEPENDS "")
+    endif()
+
     message(STATUS "Adding spdlog as an external project")
     ExternalProject_Add(ep_spdlog
       PREFIX "externals"
@@ -76,8 +83,7 @@ if (NOT SPDLOG_FOUND)
       LOG_BUILD TRUE
       LOG_INSTALL TRUE
       LOG_OUTPUT_ON_FAILURE TRUE
-      # build TileDB first, so it finds the required version of spdlog
-      DEPENDS ep_tiledb)
+      DEPENDS ${SPDLOG_DEPENDS})
     list(APPEND EXTERNAL_PROJECTS ep_spdlog)
     list(APPEND FORWARD_EP_CMAKE_ARGS
             -DTILEDB_SPDLOG_EP_BUILT=TRUE

--- a/libtiledbvcf/src/utils/logger.cc
+++ b/libtiledbvcf/src/utils/logger.cc
@@ -38,7 +38,8 @@
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 
-namespace tiledb::vcf {
+namespace tiledb {
+namespace vcf {
 
 // Set the default logging format
 // %^ : start color range
@@ -201,4 +202,5 @@ void LOG_FATAL(const std::string& msg) {
   exit(1);
 }
 
-}  // namespace tiledb::vcf
+}  // namespace vcf
+}  // namespace tiledb

--- a/libtiledbvcf/src/utils/logger.h
+++ b/libtiledbvcf/src/utils/logger.h
@@ -53,7 +53,8 @@
 
 #include <spdlog/spdlog.h>
 
-namespace tiledb::vcf {
+namespace tiledb {
+namespace vcf {
 
 /** Definition of class Logger. */
 class Logger {
@@ -237,7 +238,8 @@ class Logger {
 /** Global logger function. */
 Logger& global_logger();
 
-}  // namespace tiledb::vcf
+}  // namespace vcf
+}  // namespace tiledb
 
 // Also include the public-permissible logger functions here.
 #include "utils/logger_public.h"

--- a/libtiledbvcf/src/utils/logger_public.h
+++ b/libtiledbvcf/src/utils/logger_public.h
@@ -38,7 +38,8 @@
 
 #include "utils/logger.h"
 
-namespace tiledb::vcf {
+namespace tiledb {
+namespace vcf {
 
 /** Set log level for global logger and optionally set a logfile. */
 void LOG_CONFIG(const std::string& level, const std::string& logfile = "");
@@ -101,6 +102,7 @@ void LOG_FATAL(const char* fmt, const Arg1& arg1, const Args&... args) {
   exit(1);
 }
 
-}  // namespace tiledb::vcf
+}  // namespace vcf
+}  // namespace tiledb
 
 #endif  // TILEDB_LOGGER_PUBLIC_H


### PR DESCRIPTION
* Update `spdlog` cmake file so the `ep_tiledb` dependency is conditional.
* Remove nested namespaces, which are a C++17 extension.
