### PR TITLE
Consolidate variant stats array commits and fragment metadata

### DIFF
--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -2044,6 +2044,7 @@ void TileDBVCFDataset::consolidate_data_array_commits(
 void TileDBVCFDataset::consolidate_commits(const UtilsParams& params) {
   consolidate_data_array_commits(params);
   consolidate_vcf_header_array_commits(params);
+  VariantStats::consolidate_commits(ctx_, params.tiledb_config, root_uri_);
 }
 
 void TileDBVCFDataset::consolidate_vcf_header_array_fragment_metadata(
@@ -2066,6 +2067,8 @@ void TileDBVCFDataset::consolidate_fragment_metadata(
     const UtilsParams& params) {
   consolidate_data_array_fragment_metadata(params);
   consolidate_vcf_header_array_fragment_metadata(params);
+  VariantStats::consolidate_fragment_metadata(
+      ctx_, params.tiledb_config, root_uri_);
 }
 
 void TileDBVCFDataset::consolidate_vcf_header_array_fragments(

--- a/libtiledbvcf/src/dataset/variant_stats.h
+++ b/libtiledbvcf/src/dataset/variant_stats.h
@@ -75,7 +75,7 @@ class VariantStats {
    * @param checksum TileDB checksum filter
    */
   static void create(
-      Context& ctx, std::string root_uri, tiledb_filter_type_t checksum);
+      Context& ctx, const std::string& root_uri, tiledb_filter_type_t checksum);
 
   /**
    * @brief Open array and create query object.
@@ -86,7 +86,7 @@ class VariantStats {
    * @param ctx TileDB context
    * @param root_uri TileDB-VCF dataset uri
    */
-  static void init(std::shared_ptr<Context> ctx, std::string root_uri);
+  static void init(std::shared_ptr<Context> ctx, const std::string& root_uri);
 
   /**
    * @brief Finalize the currently open write query.
@@ -94,12 +94,43 @@ class VariantStats {
    */
   static void finalize();
 
-  // Close array
   /**
    * @brief Finalize the query and close the array.
    *
    */
   static void close();
+
+  /**
+   * @brief Get the uri for the array
+   *
+   * @param root_uri
+   * @return std::string
+   */
+  static std::string get_uri(const std::string& root_uri);
+
+  /**
+   * @brief Consolidate commits
+   *
+   * @param ctx TileDB context
+   * @param tiledb_config TileDB config
+   * @param root_uri URI for the VCF dataset
+   */
+  static void consolidate_commits(
+      std::shared_ptr<Context> ctx,
+      const std::vector<std::string>& tiledb_config,
+      const std::string& root_uri);
+
+  /**
+   * @brief Consolidate fragment metadata
+   *
+   * @param ctx TileDB context
+   * @param tiledb_config TileDB config
+   * @param root_uri URI for the VCF dataset
+   */
+  static void consolidate_fragment_metadata(
+      std::shared_ptr<Context> ctx,
+      const std::vector<std::string>& tiledb_config,
+      const std::string& root_uri);
 
   //===================================================================
   //= public non-static


### PR DESCRIPTION
Consolidate variant stats array commits and fragment metadata as part of the dataset consolidate commands.

Also closes [sc-15164]