### PR TITLE
Update native build to Ubuntu 20.04 for releases

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -93,7 +93,7 @@ stages:
         strategy:
           matrix:
             linux:
-              imageName: 'ubuntu-18.04'
+              imageName: 'ubuntu-20.04'
               python.version: '3.x'
               CXX: g++
               BUILD_PYTHON_API: ON
@@ -124,7 +124,7 @@ stages:
         strategy:
           matrix:
             ubuntu_18:
-              imageName: 'ubuntu-18.04'
+              imageName: 'ubuntu-20.04'
         pool:
           vmImage: $(imageName)
 


### PR DESCRIPTION
This solves a linker problem due to TileDB prebuilt using newer glibc linkage.