### PR TITLE
Block until safe to close arrays in vacuum operations

### DIFF
--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -111,21 +111,34 @@ TileDBVCFDataset::TileDBVCFDataset()
 }
 
 TileDBVCFDataset::~TileDBVCFDataset() {
-  // Grabbing a lock makes sure we don't delete the array in the middle of any
-  // usage (i.e. preloading)
+  // block until it's safe to delete the arrays
+  lock_and_join_data_array();
+  lock_and_join_vcf_header_array();
+
+  data_array_ = nullptr;
+  vcf_header_array_ = (nullptr);
+}
+
+void TileDBVCFDataset::lock_and_join_data_array() {
+  // Grabbing a lock makes sure we don't delete or close the array in the middle
+  // of any usage (i.e. preloading)
   utils::UniqueWriteLock data_array_lck_(
       const_cast<utils::RWLock*>(&data_array_lock_));
-  utils::UniqueWriteLock vcf_header_array_lck_(
-      const_cast<utils::RWLock*>(&vcf_header_array_lock_));
 
   // Block if the non empty domain threads have not completed.
   if (data_array_preload_non_empty_domain_thread_.joinable())
     data_array_preload_non_empty_domain_thread_.join();
+}
+
+void TileDBVCFDataset::lock_and_join_vcf_header_array() {
+  // Grabbing a lock makes sure we don't delete or close the array in the middle
+  // of any usage (i.e. preloading)
+  utils::UniqueWriteLock vcf_header_array_lck_(
+      const_cast<utils::RWLock*>(&vcf_header_array_lock_));
+
+  // Block if the non empty domain threads have not completed.
   if (vcf_header_array_preload_non_empty_domain_thread_.joinable())
     vcf_header_array_preload_non_empty_domain_thread_.join();
-
-  data_array_ = nullptr;
-  vcf_header_array_ = (nullptr);
 }
 
 void TileDBVCFDataset::create(const CreationParams& params) {
@@ -1949,6 +1962,8 @@ void TileDBVCFDataset::vacuum_vcf_header_array_fragment_metadata(
   Config cfg;
   utils::set_tiledb_config(params.tiledb_config, &cfg);
   cfg["sm.vacuum.mode"] = "fragment_meta";
+  // block until it's safe to close the array
+  lock_and_join_vcf_header_array();
   vcf_header_array_->close();
   tiledb::Array::vacuum(ctx_, vcf_headers_uri(root_uri_), &cfg);
   data_array_ = open_data_array(TILEDB_READ);
@@ -1960,6 +1975,8 @@ void TileDBVCFDataset::vacuum_data_array_fragment_metadata(
   Config cfg;
   utils::set_tiledb_config(params.tiledb_config, &cfg);
   cfg["sm.vacuum.mode"] = "fragment_meta";
+  // block until it's safe to close the array
+  lock_and_join_data_array();
   data_array_->close();
   tiledb::Array::vacuum(ctx_, data_array_uri(root_uri_), &cfg);
   data_array_ = open_data_array(TILEDB_READ);
@@ -1975,6 +1992,8 @@ void TileDBVCFDataset::vacuum_vcf_header_array_fragments(
   Config cfg;
   utils::set_tiledb_config(params.tiledb_config, &cfg);
   cfg["sm.vacuum.mode"] = "fragments";
+  // block until it's safe to close the array
+  lock_and_join_vcf_header_array();
   vcf_header_array_->close();
   tiledb::Array::vacuum(ctx_, vcf_headers_uri(root_uri_), &cfg);
   vcf_header_array_ = open_vcf_array(TILEDB_READ);
@@ -1984,6 +2003,8 @@ void TileDBVCFDataset::vacuum_data_array_fragments(const UtilsParams& params) {
   Config cfg;
   utils::set_tiledb_config(params.tiledb_config, &cfg);
   cfg["sm.vacuum.mode"] = "fragments";
+  // block until it's safe to close the array
+  lock_and_join_data_array();
   data_array_->close();
   tiledb::Array::vacuum(ctx_, data_array_uri(root_uri_), &cfg);
   data_array_ = open_data_array(TILEDB_READ);

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -875,6 +875,12 @@ class TileDBVCFDataset {
   /*          PRIVATE METHODS          */
   /* ********************************* */
 
+  /** Block until it's safe to delete or close the data array */
+  void lock_and_join_data_array();
+
+  /** Block until it's safe to delete or close the vcf header array */
+  void lock_and_join_vcf_header_array();
+
   /**
    * Populate the metadata maps of info/fmt field name -> htslib types.
    */

--- a/libtiledbvcf/test/src/unit-vcf-utils.cc
+++ b/libtiledbvcf/test/src/unit-vcf-utils.cc
@@ -46,7 +46,6 @@ using namespace tiledb::vcf;
 static const std::string input_dir = TILEDB_VCF_TEST_INPUT_DIR;
 
 TEST_CASE("TileDB-VCF: Test consolidate and vacuum", "[tiledbvcf][utils]") {
-  LOG_CONFIG("TRACE");
   tiledb::Context ctx;
   tiledb::VFS vfs(ctx);
 
@@ -213,6 +212,4 @@ TEST_CASE("TileDB-VCF: Test consolidate and vacuum", "[tiledbvcf][utils]") {
 
   if (vfs.is_dir(dataset_uri))
     vfs.remove_dir(dataset_uri);
-
-  LOG_CONFIG("FATAL");
 }


### PR DESCRIPTION
In the `TileDBVCFDataset::vacuum*array*` functions, an array can be closed while other threads (like preloading) are still using the array.

Avoid a race condition with the same lock and join sequence used to delete the arrays in `~TileDBVCFDataset`.