### PR TITLE
Fix CLI backwards compatibility

### DIFF
--- a/libtiledbvcf/src/cli/tiledbvcf.cc
+++ b/libtiledbvcf/src/cli/tiledbvcf.cc
@@ -82,6 +82,10 @@ void do_store(const IngestionParams& args, const CLI::App& cmd) {
     throw CLI::CallForHelp();
   }
 
+  if (args.verbose) {
+    LOG_SET_LEVEL("debug");
+  }
+
   LOG_TRACE("Starting store command.");
   config_to_log(cmd);
 
@@ -100,6 +104,10 @@ void do_store(const IngestionParams& args, const CLI::App& cmd) {
 
 /** Export. */
 void do_export(ExportParams& args, const CLI::App& cmd) {
+  if (args.verbose) {
+    LOG_SET_LEVEL("debug");
+  }
+
   LOG_TRACE("Starting export command.");
   config_to_log(cmd);
 
@@ -588,7 +596,7 @@ void add_export(CLI::App& app) {
       args->samples_file_uri,
       "Path to file with 1 sample name per line");
   cmd->add_option(
-         "-s,--samples-name",
+         "-s,--sample-names",
          args->sample_names,
          "CSV list of sample names to export")
       ->delimiter(',')

--- a/libtiledbvcf/test/run-cli-tests.sh
+++ b/libtiledbvcf/test/run-cli-tests.sh
@@ -77,7 +77,7 @@ $tilevcf store -u ingested_sep_indexes --remove-sample-file -f samples.txt || ex
 test -e samples.txt && exit 1
 
 # Run export checks
-$tilevcf export -u ingested_1 -s HG01762 -O v -b 512
+$tilevcf export -u ingested_1 --sample-names HG01762 -O v -b 512
 diff <(bcftools view --no-version ${input_dir}/small.bcf) HG01762.vcf || exit 1
 $tilevcf export -u ingested_2 -s HG00280 -O v -b 512
 diff <(bcftools view --no-version ${input_dir}/small2.bcf) HG00280.vcf || exit 1


### PR DESCRIPTION
Fix issues in CLI arg parser migration found when running examples in the documentation:
* Fix typo in export `--sample-names` option
* Set spdlog level to `debug` when deprecated `--verbose` flag is present