### PR TITLE
Update std::thread to std::async and add threading try/catch blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,12 @@ dist/*
 libtiledbvcf/cmake-build-*/*
 libtiledbvcf/build/*
 apis/spark/.gradle/*
+apis/spark/.project
 apis/spark/build/*
 apis/spark/out/*
 apis/spark/spark.iml
 apis/java/.gradle/*
+apis/java/.project
 apis/java/build/*
 apis/java/out/*
 core/bin/*

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -734,11 +734,14 @@ class TileDBVCFDataset {
   /** RWLock for vcf header array to prevent destruction if in use */
   utils::RWLock vcf_header_array_lock_;
 
-  /** Thread for preloading non_empty_domain of data array */
-  std::thread data_array_preload_non_empty_domain_thread_;
+  /** Future for preloading non_empty_domain of data array */
+  std::future<void> data_array_preload_non_empty_domain_thread_;
 
-  /** Thread for preloading non_empty_domain of vcf header array */
-  std::thread vcf_header_array_preload_non_empty_domain_thread_;
+  /** Future for preloading non_empty_domain of data array */
+  std::future<void> data_array_preload_fragment_info_thread_;
+
+  /** Future for preloading non_empty_domain of vcf header array */
+  std::future<void> vcf_header_array_preload_non_empty_domain_thread_;
 
   /* ********************************* */
   /*          STATIC METHODS           */

--- a/libtiledbvcf/src/utils/utils.h
+++ b/libtiledbvcf/src/utils/utils.h
@@ -36,6 +36,17 @@
 
 #include "utils/buffer.h"
 
+#define TRY_CATCH_THROW(stmt)                                      \
+  [&]() {                                                          \
+    try {                                                          \
+      (stmt);                                                      \
+    } catch (const std::exception& e) {                            \
+      auto err = std::string("TileDB-VCF exception: ") + e.what(); \
+      LOG_ERROR(err);                                              \
+      throw std::runtime_error(err);                               \
+    }                                                              \
+  }()
+
 namespace tiledb {
 namespace vcf {
 


### PR DESCRIPTION
Some threads are using raw `std::thread` and we potentially miss exceptions thrown by these threads.

Update all threads to launch with `std::async` and capture the `std::future`:
```c++
std::future<...> thr1 = std::async(std::launch::async, ...);
```

Wrap the future's `.get()` statement in a try/catch block to catch exceptions from the thread:
```c++
  try {
    thr1.get();
  } catch(...) {
    // error handling code
  }
```

Add `TRY_CATCH_THROW` in `utils.h` as a helper and wrap all thread related function calls so we catch, log, and re-throw any exceptions.