### PR TITLE
Fix global order violation

### DIFF
--- a/apis/python/conda-env.yml
+++ b/apis/python/conda-env.yml
@@ -13,3 +13,4 @@ dependencies:
   - pip:
     - pytest-runner==5.1
     - pytest==5.1.2
+    - tiledb

--- a/apis/python/tests/test_tiledbvcf.py
+++ b/apis/python/tests/test_tiledbvcf.py
@@ -1,6 +1,7 @@
 import numpy as np
 import os
 import pandas as pd
+import platform
 import pytest
 import tiledbvcf
 import tiledb
@@ -943,6 +944,10 @@ def test_variant_stats(tmp_path):
     assert ds.count() == 14
     assert ds.count(regions=["1:12700-13400"]) == 6
     assert ds.count(samples=["HG00280"], regions=["1:12700-13400"]) == 4
+
+    # TODO: remove this workaround when sc-19721 is resolved
+    if platform.system() != "Linux":
+        return
 
     # query variant_stats array with TileDB
     vs_uri = os.path.join(tmp_path, "dataset", "variant_stats")

--- a/apis/python/tests/test_tiledbvcf.py
+++ b/apis/python/tests/test_tiledbvcf.py
@@ -3,6 +3,7 @@ import os
 import pandas as pd
 import pytest
 import tiledbvcf
+import tiledb
 
 # Directory containing this file
 CONTAINING_DIR = os.path.abspath(os.path.dirname(__file__))
@@ -927,6 +928,33 @@ def test_basic_ingest(tmp_path):
     assert ds.count() == 14
     assert ds.count(regions=["1:12700-13400"]) == 6
     assert ds.count(samples=["HG00280"], regions=["1:12700-13400"]) == 4
+
+
+def test_variant_stats(tmp_path):
+    # Create the dataset
+    uri = os.path.join(tmp_path, "dataset")
+    ds = tiledbvcf.Dataset(uri, mode="w")
+    samples = [os.path.join(TESTS_INPUT_DIR, s) for s in ["small.bcf", "small2.bcf"]]
+    ds.create_dataset()
+    ds.ingest_samples(samples)
+
+    # Open it back in read mode and check some queries
+    ds = tiledbvcf.Dataset(uri, mode="r")
+    assert ds.count() == 14
+    assert ds.count(regions=["1:12700-13400"]) == 6
+    assert ds.count(samples=["HG00280"], regions=["1:12700-13400"]) == 4
+
+    # query variant_stats array with TileDB
+    vs_uri = os.path.join(tmp_path, "dataset", "variant_stats")
+
+    contig = "1"
+    region = slice(12140, 12140)
+    with tiledb.open(vs_uri) as A:
+        df = A.query(attrs=["allele", "ac"], dims=["pos"]).df[contig, region]
+
+    assert df.pos.array == 12140
+    assert df.allele.array == "C"
+    assert df.ac.array == 4
 
 
 def test_incremental_ingest(tmp_path):

--- a/libtiledbvcf/cmake/Modules/FindTileDB_EP.cmake
+++ b/libtiledbvcf/cmake/Modules/FindTileDB_EP.cmake
@@ -48,20 +48,20 @@ else()
     # Try to download prebuilt artifacts unless the user specifies to build from source
     if(DOWNLOAD_TILEDB_PREBUILT)
         if (WIN32) # Windows
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.10.1/tiledb-windows-x86_64-2.10.1-6535d4c.zip")
-          SET(DOWNLOAD_SHA1 "d0c5ed50f3c5215cae8a4dd82f756624e43252aa")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.10.2/tiledb-windows-x86_64-2.10.2-9ab84f9.zip")
+          SET(DOWNLOAD_SHA1 "fe6dac320afb08dd3f2f40f2705306f6eb245f8b")
         elseif(APPLE) # OSX
 
           if (CMAKE_OSX_ARCHITECTURES STREQUAL x86_64 OR CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(AMD64|amd64)|(^i.86$)")
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.10.1/tiledb-macos-x86_64-2.10.1-6535d4c.tar.gz")
-            SET(DOWNLOAD_SHA1 "68a43a62544ac849e1ca1b7c724f129dd7c8e50d")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.10.2/tiledb-macos-x86_64-2.10.2-9ab84f9.tar.gz")
+            SET(DOWNLOAD_SHA1 "2be62a6c48c0bd7aeea786414aa32aef26fe6a64")
           elseif (CMAKE_OSX_ARCHITECTURES STREQUAL arm64 OR CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.10.1/tiledb-macos-arm64-2.10.1-6535d4c.tar.gz")
-            SET(DOWNLOAD_SHA1 "d7af9b925e5108914fec3435278dcf9257524465")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.10.2/tiledb-macos-arm64-2.10.2-9ab84f9.tar.gz")
+            SET(DOWNLOAD_SHA1 "11fb038deb0633ee5b70a279e1b903c6b8321577")
           endif()
         else() # Linux
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.10.1/tiledb-linux-x86_64-2.10.1-6535d4c.tar.gz")
-          SET(DOWNLOAD_SHA1 "8c48232cd52934724b2b7a254ebad6c27e5a7683")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.10.2/tiledb-linux-x86_64-2.10.2-9ab84f9.tar.gz")
+          SET(DOWNLOAD_SHA1 "03f6d4892f11cbd939660b78c923325396bd600f")
         endif()
 
         ExternalProject_Add(ep_tiledb
@@ -83,8 +83,8 @@ else()
     else() # Build from source
         ExternalProject_Add(ep_tiledb
           PREFIX "externals"
-          URL "https://github.com/TileDB-Inc/TileDB/archive/2.10.1.zip"
-          URL_HASH SHA1=6bb82afdb2e1f89aeadbb46b7ac4b7197e836331
+          URL "https://github.com/TileDB-Inc/TileDB/archive/2.10.2.zip"
+          URL_HASH SHA1=e5152fb5c542a3d303125c6029ed05f696e21729
           DOWNLOAD_NAME "tiledb.zip"
           CMAKE_ARGS
             -DCMAKE_INSTALL_PREFIX=${EP_INSTALL_PREFIX}

--- a/libtiledbvcf/src/dataset/variant_stats.h
+++ b/libtiledbvcf/src/dataset/variant_stats.h
@@ -176,9 +176,9 @@ class VariantStats {
   // Array version
   inline static const int VARIANT_STATS_VERSION = 1;
 
-  // Array dimensions
-  enum Dim { CONTIG, POS, ALLELE };
-  inline static const std::vector<std::string> DIM_STR = {
+  // Array columns
+  enum ColumnNames { CONTIG, POS, ALLELE };
+  inline static const std::vector<std::string> COLUMN_STR = {
       "contig", "pos", "allele"};
 
   // Array attributes

--- a/scripts/update-tiledb-version.py
+++ b/scripts/update-tiledb-version.py
@@ -48,6 +48,7 @@ def main(args):
     filepath = os.path.realpath(filepath)
     print(f"Updating {filepath}")
     print(f"  new version = {args.version}-{new_hash}")
+    print("  computing SHA1 hashes...")
 
     # all "print" statements in this "with" block go to the "fp" file
     with FileInput(filepath, inplace=True) as fp:


### PR DESCRIPTION
This PR fixes a data dependent global order violation when writing the new `variant_stats` array. The `allele` dimension is moved from a dimension to an attribute in the `variant_stats` schema.