### PR TITLE
Upgrade TileDB-VCF to 2.10

### DIFF
--- a/apis/java/build.gradle
+++ b/apis/java/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'io.tiledb'
-version '0.16.0'
+version '0.17.0'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/apis/spark/build.gradle
+++ b/apis/spark/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'io.tiledb'
-version '0.16.0'
+version '0.17.0'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/apis/spark3/build.gradle
+++ b/apis/spark3/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'io.tiledb'
-version '0.16.0'
+version '0.17.0'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/libtiledbvcf/cmake/Modules/FindTileDB_EP.cmake
+++ b/libtiledbvcf/cmake/Modules/FindTileDB_EP.cmake
@@ -48,20 +48,20 @@ else()
     # Try to download prebuilt artifacts unless the user specifies to build from source
     if(DOWNLOAD_TILEDB_PREBUILT)
         if (WIN32) # Windows
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.9.5/tiledb-windows-x86_64-2.9.5-81e3fd1.zip")
-          SET(DOWNLOAD_SHA1 "7863afbc3109f6d43f814dd6ca897f51a864e7ea")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.10.1/tiledb-windows-x86_64-2.10.1-6535d4c.zip")
+          SET(DOWNLOAD_SHA1 "d0c5ed50f3c5215cae8a4dd82f756624e43252aa")
         elseif(APPLE) # OSX
 
           if (CMAKE_OSX_ARCHITECTURES STREQUAL x86_64 OR CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(AMD64|amd64)|(^i.86$)")
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.9.5/tiledb-macos-x86_64-2.9.5-81e3fd1.tar.gz")
-            SET(DOWNLOAD_SHA1 "9d3174acbc32dafc819ac04f3c0531bc3f94dfcf")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.10.1/tiledb-macos-x86_64-2.10.1-6535d4c.tar.gz")
+            SET(DOWNLOAD_SHA1 "68a43a62544ac849e1ca1b7c724f129dd7c8e50d")
           elseif (CMAKE_OSX_ARCHITECTURES STREQUAL arm64 OR CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.9.5/tiledb-macos-arm64-2.9.5-81e3fd1.tar.gz")
-            SET(DOWNLOAD_SHA1 "580b9ee3e35fe61d5d5fe5a68259019ae020f56f")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.10.1/tiledb-macos-arm64-2.10.1-6535d4c.tar.gz")
+            SET(DOWNLOAD_SHA1 "d7af9b925e5108914fec3435278dcf9257524465")
           endif()
         else() # Linux
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.9.5/tiledb-linux-x86_64-2.9.5-81e3fd1.tar.gz")
-          SET(DOWNLOAD_SHA1 "9a3fa1c9d1aa00a950c0c02cadc08b125888be65")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.10.1/tiledb-linux-x86_64-2.10.1-6535d4c.tar.gz")
+          SET(DOWNLOAD_SHA1 "8c48232cd52934724b2b7a254ebad6c27e5a7683")
         endif()
 
         ExternalProject_Add(ep_tiledb
@@ -83,8 +83,8 @@ else()
     else() # Build from source
         ExternalProject_Add(ep_tiledb
           PREFIX "externals"
-          URL "https://github.com/TileDB-Inc/TileDB/archive/2.9.5.zip"
-          URL_HASH SHA1=2e176186b6fac93ea765d3e4591d2cacba1804d7
+          URL "https://github.com/TileDB-Inc/TileDB/archive/2.10.1.zip"
+          URL_HASH SHA1=6bb82afdb2e1f89aeadbb46b7ac4b7197e836331
           DOWNLOAD_NAME "tiledb.zip"
           CMAKE_ARGS
             -DCMAKE_INSTALL_PREFIX=${EP_INSTALL_PREFIX}


### PR DESCRIPTION
This bumps the TileDB dependency to 2.10.1.