### PR TITLE
fix search for Catch headers

### DIFF
--- a/libtiledbvcf/cmake/Modules/FindCatch.cmake
+++ b/libtiledbvcf/cmake/Modules/FindCatch.cmake
@@ -32,10 +32,10 @@
 
 # Search the path set during the superbuild for the EP.
 message(STATUS "searching for catch in ${EP_SOURCE_DIR}")
-set(CATCH_PATHS ${EP_SOURCE_DIR}/ep_catch/single_include/catch2)
+set(CATCH_PATHS ${EP_SOURCE_DIR}/ep_catch/single_include)
 
 find_path(CATCH_INCLUDE_DIR
-  NAMES catch.hpp
+  NAMES catch2/catch.hpp
   PATHS ${CATCH_PATHS}
 )
 

--- a/libtiledbvcf/test/src/unit-bitmap.cc
+++ b/libtiledbvcf/test/src/unit-bitmap.cc
@@ -30,7 +30,7 @@
  * Tests for Bitmap.
  */
 
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 #include "utils/bitmap.h"
 #include "utils/buffer.h"

--- a/libtiledbvcf/test/src/unit-c-api-reader.cc
+++ b/libtiledbvcf/test/src/unit-c-api-reader.cc
@@ -28,7 +28,7 @@
  */
 
 #include "c_api/tiledbvcf.h"
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 #include "unit-helpers.h"
 
 #include <cstring>

--- a/libtiledbvcf/test/src/unit-c-api-writer.cc
+++ b/libtiledbvcf/test/src/unit-c-api-writer.cc
@@ -28,7 +28,7 @@
  */
 
 #include "c_api/tiledbvcf.h"
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 #include "dataset/tiledbvcfdataset.h"
 
 #include <cstring>

--- a/libtiledbvcf/test/src/unit-helpers.h
+++ b/libtiledbvcf/test/src/unit-helpers.h
@@ -31,7 +31,7 @@
 #include <sstream>
 #include <utility>
 #include <vector>
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 template <typename T, typename Compare>
 std::vector<std::size_t> sort_permutation(

--- a/libtiledbvcf/test/src/unit-vcf-export.cc
+++ b/libtiledbvcf/test/src/unit-vcf-export.cc
@@ -30,7 +30,7 @@
  * Tests for VCF export.
  */
 
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 #include "dataset/tiledbvcfdataset.h"
 #include "read/reader.h"

--- a/libtiledbvcf/test/src/unit-vcf-iter.cc
+++ b/libtiledbvcf/test/src/unit-vcf-iter.cc
@@ -30,7 +30,7 @@
  * Tests for VCF record iteration.
  */
 
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 #include "vcf/vcf_utils.h"
 #include "vcf/vcf_v2.h"

--- a/libtiledbvcf/test/src/unit-vcf-store.cc
+++ b/libtiledbvcf/test/src/unit-vcf-store.cc
@@ -30,7 +30,7 @@
  * Tests for VCF ingestion.
  */
 
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 #include "dataset/tiledbvcfdataset.h"
 #include "write/writer.h"

--- a/libtiledbvcf/test/src/unit-vcf-time-travel.cc
+++ b/libtiledbvcf/test/src/unit-vcf-time-travel.cc
@@ -30,7 +30,7 @@
  * Tests for VCF time travel.
  */
 
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 #include "dataset/tiledbvcfdataset.h"
 #include "read/reader.h"

--- a/libtiledbvcf/test/src/unit-vcf-utils.cc
+++ b/libtiledbvcf/test/src/unit-vcf-utils.cc
@@ -30,7 +30,7 @@
  * Tests for VCF export.
  */
 
-#include "catch.hpp"
+#include "catch2/catch.hpp"
 
 #include "dataset/tiledbvcfdataset.h"
 #include "read/reader.h"

--- a/libtiledbvcf/test/src/unit.cc
+++ b/libtiledbvcf/test/src/unit.cc
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch.hpp>


### PR DESCRIPTION
This fix should allow CMake to find an installed Catch 2 header library.

I'd recommend testing that CMake is finding the headers with or without Catch 2 installed prior to approving this commit.