### PR TITLE
port FindCatch_EP from core

### DIFF
--- a/libtiledbvcf/cmake/Superbuild.cmake
+++ b/libtiledbvcf/cmake/Superbuild.cmake
@@ -68,7 +68,7 @@ set(INHERITED_CMAKE_ARGS
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindCLI11.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindHTSlib.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindTileDB_EP.cmake)
-include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindCatch.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindCatch_EP.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindSpdlog.cmake)
 
 ############################################################

--- a/libtiledbvcf/test/CMakeLists.txt
+++ b/libtiledbvcf/test/CMakeLists.txt
@@ -27,7 +27,7 @@
 
 find_package(HTSlib REQUIRED)
 find_package(TileDB_EP REQUIRED)
-find_package(Catch REQUIRED)
+find_package(Catch_EP REQUIRED)
 
 ############################################################
 # Unit test executable
@@ -59,7 +59,7 @@ target_include_directories(tiledb_vcf_unit
 target_link_libraries(tiledb_vcf_unit
   PUBLIC
     tiledbvcf
-    Catch::Catch
+    Catch2::Catch2
 )
 
 # Sanitizer linker flags


### PR DESCRIPTION
This is an alternative to PR #445, porting the FindCatch_EP.cmake file from core, with one modification. I'm looking into why this is necessary in VCF but not in core: https://github.com/TileDB-Inc/TileDB-VCF/blob/awenocur/sc-19637/port-catch-search/libtiledbvcf/cmake/Modules/FindCatch_EP.cmake#L72