### PR TITLE
Fix verbose toggle for APIs

### DIFF
--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -2394,8 +2394,10 @@ void Reader::info_attribute_name(int32_t index, char** name) {
 
 void Reader::set_verbose(const bool& verbose) {
   params_.verbose = verbose;
-  LOG_CONFIG("debug");
-  LOG_INFO("Verbose mode enabled");
+  if (verbose) {
+    LOG_CONFIG("debug");
+    LOG_INFO("Verbose mode enabled");
+  }
 }
 
 void Reader::set_tiledb_query_config() {

--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -1222,8 +1222,10 @@ void Writer::set_scratch_space(const std::string& path, uint64_t size) {
 
 void Writer::set_verbose(const bool& verbose) {
   ingestion_params_.verbose = verbose;
-  LOG_CONFIG("debug");
-  LOG_INFO("Verbose mode enabled");
+  if (verbose) {
+    LOG_CONFIG("debug");
+    LOG_INFO("Verbose mode enabled");
+  }
 }
 
 void Writer::set_tiledb_stats_enabled(bool stats_enabled) {


### PR DESCRIPTION
The `verbose` argument is currently ignored by the Python API and presumably others.
