### PR TITLE
Remove error when an incomplete query has 0 results

### DIFF
--- a/ci/native_libs-linux_osx.yml
+++ b/ci/native_libs-linux_osx.yml
@@ -72,9 +72,9 @@ steps:
 
 
         if [[ ( "$AGENT_OS" == "Linux" ) ]]; then
-          cp $BUILD_REPOSITORY_LOCALPATH/libtiledbvcf/build/externals/install/lib/*.so $BUILD_BINARIESDIRECTORY
-          cp $BUILD_REPOSITORY_LOCALPATH/dist/lib/*.so $BUILD_BINARIESDIRECTORY
-          cp $BUILD_REPOSITORY_LOCALPATH/apis/java/build/install/lib/*.so $BUILD_BINARIESDIRECTORY
+          cp $BUILD_REPOSITORY_LOCALPATH/libtiledbvcf/build/externals/install/lib/*.so* $BUILD_BINARIESDIRECTORY
+          cp $BUILD_REPOSITORY_LOCALPATH/dist/lib/*.so* $BUILD_BINARIESDIRECTORY
+          cp $BUILD_REPOSITORY_LOCALPATH/apis/java/build/install/lib/*.so* $BUILD_BINARIESDIRECTORY
         fi
 
         if [[ ( "$AGENT_OS" == "Darwin" ) ]]; then

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -994,14 +994,13 @@ bool Reader::read_current_batch() {
 
     read_state_.cell_idx = 0;
 
+    // TODO: This condition is normal in TileDB 2.5-2.6, revisit in 2.7+
+    /*
     if (read_state_.query_results.num_cells() == 0 &&
         read_state_.query_results.query_status() ==
             tiledb::Query::Status::INCOMPLETE)
-      throw std::runtime_error(
-          "Error exporting region on sample range " +
-          std::to_string(read_state_.sample_min) + "-" +
-          std::to_string(read_state_.sample_max) +
-          "; incomplete TileDB query with 0 results.");
+      throw std::runtime_error("Incomplete TileDB query with 0 results.");
+    */
 
     // Process the query results.
     auto old_num_exported = read_state_.last_num_records_exported;


### PR DESCRIPTION
Before TileDB 2.5, an incomplete query that returned 0 results was an error condition and TileDB-VCF threw an error. In TileDB 2.5 - 2.6, an incomplete query that returns 0 results is a normal condition, so this PR removes the TileDB-VCF error.

This PR also includes a small change to add missing native libraries to the Spark jar file.

[sc-15261]
[sc-15262]
