### PR TITLE
Spark warning if create time attribute does not exist in VCF headers

### DIFF
--- a/apis/java/src/main/java/io/tiledb/libvcfnative/VCFReader.java
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/VCFReader.java
@@ -6,9 +6,12 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
+import java.util.logging.Logger;
 
 /** This class wraps the low level TileDB-VCF C API with a Java API. */
 public class VCFReader implements AutoCloseable {
+  static Logger log = Logger.getLogger(VCFReader.class.getName());
+
   private long readerPtr;
 
   private class BufferInfo {
@@ -146,7 +149,14 @@ public class VCFReader implements AutoCloseable {
       int j;
       for (j = 0; j < nameBytes.length && nameBytes[j] != 0; j++) {}
       String name = new String(nameBytes, 0, j);
-      res.put(name, getAttributeDatatype(name));
+      try {
+        res.put(name, getAttributeDatatype(name));
+      } catch (Exception e) {
+        log.warning(
+            String.format(
+                "Could not get datatype for attribute %s, if this is a info/fmt, it might not might not exist in header",
+                name));
+      }
     }
 
     return res;
@@ -172,7 +182,14 @@ public class VCFReader implements AutoCloseable {
       int j;
       for (j = 0; j < nameBytes.length && nameBytes[j] != 0; j++) {}
       String name = new String(nameBytes, 0, j);
-      res.put(name, getAttributeDatatype(name));
+      try {
+        res.put(name, getAttributeDatatype(name));
+      } catch (Exception e) {
+        log.warning(
+            String.format(
+                "Could not get datatype for attribute %s, if this is a info/fmt, it might not might not exist in header",
+                name));
+      }
     }
 
     return res;
@@ -197,7 +214,14 @@ public class VCFReader implements AutoCloseable {
       int j;
       for (j = 0; j < nameBytes.length && nameBytes[j] != 0; j++) {}
       String name = new String(nameBytes, 0, j);
-      res.put(name, getAttributeDatatype(name));
+      try {
+        res.put(name, getAttributeDatatype(name));
+      } catch (Exception e) {
+        log.warning(
+            String.format(
+                "Could not get datatype for attribute %s, if this is a info/fmt, it might not might not exist in header",
+                name));
+      }
     }
 
     return res;
@@ -222,7 +246,14 @@ public class VCFReader implements AutoCloseable {
       int j;
       for (j = 0; j < nameBytes.length && nameBytes[j] != 0; j++) {}
       String name = new String(nameBytes, 0, j);
-      res.put(name, getAttributeDatatype(name));
+      try {
+        res.put(name, getAttributeDatatype(name));
+      } catch (Exception e) {
+        log.warning(
+            String.format(
+                "Could not get datatype for attribute %s, if this is a info/fmt, it might not might not exist in header",
+                name));
+      }
     }
 
     return res;
@@ -485,11 +516,8 @@ public class VCFReader implements AutoCloseable {
         LibVCFNative.tiledb_vcf_reader_get_attribute_type(
             this.readerPtr, attribute, datatype, varLen, nullable, list);
     if (rc != 0) {
-      // Warn instead of throwing an error in case an attribute specified during 
-      // dataset creation does not exist in the VCF data
       String msg = getLastErrorMessage();
-      System.out.println("WARNING: " + msg);
-      return new AttributeTypeInfo(AttributeDatatype.UINT8, false, false, false);
+      throw new RuntimeException("Error getting attribute datatype: " + msg);
     }
 
     boolean isVarLen = varLen[0] == 1;

--- a/apis/java/src/main/java/io/tiledb/libvcfnative/VCFReader.java
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/VCFReader.java
@@ -485,8 +485,11 @@ public class VCFReader implements AutoCloseable {
         LibVCFNative.tiledb_vcf_reader_get_attribute_type(
             this.readerPtr, attribute, datatype, varLen, nullable, list);
     if (rc != 0) {
+      // Warn instead of throwing an error in case an attribute specified during 
+      // dataset creation does not exist in the VCF data
       String msg = getLastErrorMessage();
-      throw new RuntimeException("Error getting attribute datatype: " + msg);
+      System.out.println("WARNING: " + msg);
+      return new AttributeTypeInfo(AttributeDatatype.UINT8, false, false, false);
     }
 
     boolean isVarLen = varLen[0] == 1;


### PR DESCRIPTION
Currently, Spark generates an error when opening a dataset created with materialized fmt/info attributes that are not present in the ingested VCF data. This PR converts the error to a warning.