### PR TITLE
Fix incomplete VCF export for v4 arrays

### DIFF
--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -1085,11 +1085,16 @@ bool Reader::read_current_batch() {
     } else {
       assert(dataset_->metadata().version == TileDBVCFDataset::Version::V4);
 
-      for (const auto& s : read_state_.current_hdrs_lookup) {
-        std::string sample_name = s.first;
-        bcf_hdr_t* hdr = read_state_.current_hdrs.at(s.second).get();
-        exporter_->finalize_export(
-            SampleAndId{.sample_name = sample_name, .sample_id = 0}, hdr);
+      // If we've finished the last contig for the sample batch we need to
+      // finalize the export
+      if (read_state_.query_contig_batch_idx ==
+          read_state_.query_regions_v4.size() - 1) {
+        for (const auto& s : read_state_.current_hdrs_lookup) {
+          std::string sample_name = s.first;
+          bcf_hdr_t* hdr = read_state_.current_hdrs.at(s.second).get();
+          exporter_->finalize_export(
+              SampleAndId{.sample_name = sample_name, .sample_id = 0}, hdr);
+        }
       }
     }
   }

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -917,7 +917,6 @@ void Reader::init_exporter() {
 
 bool Reader::read_current_batch() {
   tiledb::Query* query = read_state_.query.get();
-  const bool verbose = LOG_DEBUG_ENABLED();
 
   if (read_state_.status == ReadStatus::INCOMPLETE) {
     auto exp = dynamic_cast<InMemoryExporter*>(exporter_.get());
@@ -960,13 +959,12 @@ bool Reader::read_current_batch() {
     std::swap(buffers_a, buffers_b);
   } else {
     buffers_a->set_buffers(query, dataset_->metadata().version);
-    read_state_.async_query =
-        std::async(std::launch::async, [query, verbose]() {
-          auto t0 = std::chrono::steady_clock::now();
-          auto st = query->submit();
-          LOG_DEBUG("query completed in {} sec.", utils::chrono_duration(t0));
-          return st;
-        });
+    read_state_.async_query = std::async(std::launch::async, [query]() {
+      auto t0 = std::chrono::steady_clock::now();
+      auto st = query->submit();
+      LOG_DEBUG("query completed in {} sec.", utils::chrono_duration(t0));
+      return st;
+    });
   }
 
   do {
@@ -1004,13 +1002,12 @@ bool Reader::read_current_batch() {
     if (query_status == tiledb::Query::Status::INCOMPLETE &&
         double_buffering_) {
       buffers_b->set_buffers(query, dataset_->metadata().version);
-      read_state_.async_query =
-          std::async(std::launch::async, [query, verbose]() {
-            auto t0 = std::chrono::steady_clock::now();
-            auto st = query->submit();
-            LOG_DEBUG("query completed in {} sec.", utils::chrono_duration(t0));
-            return st;
-          });
+      read_state_.async_query = std::async(std::launch::async, [query]() {
+        auto t0 = std::chrono::steady_clock::now();
+        auto st = query->submit();
+        LOG_DEBUG("query completed in {} sec.", utils::chrono_duration(t0));
+        return st;
+      });
     }
 
     // Process the query results.
@@ -1062,13 +1059,12 @@ bool Reader::read_current_batch() {
         tiledb::Query::Status::INCOMPLETE) {  // resubmit existing buffers_a if
                                               // not double buffering
       buffers_a->set_buffers(query, dataset_->metadata().version);
-      read_state_.async_query =
-          std::async(std::launch::async, [query, verbose]() {
-            auto t0 = std::chrono::steady_clock::now();
-            auto st = query->submit();
-            LOG_DEBUG("query completed in {} sec.", utils::chrono_duration(t0));
-            return st;
-          });
+      read_state_.async_query = std::async(std::launch::async, [query]() {
+        auto t0 = std::chrono::steady_clock::now();
+        auto st = query->submit();
+        LOG_DEBUG("query completed in {} sec.", utils::chrono_duration(t0));
+        return st;
+      });
     }
   } while (read_state_.query_results.query_status() ==
                tiledb::Query::Status::INCOMPLETE &&

--- a/libtiledbvcf/test/run-cli-tests.sh
+++ b/libtiledbvcf/test/run-cli-tests.sh
@@ -25,7 +25,8 @@ function clean_up {
            ingested_dupe_start_pos errored_dupe_start_pos \
            ingested_null_attr \
            ingested_capacity HG01762.vcf HG00280.vcf tmp.bed tmp1.vcf tmp2.vcf \
-           region-map.txt pfx.tsv
+           region-map.txt pfx.tsv \
+           export_test G1.bcf \
     rm -rf "$upload_dir"
 }
 
@@ -387,6 +388,12 @@ HG01762	1
 HG01762	1
 EOF
 ) || exit 1
+
+# check vcf export
+$tilevcf create -u export_test
+$tilevcf store -u export_test ${input_dir}/random_synthetic/G1.bcf
+$tilevcf export -u export_test -Ob -s G1
+diff -u <(bcftools view -H G1.bcf | sort -n -k1,1 -k2,2) <(bcftools view -H ${input_dir}/random_synthetic/G1.bcf) || exit 1
 
 # Expected failures
 echo ""


### PR DESCRIPTION
* Update when `finalize_export` is called for v4 arrays to avoid incomplete VCF exports. 
* Remove unused `verbose` variable to resolve CI build issue.