### PR TITLE
Add option to ingest chromosomes and pseudo-contigs separately

### DIFF
--- a/libtiledbvcf/src/cli/tiledbvcf.cc
+++ b/libtiledbvcf/src/cli/tiledbvcf.cc
@@ -232,6 +232,11 @@ std::map<std::string, ExportFormat> format_map{
     {"v", ExportFormat::VCF},
     {"t", ExportFormat::TSV}};
 
+std::map<std::string, IngestionParams::ContigMode> contig_mode_map{
+    {"all", IngestionParams::ContigMode::ALL},
+    {"separate", IngestionParams::ContigMode::SEPARATE},
+    {"merged", IngestionParams::ContigMode::MERGED}};
+
 // add helper functions to CLI::detail namespace
 namespace CLI {
 namespace detail {
@@ -269,6 +274,18 @@ std::ostream& operator<<(std::ostream& os, const tiledb_filter_type_t& value) {
 
 std::ostream& operator<<(std::ostream& os, const ExportFormat& value) {
   for (auto it : format_map) {
+    if (it.second == value) {
+      os << it.first;
+      return os;
+    }
+  }
+  os << "UNKNOWN";
+  return os;
+}
+
+std::ostream& operator<<(
+    std::ostream& os, const IngestionParams::ContigMode& value) {
+  for (auto it : contig_mode_map) {
     if (it.second == value) {
       os << it.first;
       return os;
@@ -554,6 +571,12 @@ void add_store(CLI::App& app) {
       ->delimiter(',')
       ->excludes("--disable-contig-fragment-merging")
       ->excludes("--contigs-to-keep-separate");
+  cmd->add_option(
+         "--contig-mode",
+         args->contig_mode,
+         "Select which contigs are ingested: 'separate', 'merged', or 'all' "
+         "contigs")
+      ->transform(CLI::CheckedTransformer(contig_mode_map));
 
   cmd->option_defaults()->group("Debug options");
   add_logging_options(cmd, args->log_level, args->log_file);

--- a/libtiledbvcf/src/write/writer.h
+++ b/libtiledbvcf/src/write/writer.h
@@ -454,6 +454,8 @@ class Writer {
    * @return true if contig is allowed to be merged based on whitelist/blacklist
    */
   bool check_contig_mergeable(const std::string& contig);
+
+  int get_merged_fragment_index(const std::string& contig);
 };
 
 }  // namespace vcf

--- a/libtiledbvcf/src/write/writer.h
+++ b/libtiledbvcf/src/write/writer.h
@@ -455,6 +455,12 @@ class Writer {
    */
   bool check_contig_mergeable(const std::string& contig);
 
+  /**
+   * @brief Get the merged fragment index for the contig
+   *
+   * @param contig Contig name
+   * @return int Merged fragment index
+   */
   int get_merged_fragment_index(const std::string& contig);
 };
 

--- a/libtiledbvcf/src/write/writer.h
+++ b/libtiledbvcf/src/write/writer.h
@@ -138,6 +138,14 @@ struct IngestionParams {
   // fragments By default we use the blacklist since usually there are less
   // non-mergeable contigs
   std::set<std::string> contigs_to_allow_merging = {};
+
+  enum class ContigMode { ALL, SEPARATE, MERGED };
+
+  // Controls which contigs are ingested:
+  //  ALL = all contigs
+  //  SEPARATE = contigs in the contigs_to_keep_separate
+  //  MERGED = contigs not in the contigs_to_keep_separate
+  ContigMode contig_mode = ContigMode::ALL;
 };
 
 /* ********************************* */


### PR DESCRIPTION
Add an option to ingest chromosomes and pseudo-contigs separately. Since pseudo-contigs are smaller, they can be ingested in larger batches, which reduces the total fragment count.

The new option for `tiledbvcf store`:
* `--contig-mode all` : Default. Ingest all contigs, no change in existing behavior.
* `--contig-mode separate`: Ingest contigs in the `contigs-to-keep-separate` list, human chromosomes by default.
* `--contig-mode merged`: Ingest contigs not in the `contigs-to-keep-separate` list and merge them into fragments that do not overlap the human chromosomes.

[sc-14684]