### PR TITLE
Add support for the new TileDB group API

### DIFF
--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -916,11 +916,15 @@ class TileDBVCFDataset {
 
   /** Returns the URI of the sample data array for the dataset. */
   static std::string data_array_uri(
-      const std::string& root_uri, bool check_for_cloud = true);
+      const std::string& root_uri, bool relative = false, bool legacy = false);
+
+  /** Returns the URI of the metadata group for the dataset. */
+  static std::string metadata_group_uri(
+      const std::string& root_uri, bool relative = false, bool legacy = false);
 
   /** Returns the URI of the VCF header data array for the dataset. */
   static std::string vcf_headers_uri(
-      const std::string& root_uri, bool check_for_cloud = true);
+      const std::string& root_uri, bool relative = false, bool legacy = false);
 
   /** Returns true if the array starts with the tiledb:// URI **/
   static bool cloud_dataset(const std::string& root_uri);
@@ -944,6 +948,25 @@ class TileDBVCFDataset {
    * Populate the metadata maps of info/fmt field name -> htslib types.
    */
   void load_field_type_maps_v4(const bcf_hdr_t* hdr) const;
+
+  /**
+   * @brief Open an array using the uri from the root group member with name
+   * `member_name`. If the group member does not exist or is a tiledb:// uri
+   *  when the root uri is not a tiledb:// uri, open the array at the
+   * `uri_path`. If these uris fail, try the `legacy_uri` before throwing and
+   * error.
+   *
+   * @param query_type query type
+   * @param member_name member name in root group
+   * @param uri_path non tiledb:// uri for the array
+   * @param legacy_uri legacy tiledb:// uri
+   * @return std::unique_ptr<tiledb::Array> unique ptr to open array
+   */
+  std::unique_ptr<tiledb::Array> open_array(
+      tiledb_query_type_t query_type,
+      const std::string& member_name,
+      const std::string& uri_path,
+      const std::string& legacy_uri);
 
   /**
    * Open the VCF header array

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -692,6 +692,10 @@ class TileDBVCFDataset {
   /*          PRIVATE ATTRIBUTES       */
   /* ********************************* */
 
+  inline static const std::string DATA_ARRAY = "data";
+  inline static const std::string METADATA_GROUP = "metadata";
+  inline static const std::string VCF_HEADER_ARRAY = "vcf_headers";
+
   /** The URI of the dataset root directory (which is a TileDB group). */
   std::string root_uri_;
 

--- a/libtiledbvcf/src/dataset/variant_stats.cc
+++ b/libtiledbvcf/src/dataset/variant_stats.cc
@@ -24,6 +24,8 @@
  * THE SOFTWARE.
  */
 
+#include <tiledb/tiledb_experimental>  // for the new group api
+
 #include "dataset/variant_stats.h"
 #include "utils/logger_public.h"
 #include "utils/utils.h"
@@ -103,6 +105,10 @@ void VariantStats::create(
   // Write metadata
   Array array(ctx, uri, TILEDB_WRITE);
   array.put_metadata("version", TILEDB_UINT32, 1, &VARIANT_STATS_VERSION);
+
+  // Add array to root group
+  Group root_group(ctx, root_uri, TILEDB_WRITE);
+  root_group.add_member(VARIANT_STATS_ARRAY, true);
 }
 
 void VariantStats::init(
@@ -183,7 +189,7 @@ void VariantStats::close() {
 
 std::string VariantStats::get_uri(const std::string& root_uri) {
   auto delim = utils::starts_with(root_uri, "tiledb://") ? '-' : '/';
-  return utils::uri_join(root_uri, VARIANT_STATS_URI, delim);
+  return utils::uri_join(root_uri, VARIANT_STATS_ARRAY, delim);
 }
 
 void VariantStats::consolidate_commits(

--- a/libtiledbvcf/src/dataset/variant_stats.cc
+++ b/libtiledbvcf/src/dataset/variant_stats.cc
@@ -107,8 +107,12 @@ void VariantStats::create(
   array.put_metadata("version", TILEDB_UINT32, 1, &VARIANT_STATS_VERSION);
 
   // Add array to root group
+  // Group assests use full paths for tiledb cloud, relative paths otherwise
+  auto relative = !utils::starts_with(root_uri, "tiledb://");
+  auto array_uri = get_uri(root_uri, relative);
+  LOG_DEBUG("Adding array '{}' to group '{}'", array_uri, root_uri);
   Group root_group(ctx, root_uri, TILEDB_WRITE);
-  root_group.add_member(VARIANT_STATS_ARRAY, true);
+  root_group.add_member(array_uri, relative, VARIANT_STATS_ARRAY);
 }
 
 void VariantStats::init(
@@ -187,9 +191,9 @@ void VariantStats::close() {
   enabled_ = false;
 }
 
-std::string VariantStats::get_uri(const std::string& root_uri) {
-  auto delim = utils::starts_with(root_uri, "tiledb://") ? '-' : '/';
-  return utils::uri_join(root_uri, VARIANT_STATS_ARRAY, delim);
+std::string VariantStats::get_uri(const std::string& root_uri, bool relative) {
+  auto root = relative ? "" : root_uri;
+  return utils::uri_join(root, VARIANT_STATS_ARRAY);
 }
 
 void VariantStats::consolidate_commits(

--- a/libtiledbvcf/src/dataset/variant_stats.h
+++ b/libtiledbvcf/src/dataset/variant_stats.h
@@ -106,7 +106,8 @@ class VariantStats {
    * @param root_uri
    * @return std::string
    */
-  static std::string get_uri(const std::string& root_uri);
+  static std::string get_uri(
+      const std::string& root_uri, bool relative = false);
 
   /**
    * @brief Consolidate commits

--- a/libtiledbvcf/src/dataset/variant_stats.h
+++ b/libtiledbvcf/src/dataset/variant_stats.h
@@ -170,7 +170,7 @@ class VariantStats {
   //===================================================================
 
   // Array config
-  inline static const std::string VARIANT_STATS_URI = "variant_stats";
+  inline static const std::string VARIANT_STATS_ARRAY = "variant_stats";
 
   // Array version
   inline static const int VARIANT_STATS_VERSION = 1;

--- a/libtiledbvcf/test/src/unit-vcf-store.cc
+++ b/libtiledbvcf/test/src/unit-vcf-store.cc
@@ -58,8 +58,10 @@ TEST_CASE("TileDB-VCF: Test create", "[tiledbvcf][ingest]") {
   args.extra_attributes = {"a1", "a2"};
   REQUIRE_THROWS(TileDBVCFDataset::create(args));
 
+  if (vfs.is_dir(dataset_uri))
+    vfs.remove_dir(dataset_uri);
+
   args.extra_attributes = {"info_a1", "fmt_a2"};
-  TileDBVCFDataset::create(args);
   REQUIRE_NOTHROW(TileDBVCFDataset::create(args));
 
   TileDBVCFDataset ds(std::make_shared<tiledb::Context>(ctx));


### PR DESCRIPTION
Add support for the new group API in TileDB 2.8.

Example usage with TileDB Cloud and S3:

1. Register a new VCF dataset group with TileDB Cloud:
```
tiledbvcf create -u tiledb://<NAMESPACE>/s3://<BUCKET>/<PREFIX> ...
```

2. Ingest samples to S3 storage:
```
tiledbvcf store -u s3://<BUCKET>/<PREFIX> ...
```

3. Query the VCF dataset group in TileDB Cloud:
```
tiledbvcf export -u tiledb://<NAMESPACE>/<GROUP> ...
```