### PR TITLE
Remove lower bound limit for buffer sizes

### DIFF
--- a/apis/java/src/main/java/io/tiledb/libvcfnative/VCFReader.java
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/VCFReader.java
@@ -328,9 +328,6 @@ public class VCFReader implements AutoCloseable {
   }
 
   public VCFReader setMemoryBudget(Integer mb) {
-    if (mb < 1) {
-      throw new RuntimeException("memory budget must be >= 1 MB");
-    }
     int rc = LibVCFNative.tiledb_vcf_reader_set_memory_budget(this.readerPtr, mb);
     if (rc != 0) {
       String msg = getLastErrorMessage();

--- a/apis/python/src/tiledbvcf/binding/reader.cc
+++ b/apis/python/src/tiledbvcf/binding/reader.cc
@@ -208,10 +208,6 @@ void Reader::alloc_buffers(const bool release_buffs) {
     alloc_size_bytes = 10;  // Some small value
   } else {
     alloc_size_bytes = (budget_mb * 1024 * 1024) / num_buffers;
-    if (alloc_size_bytes < (10 * 1024 * 1024))
-      throw std::runtime_error(
-          "TileDB-VCF-Py: buffer allocation size is below the minimum of 10MB. "
-          "Try increasing the memory budget.");
   }
 
   for (const auto& attr : attributes_) {


### PR DESCRIPTION
There are cases where users have a lot of fields and are selecting only a handful of records. For those we shouldn't block on needing 10MB per field.