### PR TITLE
Enable verbose logging and catch arrow errors in python API

### DIFF
--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pyarrow as pa
 import sys
 import warnings
 
@@ -253,7 +254,10 @@ class Dataset(object):
             raise Exception("Dataset not open in read mode")
 
         self.reader.read(release_buffers)
-        table = self.reader.get_results_arrow()
+        try:
+            table = self.reader.get_results_arrow()
+        except:
+            table = pa.Table.from_pandas(pd.DataFrame())
         return table
 
     def read_completed(self):

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -2394,6 +2394,8 @@ void Reader::info_attribute_name(int32_t index, char** name) {
 
 void Reader::set_verbose(const bool& verbose) {
   params_.verbose = verbose;
+  LOG_CONFIG("debug");
+  LOG_INFO("Verbose mode enabled");
 }
 
 void Reader::set_tiledb_query_config() {

--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -1222,6 +1222,8 @@ void Writer::set_scratch_space(const std::string& path, uint64_t size) {
 
 void Writer::set_verbose(const bool& verbose) {
   ingestion_params_.verbose = verbose;
+  LOG_CONFIG("debug");
+  LOG_INFO("Verbose mode enabled");
 }
 
 void Writer::set_tiledb_stats_enabled(bool stats_enabled) {


### PR DESCRIPTION
* Enable `log-level=debug` when the `verbose` option is set in python.
* Catch errors from arrow and return an empty Table

[sc12783]