### PR TITLE
Update location of pip packages in tiledbvcf-py docker image

### DIFF
--- a/docker/Dockerfile-py
+++ b/docker/Dockerfile-py
@@ -47,8 +47,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     && apt-get purge -y \
     && rm -rf /var/lib/apt/lists*
 
-RUN pip install --user pandas cython
-
+# avoid --home to prevent issues with singularity
+RUN pip install --no-cache-dir pandas cython
 
 # Build arrow
 ENV ARROW_HOME=/usr/local


### PR DESCRIPTION
This removes `pip`'s `--user` flag to avoid installing packages in the user's home directory, which cannot be found when running via `singularity`.  

Thanks to @alexander-stuckey for reporting. 