### PR TITLE
Fix global order of anchors at region boundaries

### DIFF
--- a/libtiledbvcf/cmake/Modules/FindTileDB_EP.cmake
+++ b/libtiledbvcf/cmake/Modules/FindTileDB_EP.cmake
@@ -48,20 +48,20 @@ else()
     # Try to download prebuilt artifacts unless the user specifies to build from source
     if(DOWNLOAD_TILEDB_PREBUILT)
         if (WIN32) # Windows
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.8.0/tiledb-windows-x86_64-2.8.0-f8efd39.zip")
-          SET(DOWNLOAD_SHA1 "ee28b243e1b025a1966643a4c924cb7485418285")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.8.2/tiledb-windows-x86_64-2.8.2-6f382df.zip")
+          SET(DOWNLOAD_SHA1 "32d8eddaacf017b99d96f04746484d5a23974e9d")
         elseif(APPLE) # OSX
 
           if (CMAKE_OSX_ARCHITECTURES STREQUAL x86_64 OR CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(AMD64|amd64)|(^i.86$)")
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.8.0/tiledb-macos-x86_64-2.8.0-f8efd39.tar.gz")
-            SET(DOWNLOAD_SHA1 "6e6033b26bcea96b8a9d0948833958d5e8609e56")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.8.2/tiledb-macos-x86_64-2.8.2-6f382df.tar.gz")
+            SET(DOWNLOAD_SHA1 "6852e8829117dcab6e89067e4c1a26c7b151ccf2")
           elseif (CMAKE_OSX_ARCHITECTURES STREQUAL arm64 OR CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.8.0/tiledb-macos-arm64-2.8.0-f8efd39.tar.gz")
-            SET(DOWNLOAD_SHA1 "9b31a221906e10da8a88e1a54e74c52ee1b19d2c")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.8.2/tiledb-macos-arm64-2.8.2-6f382df.tar.gz")
+            SET(DOWNLOAD_SHA1 "8012c122866077a442f37bd824b3429dc4c193ac")
           endif()
         else() # Linux
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.8.0/tiledb-linux-x86_64-2.8.0-f8efd39.tar.gz")
-          SET(DOWNLOAD_SHA1 "8fe5e69d825829f10a4c35f529a9839da0c254b0")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.8.2/tiledb-linux-x86_64-2.8.2-6f382df.tar.gz")
+          SET(DOWNLOAD_SHA1 "9af5c8db1b5e7d7f16e39976aa433544bc78e7ec")
         endif()
 
         ExternalProject_Add(ep_tiledb
@@ -83,8 +83,8 @@ else()
     else() # Build from source
         ExternalProject_Add(ep_tiledb
           PREFIX "externals"
-          URL "https://github.com/TileDB-Inc/TileDB/archive/2.8.0.zip"
-          URL_HASH SHA1=490ccbbe882a1f1a90d0ca81abecb3612d0d8cc1
+          URL "https://github.com/TileDB-Inc/TileDB/archive/2.8.2.zip"
+          URL_HASH SHA1=1dbc27bb900696f1b5e9b96975019ceafea0dc00
           DOWNLOAD_NAME "tiledb.zip"
           CMAKE_ARGS
             -DCMAKE_INSTALL_PREFIX=${EP_INSTALL_PREFIX}

--- a/libtiledbvcf/src/write/record_heap_v4.cc
+++ b/libtiledbvcf/src/write/record_heap_v4.cc
@@ -40,7 +40,7 @@ bool RecordHeapV4::empty() const {
 }
 
 void RecordHeapV4::insert(
-    VCFV4* vcf,
+    std::shared_ptr<VCFV4> vcf,
     NodeType type,
     SafeSharedBCFRec record,
     const std::string& contig,
@@ -72,12 +72,27 @@ void RecordHeapV4::insert(
   heap_.push(std::move(node));
 }
 
+void RecordHeapV4::insert(const Node& node) {
+  insert(
+      node.vcf,
+      node.type,
+      node.record,
+      node.contig,
+      node.start_pos,
+      node.end_pos,
+      node.sample_name);
+}
+
 const RecordHeapV4::Node& RecordHeapV4::top() const {
   return *heap_.top();
 }
 
 void RecordHeapV4::pop() {
   heap_.pop();
+}
+
+size_t RecordHeapV4::size() {
+  return heap_.size();
 }
 
 }  // namespace vcf

--- a/libtiledbvcf/src/write/record_heap_v4.h
+++ b/libtiledbvcf/src/write/record_heap_v4.h
@@ -48,7 +48,7 @@ class RecordHeapV4 {
         , sample_name() {
     }
 
-    VCFV4* vcf;
+    std::shared_ptr<VCFV4> vcf;
     NodeType type;
     SafeSharedBCFRec record;
     std::string contig;
@@ -62,7 +62,7 @@ class RecordHeapV4 {
   bool empty() const;
 
   void insert(
-      VCFV4* vcf,
+      std::shared_ptr<VCFV4> vcf,
       NodeType type,
       SafeSharedBCFRec record,
       const std::string& contig,
@@ -70,9 +70,13 @@ class RecordHeapV4 {
       uint32_t end_pos,
       const std::string& sample_name);
 
+  void insert(const Node& node);
+
   const Node& top() const;
 
   void pop();
+
+  size_t size();
 
  private:
   /**

--- a/libtiledbvcf/src/write/writer.h
+++ b/libtiledbvcf/src/write/writer.h
@@ -41,6 +41,7 @@
 #include "dataset/tiledbvcfdataset.h"
 #include "utils/utils.h"
 #include "vcf/htslib_value.h"
+#include "write/writer_worker_v4.h"
 
 namespace tiledb {
 namespace vcf {
@@ -48,6 +49,9 @@ namespace vcf {
 /* ********************************* */
 /*       AUXILIARY DATATYPES         */
 /* ********************************* */
+
+// Forward declaration
+class WriterWorkerV4;
 
 /** Arguments/params for dataset ingestion. */
 struct IngestionParams {
@@ -463,6 +467,13 @@ class Writer {
    * @return int Merged fragment index
    */
   int get_merged_fragment_index(const std::string& contig);
+
+  /**
+   * @brief Write anchors to a TileDB fragment.
+   *
+   * @param worker Writer worker containing the anchors.
+   */
+  size_t write_anchors(WriterWorkerV4& worker);
 };
 
 }  // namespace vcf

--- a/libtiledbvcf/src/write/writer_worker.h
+++ b/libtiledbvcf/src/write/writer_worker.h
@@ -44,6 +44,9 @@
 namespace tiledb {
 namespace vcf {
 
+// Forward declaration
+struct IngestionParams;
+
 /**
  * A WriterWorker is responsible for parsing a particular genomic region from a
  * set of VCFs, into a set of attribute buffers that will be used to submit

--- a/libtiledbvcf/test/src/unit-vcf-export.cc
+++ b/libtiledbvcf/test/src/unit-vcf-export.cc
@@ -1530,13 +1530,13 @@ TEST_CASE(
     writer.ingest_samples();
   }
 
-  // Check that there were 42 fragments created
+  // Check that there were 44 fragments created
   // Then remove the last fragment
   {
     tiledb::FragmentInfo fragmentInfo(ctx, dataset_uri + "/data");
     fragmentInfo.load();
 
-    REQUIRE(fragmentInfo.fragment_num() == 42);
+    REQUIRE(fragmentInfo.fragment_num() == 44);
 
     // Find the fragment containing contig chrX and remove it
     std::string remove_contig = "chrX";
@@ -1610,12 +1610,12 @@ TEST_CASE(
     writer.ingest_samples();
   }
 
-  // Check that there are only 42 fragments created
+  // Check that there are only 44 fragments created
   {
     tiledb::FragmentInfo fragmentInfo(ctx, dataset_uri + "/data");
     fragmentInfo.load();
 
-    REQUIRE(fragmentInfo.fragment_num() == 42);
+    REQUIRE(fragmentInfo.fragment_num() == 44);
   }
 
   // Query for record that should now exist
@@ -1679,12 +1679,12 @@ TEST_CASE(
     writer.ingest_samples();
   }
 
-  // Check that there are only 42 fragments
+  // Check that there are only 44 fragments
   {
     tiledb::FragmentInfo fragmentInfo(ctx, dataset_uri + "/data");
     fragmentInfo.load();
 
-    REQUIRE(fragmentInfo.fragment_num() == 42);
+    REQUIRE(fragmentInfo.fragment_num() == 44);
   }
 
   // Query should still return a single record
@@ -1766,13 +1766,13 @@ TEST_CASE(
     writer.ingest_samples();
   }
 
-  // Check that there were 36 fragments created
+  // Check that there were 38 fragments created
   // Then remove the last fragment
   {
     tiledb::FragmentInfo fragmentInfo(ctx, dataset_uri + "/data");
     fragmentInfo.load();
 
-    REQUIRE(fragmentInfo.fragment_num() == 36);
+    REQUIRE(fragmentInfo.fragment_num() == 38);
 
     // Find the fragment containing contig chrUn and remove it
     std::string remove_contig = "chrUn";
@@ -1846,12 +1846,12 @@ TEST_CASE(
     writer.ingest_samples();
   }
 
-  // Check that there are only 36 fragments created
+  // Check that there are only 38 fragments created
   {
     tiledb::FragmentInfo fragmentInfo(ctx, dataset_uri + "/data");
     fragmentInfo.load();
 
-    REQUIRE(fragmentInfo.fragment_num() == 36);
+    REQUIRE(fragmentInfo.fragment_num() == 38);
   }
 
   // Query for record that should now exist
@@ -1915,12 +1915,12 @@ TEST_CASE(
     writer.ingest_samples();
   }
 
-  // Check that there are only 36 fragments
+  // Check that there are only 38 fragments
   {
     tiledb::FragmentInfo fragmentInfo(ctx, dataset_uri + "/data");
     fragmentInfo.load();
 
-    REQUIRE(fragmentInfo.fragment_num() == 36);
+    REQUIRE(fragmentInfo.fragment_num() == 38);
   }
 
   // Query should still return a single record
@@ -2003,12 +2003,12 @@ TEST_CASE(
     writer.ingest_samples();
   }
 
-  // Check that there were 2 fragments created
+  // Check that there were 3 fragments created
   {
     tiledb::FragmentInfo fragmentInfo(ctx, dataset_uri + "/data");
     fragmentInfo.load();
 
-    REQUIRE(fragmentInfo.fragment_num() == 2);
+    REQUIRE(fragmentInfo.fragment_num() == 3);
   }
 
   // Query should still return a single record
@@ -2083,12 +2083,12 @@ TEST_CASE(
     writer.ingest_samples();
   }
 
-  // Check that there were 42 fragments created
+  // Check that there were 44 fragments created
   {
     tiledb::FragmentInfo fragmentInfo(ctx, dataset_uri + "/data");
     fragmentInfo.load();
 
-    REQUIRE(fragmentInfo.fragment_num() == 42);
+    REQUIRE(fragmentInfo.fragment_num() == 44);
   }
 
   // Query should still return a single record

--- a/libtiledbvcf/test/src/unit-vcf-store.cc
+++ b/libtiledbvcf/test/src/unit-vcf-store.cc
@@ -422,7 +422,7 @@ TEST_CASE("TileDB-VCF: Test Resume", "[tiledbvcf][ingest]") {
     tiledb::FragmentInfo fragmentInfo(ctx, dataset_uri + "/data");
     fragmentInfo.load();
 
-    REQUIRE(fragmentInfo.fragment_num() == 42);
+    REQUIRE(fragmentInfo.fragment_num() == 44);
 
     // Get the last fragment
     std::string uri = fragmentInfo.fragment_uri(41);
@@ -443,13 +443,13 @@ TEST_CASE("TileDB-VCF: Test Resume", "[tiledbvcf][ingest]") {
     writer.ingest_samples();
   }
 
-  // Check that there are only 42 fragments created
+  // Check that there are only 44 fragments created
   // Then remove the middle fragments (21-23)
   {
     tiledb::FragmentInfo fragmentInfo(ctx, dataset_uri + "/data");
     fragmentInfo.load();
 
-    REQUIRE(fragmentInfo.fragment_num() == 42);
+    REQUIRE(fragmentInfo.fragment_num() == 44);
 
     // Remove fragment 21
     std::string uri = fragmentInfo.fragment_uri(21);
@@ -482,12 +482,12 @@ TEST_CASE("TileDB-VCF: Test Resume", "[tiledbvcf][ingest]") {
     writer.ingest_samples();
   }
 
-  // Check that there are only 42 fragments created
+  // Check that there are only 44 fragments created
   {
     tiledb::FragmentInfo fragmentInfo(ctx, dataset_uri + "/data");
     fragmentInfo.load();
 
-    REQUIRE(fragmentInfo.fragment_num() == 42);
+    REQUIRE(fragmentInfo.fragment_num() == 44);
   }
 
   // Ingest the sample one last time, this should result in no fragment changes
@@ -502,12 +502,12 @@ TEST_CASE("TileDB-VCF: Test Resume", "[tiledbvcf][ingest]") {
     writer.ingest_samples();
   }
 
-  // Check that there are only 42 fragments created
+  // Check that there are only 44 fragments created
   {
     tiledb::FragmentInfo fragmentInfo(ctx, dataset_uri + "/data");
     fragmentInfo.load();
 
-    REQUIRE(fragmentInfo.fragment_num() == 42);
+    REQUIRE(fragmentInfo.fragment_num() == 44);
   }
 
   if (vfs.is_dir(dataset_uri))
@@ -539,15 +539,15 @@ TEST_CASE("TileDB-VCF: Test Resume Disabled", "[tiledbvcf][ingest]") {
     writer.ingest_samples();
   }
 
-  // Check that there were 42 fragments created
+  // Check that there were 44 fragments created
   {
     tiledb::FragmentInfo fragmentInfo(ctx, dataset_uri + "/data");
     fragmentInfo.load();
 
-    REQUIRE(fragmentInfo.fragment_num() == 42);
+    REQUIRE(fragmentInfo.fragment_num() == 44);
   }
 
-  // Ingest the sample a second time, we should get 84 fragments
+  // Ingest the sample a second time, we should get 88 fragments
   {
     Writer writer;
     IngestionParams params;
@@ -559,12 +559,12 @@ TEST_CASE("TileDB-VCF: Test Resume Disabled", "[tiledbvcf][ingest]") {
     writer.ingest_samples();
   }
 
-  // Check that there were 84 fragments created
+  // Check that there were 88 fragments created
   {
     tiledb::FragmentInfo fragmentInfo(ctx, dataset_uri + "/data");
     fragmentInfo.load();
 
-    REQUIRE(fragmentInfo.fragment_num() == 84);
+    REQUIRE(fragmentInfo.fragment_num() == 88);
   }
 
   if (vfs.is_dir(dataset_uri))
@@ -596,15 +596,15 @@ TEST_CASE("TileDB-VCF: Test Merging Contigs Defaults", "[tiledbvcf][ingest]") {
     writer.ingest_samples();
   }
 
-  // Check that there were 36 fragments created
+  // Check that there were 38 fragments created
   {
     tiledb::FragmentInfo fragmentInfo(ctx, dataset_uri + "/data");
     fragmentInfo.load();
 
-    REQUIRE(fragmentInfo.fragment_num() == 36);
+    REQUIRE(fragmentInfo.fragment_num() == 38);
   }
 
-  // Ingest the sample a second time, we should get 72 fragments
+  // Ingest the sample a second time, we should get 76 fragments
   {
     Writer writer;
     IngestionParams params;
@@ -616,12 +616,12 @@ TEST_CASE("TileDB-VCF: Test Merging Contigs Defaults", "[tiledbvcf][ingest]") {
     writer.ingest_samples();
   }
 
-  // Check that there were 72 fragments created
+  // Check that there were 76 fragments created
   {
     tiledb::FragmentInfo fragmentInfo(ctx, dataset_uri + "/data");
     fragmentInfo.load();
 
-    REQUIRE(fragmentInfo.fragment_num() == 72);
+    REQUIRE(fragmentInfo.fragment_num() == 76);
   }
 
   if (vfs.is_dir(dataset_uri))
@@ -655,16 +655,16 @@ TEST_CASE("TileDB-VCF: Test Resume Contig Merge", "[tiledbvcf][ingest]") {
     writer.ingest_samples();
   }
 
-  // Check that there were 36 fragments created
+  // Check that there were 38 fragments created
   // Then remove the last fragment
   {
     tiledb::FragmentInfo fragmentInfo(ctx, dataset_uri + "/data");
     fragmentInfo.load();
 
-    REQUIRE(fragmentInfo.fragment_num() == 36);
+    REQUIRE(fragmentInfo.fragment_num() == 38);
 
     // Get the last fragment
-    std::string uri = fragmentInfo.fragment_uri(35);
+    std::string uri = fragmentInfo.fragment_uri(37);
     vfs.remove_dir(uri);
     uri = std::regex_replace(uri, std::regex("__fragments"), "__commits");
     vfs.remove_file(uri + ".wrt");
@@ -684,13 +684,13 @@ TEST_CASE("TileDB-VCF: Test Resume Contig Merge", "[tiledbvcf][ingest]") {
     writer.ingest_samples();
   }
 
-  // Check that there are only 36 fragments created
+  // Check that there are only 38 fragments created
   // Then remove the middle fragments (17-19)
   {
     tiledb::FragmentInfo fragmentInfo(ctx, dataset_uri + "/data");
     fragmentInfo.load();
 
-    REQUIRE(fragmentInfo.fragment_num() == 36);
+    REQUIRE(fragmentInfo.fragment_num() == 38);
 
     // Remove fragment 17
     std::string uri = fragmentInfo.fragment_uri(17);
@@ -723,12 +723,12 @@ TEST_CASE("TileDB-VCF: Test Resume Contig Merge", "[tiledbvcf][ingest]") {
     writer.ingest_samples();
   }
 
-  // Check that there are only 36 fragments created
+  // Check that there are only 38 fragments created
   {
     tiledb::FragmentInfo fragmentInfo(ctx, dataset_uri + "/data");
     fragmentInfo.load();
 
-    REQUIRE(fragmentInfo.fragment_num() == 36);
+    REQUIRE(fragmentInfo.fragment_num() == 38);
   }
 
   // Ingest the sample one last time, this should result in no fragment changes
@@ -743,12 +743,12 @@ TEST_CASE("TileDB-VCF: Test Resume Contig Merge", "[tiledbvcf][ingest]") {
     writer.ingest_samples();
   }
 
-  // Check that there are only 36 fragments created
+  // Check that there are only 38 fragments created
   {
     tiledb::FragmentInfo fragmentInfo(ctx, dataset_uri + "/data");
     fragmentInfo.load();
 
-    REQUIRE(fragmentInfo.fragment_num() == 36);
+    REQUIRE(fragmentInfo.fragment_num() == 38);
   }
 
   if (vfs.is_dir(dataset_uri))


### PR DESCRIPTION
This PR moves anchor records for each contig (or combined contig) into a separate TileDB fragment. This change avoids an edge case where anchor records could violate the global sort order.