### PR TITLE
Fix issue with legacy ingestion option

### DIFF
--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -509,8 +509,8 @@ std::pair<uint64_t, uint64_t> Writer::ingest_samples(
     }
 
     workers[i]->init(*dataset_, params, samples);
-    workers[i]->set_max_total_buffer_size_bytes(
-        params.max_tiledb_buffer_size_mb * 1024 * 1024);
+    workers[i]->set_max_total_buffer_size_mb(
+        params.max_tiledb_buffer_size_mb);
   }
 
   // First compose the set of contigs that are nonempty.
@@ -635,8 +635,8 @@ std::pair<uint64_t, uint64_t> Writer::ingest_samples_v4(
     workers[i] = std::unique_ptr<WriterWorker>(new WriterWorkerV4(i));
 
     workers[i]->init(*dataset_, params, samples);
-    workers[i]->set_max_total_buffer_size_bytes(
-        params.max_tiledb_buffer_size_mb * 1024 * 1024);
+    workers[i]->set_max_total_buffer_size_mb(
+        params.max_tiledb_buffer_size_mb);
   }
 
   // First compose the set of contigs that are nonempty.
@@ -762,10 +762,11 @@ std::pair<uint64_t, uint64_t> Writer::ingest_samples_v4(
     return {0, 0};
 
   // Estimate the number of records that will fill the output buffer
-  uint32_t output_buffer_records =
-      (params.max_tiledb_buffer_size_mb << 20) / params.avg_vcf_record_size;
+  float output_buffer_records =
+      1024.0 * 1024.0 * params.max_tiledb_buffer_size_mb / params.avg_vcf_record_size;
 
   LOG_DEBUG("Output buffer records = {}", output_buffer_records);
+  assert(output_buffer_records > 0 && output_buffer_records < UINT32_MAX);
 
   if (params.use_legacy_thread_task_size) {
     LOG_INFO(

--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -509,8 +509,7 @@ std::pair<uint64_t, uint64_t> Writer::ingest_samples(
     }
 
     workers[i]->init(*dataset_, params, samples);
-    workers[i]->set_max_total_buffer_size_mb(
-        params.max_tiledb_buffer_size_mb);
+    workers[i]->set_max_total_buffer_size_mb(params.max_tiledb_buffer_size_mb);
   }
 
   // First compose the set of contigs that are nonempty.
@@ -635,8 +634,7 @@ std::pair<uint64_t, uint64_t> Writer::ingest_samples_v4(
     workers[i] = std::unique_ptr<WriterWorker>(new WriterWorkerV4(i));
 
     workers[i]->init(*dataset_, params, samples);
-    workers[i]->set_max_total_buffer_size_mb(
-        params.max_tiledb_buffer_size_mb);
+    workers[i]->set_max_total_buffer_size_mb(params.max_tiledb_buffer_size_mb);
   }
 
   // First compose the set of contigs that are nonempty.
@@ -762,8 +760,9 @@ std::pair<uint64_t, uint64_t> Writer::ingest_samples_v4(
     return {0, 0};
 
   // Estimate the number of records that will fill the output buffer
-  float output_buffer_records =
-      1024.0 * 1024.0 * params.max_tiledb_buffer_size_mb / params.avg_vcf_record_size;
+  float output_buffer_records = 1024.0 * 1024.0 *
+                                params.max_tiledb_buffer_size_mb /
+                                params.avg_vcf_record_size;
 
   LOG_DEBUG("Output buffer records = {}", output_buffer_records);
   assert(output_buffer_records > 0 && output_buffer_records < UINT32_MAX);

--- a/libtiledbvcf/src/write/writer_worker.h
+++ b/libtiledbvcf/src/write/writer_worker.h
@@ -106,15 +106,15 @@ class WriterWorker {
   /** Region being parsed. */
   Region region_;
 
-  /** max bytes to buffer before flushing to TileDB. */
-  uint64_t max_total_buffer_size_bytes_;
+  /** max MiB to buffer before flushing to TileDB. */
+  uint64_t max_total_buffer_size_mb_;
 
   /**
-   * Set the max buffer size in bytes for worker
+   * Set the max buffer size in MiB for worker
    * @param size
    */
-  void set_max_total_buffer_size_bytes(uint64_t size) {
-    max_total_buffer_size_bytes_ = size;
+  void set_max_total_buffer_size_mb(uint64_t size) {
+    max_total_buffer_size_mb_ = size;
   }
 };
 

--- a/libtiledbvcf/src/write/writer_worker_v2.cc
+++ b/libtiledbvcf/src/write/writer_worker_v2.cc
@@ -283,9 +283,9 @@ bool WriterWorkerV2::buffer_record(
   else
     anchors_buffered_++;
 
-  // TODO: make this max buffer size check a parameter.
-  const uint64_t buffer_size = buffers_.total_size();
-  if (buffer_size > max_total_buffer_size_bytes_) {
+  // Return false if buffers are full
+  const uint64_t buffer_size_mb = buffers_.total_size() >> 20;
+  if (buffer_size_mb > max_total_buffer_size_mb_) {
     return false;
   }
 

--- a/libtiledbvcf/src/write/writer_worker_v3.cc
+++ b/libtiledbvcf/src/write/writer_worker_v3.cc
@@ -314,9 +314,9 @@ bool WriterWorkerV3::buffer_record(
   else
     anchors_buffered_++;
 
-  // TODO: make this max buffer size check a parameter.
-  const uint64_t buffer_size = buffers_.total_size();
-  if (buffer_size > max_total_buffer_size_bytes_) {
+  // Return false if buffers are full
+  const uint64_t buffer_size_mb = buffers_.total_size() >> 20;
+  if (buffer_size_mb > max_total_buffer_size_mb_) {
     return false;
   }
 

--- a/libtiledbvcf/src/write/writer_worker_v4.cc
+++ b/libtiledbvcf/src/write/writer_worker_v4.cc
@@ -336,8 +336,8 @@ bool WriterWorkerV4::buffer_record(const RecordHeapV4::Node& node) {
     anchors_buffered_++;
 
   // Return false if buffers are full
-  const uint64_t buffer_size = buffers_.total_size();
-  if (buffer_size > max_total_buffer_size_bytes_) {
+  const uint64_t buffer_size_mb = buffers_.total_size() >> 20;
+  if (buffer_size_mb > max_total_buffer_size_mb_) {
     return false;
   }
 


### PR DESCRIPTION
Fix issue where setting the ingestion legacy option `--mem-budget-mb` to a value >4GB resulted in 0 records being ingested.