### PR TITLE
Change TSV export prefix for FORMAT fields

### DIFF
--- a/libtiledbvcf/cmake/Modules/FindCatch_EP.cmake
+++ b/libtiledbvcf/cmake/Modules/FindCatch_EP.cmake
@@ -48,8 +48,8 @@ if (NOT CATCH_FOUND AND SUPERBUILD)
   message(STATUS "Adding Catch as an external project")
   ExternalProject_Add(ep_catch
     PREFIX "externals"
-    URL "https://github.com/catchorg/Catch2/archive/v2.13.1.zip"
-    URL_HASH SHA1=7efd0a2ac05b61649153c6279bfc9554b2c02195
+    URL "https://github.com/catchorg/Catch2/archive/v2.13.7.zip"
+    URL_HASH SHA1=c167985cc91899ecaba3bce924acf1563b15284a
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ""

--- a/libtiledbvcf/src/cli/tiledbvcf.cc
+++ b/libtiledbvcf/src/cli/tiledbvcf.cc
@@ -544,7 +544,7 @@ void add_export(CLI::App& app) {
          "the TSV. A field name can be one of 'SAMPLE', 'ID', 'REF', "
          "'ALT', 'QUAL', 'POS', 'CHR', 'FILTER'. Additionally, INFO "
          "fields can be specified by 'I:<name>' and FMT fields with "
-         "'S:<name>'. To export the intersecting query region for each "
+         "'F:<name>'. To export the intersecting query region for each "
          "row in the output, use the field names 'Q:POS', 'Q:END' and "
          "'Q:LINE'.")
       ->delimiter(',');

--- a/libtiledbvcf/src/read/tsv_exporter.cc
+++ b/libtiledbvcf/src/read/tsv_exporter.cc
@@ -53,7 +53,10 @@ TSVExporter::TSVExporter(
         output_fields_.emplace_back(OutputField::Type::Info, name);
       } else if (utils::starts_with(f, "F:")) {
         need_headers_ = true;
-        output_fields_.emplace_back(OutputField::Type::Fmt, name);
+        output_fields_.emplace_back(OutputField::Type::FmtF, name);
+      } else if (utils::starts_with(f, "S:")) {
+        need_headers_ = true;
+        output_fields_.emplace_back(OutputField::Type::FmtS, name);
       } else if (utils::starts_with(f, "Q:")) {
         output_fields_.emplace_back(OutputField::Type::Query, name);
       } else {
@@ -168,7 +171,8 @@ bool TSVExporter::export_record(
         }
         break;
       }
-      case OutputField::Type::Fmt: {
+      case OutputField::Type::FmtF:
+      case OutputField::Type::FmtS: {
         int tag_id = bcf_hdr_id2int(hdr, BCF_DT_ID, field.name.c_str());
         if (!bcf_hdr_idinfo_exists(hdr, BCF_HL_FMT, tag_id))
           throw std::runtime_error(
@@ -285,8 +289,11 @@ void TSVExporter::init_output_stream() {
       case OutputField::Type::Info:
         os << "I:";
         break;
-      case OutputField::Type::Fmt:
+      case OutputField::Type::FmtF:
         os << "F:";
+        break;
+      case OutputField::Type::FmtS:
+        os << "S:";
         break;
       case OutputField::Type::Query:
         os << "Q:";

--- a/libtiledbvcf/src/read/tsv_exporter.cc
+++ b/libtiledbvcf/src/read/tsv_exporter.cc
@@ -51,7 +51,7 @@ TSVExporter::TSVExporter(
       if (utils::starts_with(f, "I:")) {
         need_headers_ = true;
         output_fields_.emplace_back(OutputField::Type::Info, name);
-      } else if (utils::starts_with(f, "S:")) {
+      } else if (utils::starts_with(f, "F:")) {
         need_headers_ = true;
         output_fields_.emplace_back(OutputField::Type::Fmt, name);
       } else if (utils::starts_with(f, "Q:")) {
@@ -286,7 +286,7 @@ void TSVExporter::init_output_stream() {
         os << "I:";
         break;
       case OutputField::Type::Fmt:
-        os << "S:";
+        os << "F:";
         break;
       case OutputField::Type::Query:
         os << "Q:";

--- a/libtiledbvcf/src/read/tsv_exporter.h
+++ b/libtiledbvcf/src/read/tsv_exporter.h
@@ -59,7 +59,7 @@ class TSVExporter : public Exporter {
 
  private:
   struct OutputField {
-    enum class Type { Regular, Info, Fmt, Query };
+    enum class Type { Regular, Info, FmtF, FmtS, Query };
     OutputField(Type type, const std::string& name)
         : type(type)
         , name(name) {

--- a/libtiledbvcf/test/run-cli-tests.sh
+++ b/libtiledbvcf/test/run-cli-tests.sh
@@ -311,6 +311,17 @@ EOF
 ) || exit 1
 rm -f /tmp/pfx.tsv
 
+echo "Export records with a null fmt attribute with old FORMAT prefix (S:)"
+$tilevcf export -u ingested_null_attr -Ot -tPOS,S:MIN_DP -r1:69511-69512 -v -o pfx.tsv -d /tmp/ || exit 1
+diff -uw /tmp/pfx.tsv <(
+cat <<EOF
+SAMPLE	POS	S:MIN_DP
+HG00280	69511	.
+HG00280	69512	24
+EOF
+) || exit 1
+rm -f /tmp/pfx.tsv
+
 echo "Export non-contiguous samples (#79)"
 $tilevcf export -u ingested_3_samples -Ob -v -s G1,G3 || exit 1
 rm -f G{1,3}.bcf

--- a/libtiledbvcf/test/run-cli-tests.sh
+++ b/libtiledbvcf/test/run-cli-tests.sh
@@ -301,10 +301,10 @@ rm -f HG00280.vcf HG01762.vcf region-map.txt $upload_dir/*
 
 echo "Export records with a null fmt attribute (#142)"
 create_register_ingest ingested_null_attr ${input_dir}/small3.bcf ${input_dir}/small.bcf
-$tilevcf export -u ingested_null_attr -Ot -tPOS,S:MIN_DP -r1:69511-69512 -v -o pfx.tsv -d /tmp/ || exit 1
+$tilevcf export -u ingested_null_attr -Ot -tPOS,F:MIN_DP -r1:69511-69512 -v -o pfx.tsv -d /tmp/ || exit 1
 diff -uw /tmp/pfx.tsv <(
 cat <<EOF
-SAMPLE	POS	S:MIN_DP
+SAMPLE	POS	F:MIN_DP
 HG00280	69511	.
 HG00280	69512	24
 EOF


### PR DESCRIPTION
Change the TSV export prefix for `FORMAT` fields from `S:`  to `F:`.

[sc-11687]
