### PR TITLE
BED file line number handling

### DIFF
--- a/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.c
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.c
@@ -1062,10 +1062,10 @@ Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1bed_1file_1get_1contig_1re
       &region_start,
       &region_end);
   if (rc == TILEDB_VCF_OK) {
-    int length = strlen(region_str);
+    int length = strlen(region_str) + 1;  // add 1 to copy null terminator
     (*env)->SetByteArrayRegion(env, regionStrOut, 0, length, region_str);
 
-    int length2 = strlen(region_contig);
+    int length2 = strlen(region_contig) + 1;  // add 1 to copy null terminator
     (*env)->SetByteArrayRegion(env, regionContigOut, 0, length2, region_contig);
 
     // Upcast to 64bit because java doesn't have unsigned 32bit ints

--- a/apis/java/src/main/java/io/tiledb/libvcfnative/VCFBedFile.java
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/VCFBedFile.java
@@ -97,9 +97,6 @@ public class VCFBedFile implements AutoCloseable {
         for (j = 0; j < regionContigBytes.length && regionContigBytes[j] != 0; j++) {}
         regionContig = new String(regionContigBytes, 0, j);
 
-        // the regionStr has 2 zeros appended to it, not sure why, need to debug futher
-        // cause of this we just make the string ourselves
-        regionStr = regionContig + ":" + (regionStart[0] + 1) + "-" + (regionEnd[0] + 1);
         regionList.add(new Region(regionStr, regionContig, regionStart[0], regionEnd[0]));
       }
       contigRegions.put(regionContig, regionList);

--- a/apis/spark/build.gradle
+++ b/apis/spark/build.gradle
@@ -45,6 +45,8 @@ configurations {
 }
 
 test {
+    minHeapSize = "4096m"
+    maxHeapSize = "4096m"
     testLogging {
         showStandardStreams = true
     }

--- a/apis/spark/build.gradle
+++ b/apis/spark/build.gradle
@@ -45,8 +45,8 @@ configurations {
 }
 
 test {
-    minHeapSize = "4096m"
-    maxHeapSize = "4096m"
+    minHeapSize = "8192m"
+    maxHeapSize = "8192m"
     testLogging {
         showStandardStreams = true
     }

--- a/apis/spark/src/main/java/io/tiledb/vcf/VCFDataSourceReader.java
+++ b/apis/spark/src/main/java/io/tiledb/vcf/VCFDataSourceReader.java
@@ -219,7 +219,7 @@ public class VCFDataSourceReader
       numRangePartitions = regions.size();
       ranges_end = regions.size();
       log.info(
-          "Forcing regions per contig partitioning has yielded "
+          "New partition method has yielded "
               + numRangePartitions
               + " range partitions");
     }
@@ -231,6 +231,7 @@ public class VCFDataSourceReader
         // Skip empty region list
         // TODO: find out why this happens?
         if (local_regions.size() == 0) {
+          log.warn(String.format("range %d of %d: local_regions.size() == 0", r, ranges_end));
           continue;
         }
       }

--- a/apis/spark/src/main/java/io/tiledb/vcf/VCFDataSourceReader.java
+++ b/apis/spark/src/main/java/io/tiledb/vcf/VCFDataSourceReader.java
@@ -218,10 +218,7 @@ public class VCFDataSourceReader
       regions = computeRegionPartitionsFromBedFile(numRangePartitions);
       numRangePartitions = regions.size();
       ranges_end = regions.size();
-      log.info(
-          "New partition method has yielded "
-              + numRangePartitions
-              + " range partitions");
+      log.info("New partition method has yielded " + numRangePartitions + " range partitions");
     }
 
     for (int r = ranges_start; r < ranges_end; r++) {
@@ -276,8 +273,8 @@ public class VCFDataSourceReader
     Map<String, List<String>> mapOfRegions = bedFile.getContigRegionStrings();
     List<List<String>> res = new LinkedList<>(mapOfRegions.values());
 
-    // Sort the region list by size of regions in contig
-    res.sort(Comparator.comparingInt(List::size));
+    // Sort the region list by size of regions in contig, largest first
+    res.sort(Comparator.comparingInt(List<String>::size).reversed());
 
     // Keep splitting the larges region lists until we have the desired minimum number of range
     // Partitions, we stop if the large region has a size of 10 or less

--- a/apis/spark/src/main/java/io/tiledb/vcf/VCFSparkSchema.java
+++ b/apis/spark/src/main/java/io/tiledb/vcf/VCFSparkSchema.java
@@ -315,7 +315,7 @@ public class VCFSparkSchema implements Serializable {
       String fieldPart = field.substring(5);
       return fieldPart.toUpperCase() + " field in INFO block of BCF";
     } else if (field.equals("queryBedStart")) return "BED start position (0-based) of query";
-    else if (field.equals("queryBedEnd")) return "BED end position (1-based) of query";
+    else if (field.equals("queryBedEnd")) return "BED end position (half-open) of query";
     else if (field.equals("queryBedLine")) return "BED file line number of query";
 
     return field;

--- a/apis/spark/src/test/java/io/tiledb/vcf/VCFDatasourceTest.java
+++ b/apis/spark/src/test/java/io/tiledb/vcf/VCFDatasourceTest.java
@@ -438,6 +438,48 @@ public class VCFDatasourceTest extends SharedJavaSparkSession {
     }
   }
 
+  // TODO: test is WIP
+  //@Test
+  public void testNewPartition() {
+    boolean new_partition_method = true;
+    int rangePartitions = 8;
+    int samplePartitions = 1;
+    if (new_partition_method) {
+      rangePartitions = 1;
+      samplePartitions = 1;
+    }
+    Dataset<Row> dfRead =
+        session()
+            .read()
+            .format("io.tiledb.vcf")
+//            .option("uri", "s3://tiledb-inc-demo-data/tiledbvcf-arrays/v4/vcf-samples-20")
+            .option("uri", "~/data/vcf-samples-20")
+//            .option("bedfile", "~/data/clinvar.bed.gz")
+            .option("bedfile", "~/data/clinvar-chrx.bed.gz")
+            .option("samples", "v2-DjrIAzkP")
+            .option("new_partition_method", new_partition_method)
+            .option("range_partitions", rangePartitions)
+            .option("sample_partitions", samplePartitions)
+            .option("tiledb.vcf.log_level", "TRACE")
+            .load();
+    System.out.println(String.format("*** num partitions = %d", dfRead.select("sampleName").rdd().getNumPartitions()));
+//    Assert.assertEquals(rangePartitions, dfRead.select("sampleName").rdd().getNumPartitions());
+    
+    List<Row> rows = dfRead.select("sampleName", "contig", "posStart", "posEnd", "queryBedStart", "queryBedEnd", "queryBedLine").collectAsList();
+
+    for (int i = 0; i < rows.size(); i++) {
+      System.out.println(String.format("*** %s, %s, pos=%d-%d, query=%d-%d, bedLine=%d", 
+        rows.get(i).getString(0),
+        rows.get(i).getString(1),
+        rows.get(i).getInt(2),
+        rows.get(i).getInt(3),
+        rows.get(i).getInt(4),
+        rows.get(i).getInt(5),
+        rows.get(i).getInt(6)
+      ));
+    }
+  }
+
   @Test
   public void testBedFile() {
     Dataset<Row> dfRead =

--- a/apis/spark/src/test/resources/E001_15_coreMarks_dense.bed.gz
+++ b/apis/spark/src/test/resources/E001_15_coreMarks_dense.bed.gz
@@ -1,0 +1,1 @@
+../../../../../libtiledbvcf/test/inputs/E001_15_coreMarks_dense.bed.gz

--- a/apis/spark/src/test/resources/E001_15_coreMarks_dense.bed.gz.tbi
+++ b/apis/spark/src/test/resources/E001_15_coreMarks_dense.bed.gz.tbi
@@ -1,0 +1,1 @@
+../../../../../libtiledbvcf/test/inputs/E001_15_coreMarks_dense.bed.gz.tbi

--- a/libtiledbvcf/src/read/in_memory_exporter.cc
+++ b/libtiledbvcf/src/read/in_memory_exporter.cc
@@ -447,6 +447,8 @@ bool InMemoryExporter::export_record(
         break;
       }
       case ExportableAttribute::QueryBedEnd: {
+        // converting 0-indexed, inclusive end position to 0-indexed, half-open
+        // end position to match the BED file
         uint32_t end = query_region.max + 1;
         overflow = !copy_cell(&user_buff, &end, sizeof(end), 1, hdr);
         break;

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -1682,10 +1682,11 @@ void Reader::prepare_regions_v4(
   // of BED file
   std::list<Region> pre_partition_regions_list;
 
-  // Manually-specified regions (-r) are 1-indexed and inclusive
+  // Add manually-specified regions (-r) which are 1-indexed and inclusive
+  // and spark generated regions, which are 0-indexed and inclusive
+  // conversion is handled in the Region constructor
   for (const std::string& r : params_.regions)
-    pre_partition_regions_list.emplace_back(
-        r, Region::Type::OneIndexedInclusive);
+    pre_partition_regions_list.emplace_back(r);
 
   // Add BED file regions, if specified.
   if (!params_.regions_file_uri.empty()) {
@@ -1865,10 +1866,11 @@ void Reader::prepare_regions_v3(
   // of BED file
   std::list<Region> pre_partition_regions_list;
 
-  // Manually-specified regions (-r) are 1-indexed and inclusive
+  // Add manually-specified regions (-r) which are 1-indexed and inclusive
+  // and spark generated regions, which are 0-indexed and inclusive
+  // conversion is handled in the Region constructor
   for (const std::string& r : params_.regions)
-    pre_partition_regions_list.emplace_back(
-        r, Region::Type::OneIndexedInclusive);
+    pre_partition_regions_list.emplace_back(r);
 
   // Add BED file regions, if specified.
   if (!params_.regions_file_uri.empty()) {
@@ -1992,10 +1994,11 @@ void Reader::prepare_regions_v2(
   // of BED file
   std::list<Region> pre_partition_regions_list;
 
-  // Manually-specified regions (-r) are 1-indexed and inclusive
+  // Add manually-specified regions (-r) which are 1-indexed and inclusive
+  // and spark generated regions, which are 0-indexed and inclusive
+  // conversion is handled in the Region constructor
   for (const std::string& r : params_.regions)
-    pre_partition_regions_list.emplace_back(
-        r, Region::Type::OneIndexedInclusive);
+    pre_partition_regions_list.emplace_back(r);
 
   // Add BED file regions, if specified.
   if (!params_.regions_file_uri.empty()) {

--- a/libtiledbvcf/src/vcf/region.h
+++ b/libtiledbvcf/src/vcf/region.h
@@ -55,7 +55,7 @@ struct Region {
 
   Region();
 
-  Region(const std::string& seq, unsigned min, unsigned max, uint64_t line = 0);
+  Region(const std::string& seq, uint32_t min, uint32_t max, uint32_t line = 0);
 
   Region(const std::string& str, Type parse_from);
 

--- a/libtiledbvcf/test/src/unit-c-api-reader.cc
+++ b/libtiledbvcf/test/src/unit-c-api-reader.cc
@@ -5068,7 +5068,8 @@ TEST_CASE("C API: Reader BED file parsing", "[capi][reader][bed]") {
           &region_end) == TILEDB_VCF_OK);
   REQUIRE(12099 == region_start);
   REQUIRE(13359 == region_end);
-  REQUIRE_THAT(region_str, Catch::Matchers::Equals("1:12099-13360:0"));
+  // region_str is 0-indexed, inclusive
+  REQUIRE_THAT(region_str, Catch::Matchers::Equals("1:12099-13359:0"));
   REQUIRE_THAT(region_contig, Catch::Matchers::Equals("1"));
 
   tiledb_vcf_bed_file_free(&bed_file);

--- a/libtiledbvcf/test/src/unit-c-api-reader.cc
+++ b/libtiledbvcf/test/src/unit-c-api-reader.cc
@@ -5068,7 +5068,7 @@ TEST_CASE("C API: Reader BED file parsing", "[capi][reader][bed]") {
           &region_end) == TILEDB_VCF_OK);
   REQUIRE(12099 == region_start);
   REQUIRE(13359 == region_end);
-  REQUIRE_THAT(region_str, Catch::Matchers::Equals("1:12099-13360"));
+  REQUIRE_THAT(region_str, Catch::Matchers::Equals("1:12099-13360:0"));
   REQUIRE_THAT(region_contig, Catch::Matchers::Equals("1"));
 
   tiledb_vcf_bed_file_free(&bed_file);


### PR DESCRIPTION
Implement queries of BED file line numbers in the new Spark partitioning method.

The `Region` class was refactored:
* All regions objects are always "0-indexed, inclusive" (this was already true).
* Simplify the logic for creating a region object by removing the `Region::Type`.
* Always maintain a "0-indexed, inclusive" string representation of the region in the `region_str` field.
* Add the line number field to the `region_str` field to preserve line number information as the region string is passed back and forth between `C` and `Java`.
* Handle "1-indexed, inclusive" regions and "0-indexed, inclusive" regions in the `Region::Region(str)` constructor, which is required by the new Spark partitioning method.

More documentation on the `Region` class changes can be found in `libtiledbvcf/src/vcf/region.h`.