### PR TITLE
Add libcurl to the CLI's final image

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -62,7 +62,7 @@ stages:
       - template: ci/azure-linux_mac.yml
 
   - stage: Docker
-    condition: or(succeeded(), eq(variables.isRefTag, true))
+    # condition: or(succeeded(), eq(variables.isRefTag, true))
     jobs:
       - job: Build
         pool:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -62,7 +62,7 @@ stages:
       - template: ci/azure-linux_mac.yml
 
   - stage: Docker
-    # condition: or(succeeded(), eq(variables.isRefTag, true))
+    condition: or(succeeded(), eq(variables.isRefTag, true))
     jobs:
       - job: Build
         pool:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -73,10 +73,12 @@ stages:
               dockerfile: docker/Dockerfile-cli
               repository: tiledb/tiledbvcf-cli
               context: .
+              test_cmd: version
             python:
               dockerfile: docker/Dockerfile-py
               repository: tiledb/tiledbvcf-py
               context: .
+              test_cmd: -c "import tiledbvcf; print(tiledbvcf.version)"
             # dask:
             #   dockerfile: docker/Dockerfile-dask-py
             #   repository: tiledb/tiledbvcf-dask

--- a/ci/build-images.yml
+++ b/ci/build-images.yml
@@ -12,6 +12,11 @@ steps:
         latest
         $(build.SourceBranchName)
 
+  - script: |
+      docker run --rm $(repository):dev $(test_cmd)
+    env: { sourceVersion: $(Build.SourceVersion) }
+    displayName: Test Image
+
   - task: Docker@2
     displayName: Push Latest Tag
     condition: eq(variables['build.sourceBranch'], 'refs/heads/master')

--- a/docker/Dockerfile-cli
+++ b/docker/Dockerfile-cli
@@ -2,7 +2,7 @@ FROM ubuntu:latest as builder
 
 ENV AWS_EC2_METADATA_DISABLED true
 
-# Install some dependencies
+# Install build-time dependencies
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     cmake \
     wget \
@@ -38,6 +38,12 @@ RUN cmake .. -DCMAKE_BUILD_TYPE=Release \
     && make install-libtiledbvcf
 
 FROM ubuntu:latest
+# Install run-time dependencies
+RUN apt-get update && apt-get install -y \
+    libcurl4-openssl-dev \
+    && apt-get clean \
+    && apt-get purge -y \
+    && rm -rf /var/lib/apt/lists*
 COPY --from=builder /usr/local/bin/* /usr/local/bin/
 COPY --from=builder /usr/local/include/* /usr/local/include/
 COPY --from=builder /usr/local/lib/* /usr/local/lib/


### PR DESCRIPTION
This addresses an issue with the CLI Docker image reported in #370 by @Alexander-Stuckey and incorporates his suggested fix (thanks, Alexander!). We've also added a CI step to validate the images after they're built.