### PR TITLE
Consolidate and vacuum commits

### DIFF
--- a/libtiledbvcf/src/cli/tiledbvcf.cc
+++ b/libtiledbvcf/src/cli/tiledbvcf.cc
@@ -164,6 +164,19 @@ void do_stat(const StatParams& args, const CLI::App& cmd) {
 }
 
 /** Utils. */
+void do_utils_consolidate_commits(
+    const UtilsParams& args, const CLI::App& cmd) {
+  LOG_TRACE("Starting utils consolidate commits command.");
+  config_to_log(cmd);
+  utils::set_htslib_tiledb_context(args.tiledb_config);
+  tiledb::Config cfg;
+  utils::set_tiledb_config(args.tiledb_config, &cfg);
+  TileDBVCFDataset dataset(cfg);
+  dataset.open(args.uri, args.tiledb_config);
+  dataset.consolidate_commits(args);
+  LOG_TRACE("Finished utils consolidate commits command.");
+}
+
 void do_utils_consolidate_fragments(
     const UtilsParams& args, const CLI::App& cmd) {
   LOG_TRACE("Starting utils consolidate fragments command.");
@@ -188,6 +201,18 @@ void do_utils_consolidate_fragment_metadata(
   dataset.open(args.uri, args.tiledb_config);
   dataset.consolidate_fragment_metadata(args);
   LOG_TRACE("Finished utils consolidate fragment metadata command.");
+}
+
+void do_utils_vacuum_commits(const UtilsParams& args, const CLI::App& cmd) {
+  LOG_TRACE("Starting utils vacuum commits command.");
+  config_to_log(cmd);
+  utils::set_htslib_tiledb_context(args.tiledb_config);
+  tiledb::Config cfg;
+  utils::set_tiledb_config(args.tiledb_config, &cfg);
+  TileDBVCFDataset dataset(cfg);
+  dataset.open(args.uri, args.tiledb_config);
+  dataset.vacuum_commits(args);
+  LOG_TRACE("Finished utils vacuum commits command.");
 }
 
 void do_utils_vacuum_fragments(const UtilsParams& args, const CLI::App& cmd) {
@@ -809,6 +834,12 @@ void add_utils(CLI::App& app) {
       cmd->add_subcommand("consolidate", "Consolidate TileDB-VCF dataset");
   c_cmd->require_subcommand(1, 1);
 
+  auto c_c_cmd = c_cmd->add_subcommand(
+      "commits", "Consolidate TileDB-VCF dataset commits");
+  add_util_options(c_c_cmd, *args);
+  c_c_cmd->callback(
+      [args, cmd]() { do_utils_consolidate_commits(*args, *cmd); });
+
   auto c_f_cmd = c_cmd->add_subcommand(
       "fragments", "Consolidate TileDB-VCF dataset fragments");
   add_util_options(c_f_cmd, *args);
@@ -823,6 +854,11 @@ void add_utils(CLI::App& app) {
 
   auto v_cmd = cmd->add_subcommand("vacuum", "Vacuum TileDB-VCF dataset");
   v_cmd->require_subcommand(1, 1);
+
+  auto v_c_cmd =
+      v_cmd->add_subcommand("commits", "Vacuum TileDB-VCF dataset commits");
+  add_util_options(v_c_cmd, *args);
+  v_c_cmd->callback([args, cmd]() { do_utils_vacuum_commits(*args, *cmd); });
 
   auto v_f_cmd =
       v_cmd->add_subcommand("fragments", "Vacuum TileDB-VCF dataset fragments");

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -495,6 +495,25 @@ class TileDBVCFDataset {
   void set_tiledb_stats_enabled_vcf_header(const bool stats_enabled);
 
   /**
+   * Consolidate commits of the vcf header array
+   * @param params
+   */
+  void consolidate_vcf_header_array_commits(const UtilsParams& params);
+
+  /**
+   * Consolidate commits of the data array
+   * @param params
+   */
+  void consolidate_data_array_commits(const UtilsParams& params);
+
+  /**
+   * Consolidate commits of all arrays (vcf header array and data
+   * array)
+   * @param params
+   */
+  void consolidate_commits(const UtilsParams& params);
+
+  /**
    * Consolidate fragment metadata of the vcf header array
    * @param params
    */
@@ -531,6 +550,24 @@ class TileDBVCFDataset {
    * @param params
    */
   void consolidate_fragments(const UtilsParams& params);
+
+  /**
+   * Vacuum commits of the vcf header array
+   * @param params
+   */
+  void vacuum_vcf_header_array_commits(const UtilsParams& params);
+
+  /**
+   * Vacuum commits of the data array
+   * @param params
+   */
+  void vacuum_data_array_commits(const UtilsParams& params);
+
+  /**
+   * Vacuum fragment metadata of all arrays (vcf header array and data array)
+   * @param params
+   */
+  void vacuum_commits(const UtilsParams& params);
 
   /**
    * Vacuum fragment metadata of the vcf header array


### PR DESCRIPTION
Add capability to consolidate and vacuum commits, which is a new feature in TileDB 2.8.