### PR TITLE
Add optional ingestion tasks

### DIFF
--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -106,5 +106,7 @@ PYBIND11_MODULE(libtiledbvcf, m) {
           "set_contigs_to_keep_separate", &Writer::set_contigs_to_keep_separate)
       .def(
           "set_contigs_to_allow_merging", &Writer::set_contigs_to_allow_merging)
-      .def("set_contig_mode", &Writer::set_contig_mode);
+      .def("set_contig_mode", &Writer::set_contig_mode)
+      .def("set_enable_allele_count", &Writer::set_enable_allele_count)
+      .def("set_enable_variant_stats", &Writer::set_enable_variant_stats);
 }

--- a/apis/python/src/tiledbvcf/binding/writer.cc
+++ b/apis/python/src/tiledbvcf/binding/writer.cc
@@ -329,4 +329,14 @@ void Writer::set_contig_mode(int contig_mode) {
   check_error(writer, tiledb_vcf_writer_set_contig_mode(writer, contig_mode));
 }
 
+void Writer::set_enable_allele_count(bool enable) {
+  auto writer = ptr.get();
+  check_error(writer, tiledb_vcf_writer_set_enable_allele_count(writer, enable));
+}
+
+void Writer::set_enable_variant_stats(bool enable) {
+  auto writer = ptr.get();
+  check_error(writer, tiledb_vcf_writer_set_enable_variant_stats(writer, enable));
+}
+
 }  // namespace tiledbvcfpy

--- a/apis/python/src/tiledbvcf/binding/writer.cc
+++ b/apis/python/src/tiledbvcf/binding/writer.cc
@@ -331,12 +331,14 @@ void Writer::set_contig_mode(int contig_mode) {
 
 void Writer::set_enable_allele_count(bool enable) {
   auto writer = ptr.get();
-  check_error(writer, tiledb_vcf_writer_set_enable_allele_count(writer, enable));
+  check_error(
+      writer, tiledb_vcf_writer_set_enable_allele_count(writer, enable));
 }
 
 void Writer::set_enable_variant_stats(bool enable) {
   auto writer = ptr.get();
-  check_error(writer, tiledb_vcf_writer_set_enable_variant_stats(writer, enable));
+  check_error(
+      writer, tiledb_vcf_writer_set_enable_variant_stats(writer, enable));
 }
 
 }  // namespace tiledbvcfpy

--- a/apis/python/src/tiledbvcf/binding/writer.h
+++ b/apis/python/src/tiledbvcf/binding/writer.h
@@ -220,6 +220,16 @@ class Writer {
   */
   void set_contig_mode(int contig_mode);
 
+  /**
+    Enable the allele count ingestion task
+  */
+  void set_enable_allele_count(bool enable);
+
+  /**
+    Enable the variant stats ingestion task
+  */
+  void set_enable_variant_stats(bool enable);
+
  private:
   /** Helper function to free a C writer instance */
   static void deleter(tiledb_vcf_writer_t* w);

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -370,6 +370,8 @@ class Dataset(object):
         anchor_gap=None,
         checksum_type=None,
         allow_duplicates=True,
+        enable_allele_count=False,
+        enable_variant_stats=False,
     ):
         """Create a new dataset
 
@@ -385,6 +387,8 @@ class Dataset(object):
             new dataset valid values are sha256, md5 or none.
         :param bool allow_duplicates: Allow records with duplicate start
             positions to be written to the array.
+        :param bool enable_allele_count: Enable the allele count ingestion task.
+        :param bool enable_variant_stats: Enable the variant stats ingestion task.
         """
         if self.mode != "w":
             raise Exception("Dataset not open in write mode")
@@ -409,6 +413,12 @@ class Dataset(object):
             self.writer.set_checksum(checksum_type)
 
         self.writer.set_allow_duplicates(allow_duplicates)
+
+        if enable_allele_count is not None:
+            self.writer.set_enable_allele_count(enable_allele_count)
+
+        if enable_variant_stats is not None:
+            self.writer.set_enable_variant_stats(enable_variant_stats)
 
         # Create is a no-op if the dataset already exists.
         # TODO: Inform user if dataset already exists?

--- a/apis/python/tests/test_tiledbvcf.py
+++ b/apis/python/tests/test_tiledbvcf.py
@@ -931,12 +931,43 @@ def test_basic_ingest(tmp_path):
     assert ds.count(samples=["HG00280"], regions=["1:12700-13400"]) == 4
 
 
-def test_ingestion_tasks(tmp_path):
+def test_disable_ingestion_tasks(tmp_path):
     # Create the dataset
     uri = os.path.join(tmp_path, "dataset")
     ds = tiledbvcf.Dataset(uri, mode="w")
     samples = [os.path.join(TESTS_INPUT_DIR, s) for s in ["small.bcf", "small3.bcf"]]
     ds.create_dataset()
+    ds.ingest_samples(samples)
+
+    # TODO: remove this workaround when sc-19721 is resolved
+    if platform.system() != "Linux":
+        return
+
+    # query allele_count array with TileDB
+    ac_uri = os.path.join(tmp_path, "dataset", "allele_count")
+
+    contig = "1"
+    region = slice(69896)
+    with pytest.raises(Exception):
+        with tiledb.open(ac_uri) as A:
+            df = A.query(attrs=["alt", "count"], dims=["pos"]).df[contig, region]
+
+    # query variant_stats array with TileDB
+    vs_uri = os.path.join(tmp_path, "dataset", "variant_stats")
+
+    contig = "1"
+    region = slice(12140)
+    with pytest.raises(Exception):
+        with tiledb.open(vs_uri) as A:
+            df = A.query(attrs=["allele", "ac"], dims=["pos"]).df[contig, region]
+
+
+def test_ingestion_tasks(tmp_path):
+    # Create the dataset
+    uri = os.path.join(tmp_path, "dataset")
+    ds = tiledbvcf.Dataset(uri, mode="w")
+    samples = [os.path.join(TESTS_INPUT_DIR, s) for s in ["small.bcf", "small3.bcf"]]
+    ds.create_dataset(enable_allele_count=True, enable_variant_stats=True)
     ds.ingest_samples(samples)
 
     # TODO: remove this workaround when sc-19721 is resolved

--- a/apis/python/tests/test_tiledbvcf.py
+++ b/apis/python/tests/test_tiledbvcf.py
@@ -931,35 +931,41 @@ def test_basic_ingest(tmp_path):
     assert ds.count(samples=["HG00280"], regions=["1:12700-13400"]) == 4
 
 
-def test_variant_stats(tmp_path):
+def test_ingestion_tasks(tmp_path):
     # Create the dataset
     uri = os.path.join(tmp_path, "dataset")
     ds = tiledbvcf.Dataset(uri, mode="w")
-    samples = [os.path.join(TESTS_INPUT_DIR, s) for s in ["small.bcf", "small2.bcf"]]
+    samples = [os.path.join(TESTS_INPUT_DIR, s) for s in ["small.bcf", "small3.bcf"]]
     ds.create_dataset()
     ds.ingest_samples(samples)
-
-    # Open it back in read mode and check some queries
-    ds = tiledbvcf.Dataset(uri, mode="r")
-    assert ds.count() == 14
-    assert ds.count(regions=["1:12700-13400"]) == 6
-    assert ds.count(samples=["HG00280"], regions=["1:12700-13400"]) == 4
 
     # TODO: remove this workaround when sc-19721 is resolved
     if platform.system() != "Linux":
         return
 
+    # query allele_count array with TileDB
+    ac_uri = os.path.join(tmp_path, "dataset", "allele_count")
+
+    contig = "1"
+    region = slice(69896)
+    with tiledb.open(ac_uri) as A:
+        df = A.query(attrs=["alt", "count"], dims=["pos"]).df[contig, region]
+
+    assert df["pos"].array == 69896
+    assert df["alt"].array == "C"
+    assert df["count"].array == 1
+
     # query variant_stats array with TileDB
     vs_uri = os.path.join(tmp_path, "dataset", "variant_stats")
 
     contig = "1"
-    region = slice(12140, 12140)
+    region = slice(12140)
     with tiledb.open(vs_uri) as A:
         df = A.query(attrs=["allele", "ac"], dims=["pos"]).df[contig, region]
 
-    assert df.pos.array == 12140
-    assert df.allele.array == "C"
-    assert df.ac.array == 4
+    assert df["pos"].array == 12140
+    assert df["allele"].array == "C"
+    assert df["ac"].array == 4
 
 
 def test_incremental_ingest(tmp_path):
@@ -1231,3 +1237,7 @@ def test_vcf_attrs(tmp_path):
     assert ds.attributes(attr_type="info") == []
     assert ds.attributes(attr_type="fmt") == []
     assert sorted(ds.attributes()) == sorted(queryable_attrs)
+
+
+if __name__ == "__main__":
+    test_allele_count("/tmp/gspowley-debug")

--- a/apis/spark/src/main/java/io/tiledb/vcf/VCFInputPartitionReader.java
+++ b/apis/spark/src/main/java/io/tiledb/vcf/VCFInputPartitionReader.java
@@ -268,7 +268,16 @@ public class VCFInputPartitionReader implements InputPartitionReader<ColumnarBat
             + ", sample partition "
             + (samplePartitionInfo.getIndex() + 1)
             + " of "
-            + samplePartitionInfo.getNumPartitions());
+            + samplePartitionInfo.getNumPartitions()
+            + " (range_partition_index="
+            + rangePartitionInfo.getIndex()
+            + ", range_partitions="
+            + rangePartitionInfo.getNumPartitions()
+            + ", sample_partition_index="
+            + samplePartitionInfo.getIndex()
+            + ", sample_partitions="
+            + samplePartitionInfo.getNumPartitions()
+            + ")");
     String uriString = datasetURI.toString();
 
     Optional<String> credentialsCsv =

--- a/apis/spark3/src/main/java/io/tiledb/vcf/VCFPartitionReader.java
+++ b/apis/spark3/src/main/java/io/tiledb/vcf/VCFPartitionReader.java
@@ -269,7 +269,16 @@ public class VCFPartitionReader implements PartitionReader<ColumnarBatch> {
             + ", sample partition "
             + (samplePartitionInfo.getIndex() + 1)
             + " of "
-            + samplePartitionInfo.getNumPartitions());
+            + samplePartitionInfo.getNumPartitions()
+            + " (range_partition_index="
+            + rangePartitionInfo.getIndex()
+            + ", range_partitions="
+            + rangePartitionInfo.getNumPartitions()
+            + ", sample_partition_index="
+            + samplePartitionInfo.getIndex()
+            + ", sample_partitions="
+            + samplePartitionInfo.getNumPartitions()
+            + ")");
     String uriString = datasetURI.toString();
 
     Optional<String> credentialsCsv =

--- a/libtiledbvcf/src/CMakeLists.txt
+++ b/libtiledbvcf/src/CMakeLists.txt
@@ -48,6 +48,7 @@ set(TILEDB_VCF_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/c_api/tiledbvcf.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/dataset/attribute_buffer_set.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/dataset/tiledbvcfdataset.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/dataset/allele_count.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/dataset/variant_stats.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/htslib_plugin/hfile_tiledb_vfs.c
   ${CMAKE_CURRENT_SOURCE_DIR}/read/bcf_exporter.cc

--- a/libtiledbvcf/src/c_api/tiledbvcf.cc
+++ b/libtiledbvcf/src/c_api/tiledbvcf.cc
@@ -1594,6 +1594,30 @@ int32_t tiledb_vcf_writer_set_contig_mode(
   return TILEDB_VCF_OK;
 }
 
+int32_t tiledb_vcf_writer_set_enable_allele_count(
+    tiledb_vcf_writer_t* writer, bool enable) {
+  if (sanity_check(writer) == TILEDB_VCF_ERR)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          writer, writer->writer_->set_enable_allele_count(enable)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
+int32_t tiledb_vcf_writer_set_enable_variant_stats(
+    tiledb_vcf_writer_t* writer, bool enable) {
+  if (sanity_check(writer) == TILEDB_VCF_ERR)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          writer, writer->writer_->set_enable_variant_stats(enable)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
 /* ********************************* */
 /*               ERROR               */
 /* ********************************* */

--- a/libtiledbvcf/src/c_api/tiledbvcf.h
+++ b/libtiledbvcf/src/c_api/tiledbvcf.h
@@ -1553,6 +1553,22 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_set_contigs_to_allow_merging(
 TILEDBVCF_EXPORT int32_t
 tiledb_vcf_writer_set_contig_mode(tiledb_vcf_writer_t* writer, int contig_mode);
 
+/**
+ * Sets enable allele count ingestion task
+ * @param writer VCF writer object
+ * @param enable enable/disable
+ */
+TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_set_enable_allele_count(
+    tiledb_vcf_writer_t* writer, bool enable);
+
+/**
+ * Sets enable variant stats ingestion task
+ * @param writer VCF writer object
+ * @param enable enable/disable
+ */
+TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_set_enable_variant_stats(
+    tiledb_vcf_writer_t* writer, bool enable);
+
 /* ********************************* */
 /*               ERROR               */
 /* ********************************* */

--- a/libtiledbvcf/src/cli/tiledbvcf.cc
+++ b/libtiledbvcf/src/cli/tiledbvcf.cc
@@ -421,6 +421,16 @@ void add_create(CLI::App& app) {
       "Allow records with duplicate start positions to be written to the "
       "array.");
 
+  cmd->option_defaults()->group("Ingestion task options");
+  cmd->add_flag(
+      "--enable-allele-count",
+      args->enable_allele_count,
+      "Enable allele count ingestion task");
+  cmd->add_flag(
+      "--enable-variant-stats",
+      args->enable_variant_stats,
+      "Enable variant stats ingestion task");
+
   cmd->option_defaults()->group("TileDB options");
   cmd->add_option(
       "-c,--tile-capacity",

--- a/libtiledbvcf/src/dataset/allele_count.cc
+++ b/libtiledbvcf/src/dataset/allele_count.cc
@@ -26,7 +26,7 @@
 
 #include <tiledb/tiledb_experimental>  // for the new group api
 
-#include "dataset/variant_stats.h"
+#include "dataset/allele_count.h"
 #include "utils/logger_public.h"
 #include "utils/utils.h"
 
@@ -36,34 +36,34 @@ namespace tiledb::vcf {
 //= public static functions
 //===================================================================
 
-void VariantStats::create(
+void AlleleCount::create(
     Context& ctx, const std::string& root_uri, tiledb_filter_type_t checksum) {
-  LOG_DEBUG("VariantStats: Create array");
+  LOG_DEBUG("AlleleCount: Create array");
 
   // Create filter lists
   FilterList rle_coord_filters(ctx);
   FilterList int_coord_filters(ctx);
-  FilterList str_filters(ctx);
   FilterList offset_filters(ctx);
-  FilterList int_attr_filters(ctx);
+  FilterList int_filters(ctx);
+  FilterList str_filters(ctx);
 
   rle_coord_filters.add_filter({ctx, TILEDB_FILTER_RLE});
   int_coord_filters.add_filter({ctx, TILEDB_FILTER_DOUBLE_DELTA})
       .add_filter({ctx, TILEDB_FILTER_BIT_WIDTH_REDUCTION})
       .add_filter({ctx, TILEDB_FILTER_ZSTD});
-  str_filters.add_filter({ctx, TILEDB_FILTER_ZSTD});
   offset_filters.add_filter({ctx, TILEDB_FILTER_DOUBLE_DELTA})
       .add_filter({ctx, TILEDB_FILTER_BIT_WIDTH_REDUCTION})
       .add_filter({ctx, TILEDB_FILTER_ZSTD});
-  int_attr_filters.add_filter({ctx, TILEDB_FILTER_BIT_WIDTH_REDUCTION})
+  int_filters.add_filter({ctx, TILEDB_FILTER_BIT_WIDTH_REDUCTION})
       .add_filter({ctx, TILEDB_FILTER_ZSTD});
+  str_filters.add_filter({ctx, TILEDB_FILTER_ZSTD});
 
   if (checksum) {
     // rle_coord_filters.add_filter({ctx, checksum});
     int_coord_filters.add_filter({ctx, checksum});
-    str_filters.add_filter({ctx, checksum});
     offset_filters.add_filter({ctx, checksum});
-    int_attr_filters.add_filter({ctx, checksum});
+    int_filters.add_filter({ctx, checksum});
+    str_filters.add_filter({ctx, checksum});
   }
 
   // Create schema and domain
@@ -77,26 +77,27 @@ void VariantStats::create(
   const uint32_t pos_max = std::numeric_limits<uint32_t>::max() - 1;
   const uint32_t pos_extent = pos_max - pos_min + 1;
 
+  // Create dimensions
   auto contig = Dimension::create(
-      ctx, COLUMN_STR[CONTIG], TILEDB_STRING_ASCII, nullptr, nullptr);
+      ctx, COLUMN_NAME[CONTIG], TILEDB_STRING_ASCII, nullptr, nullptr);
   contig.set_filter_list(rle_coord_filters);  // d0
 
   auto pos = Dimension::create<uint32_t>(
-      ctx, COLUMN_STR[POS], {{pos_min, pos_max}}, pos_extent);
+      ctx, COLUMN_NAME[POS], {{pos_min, pos_max}}, pos_extent);
   pos.set_filter_list(int_coord_filters);  // d1
 
   domain.add_dimensions(contig, pos);
   schema.set_domain(domain);
 
-  auto allele =
-      Attribute::create<std::string>(ctx, COLUMN_STR[ALLELE], str_filters);
-  schema.add_attributes(allele);
-
   // Create attributes
-  for (int i = 0; i < LAST_; i++) {
-    auto attr = Attribute::create<int32_t>(ctx, ATTR_STR[i], int_attr_filters);
+  for (int i = REF; i < COUNT; i++) {
+    auto attr =
+        Attribute::create<std::string>(ctx, COLUMN_NAME[i], str_filters);
     schema.add_attributes(attr);
   }
+
+  auto count = Attribute::create<int32_t>(ctx, COLUMN_NAME[COUNT], int_filters);
+  schema.add_attributes(count);
 
   // Create array
   auto uri = get_uri(root_uri);
@@ -104,21 +105,21 @@ void VariantStats::create(
 
   // Write metadata
   Array array(ctx, uri, TILEDB_WRITE);
-  array.put_metadata("version", TILEDB_UINT32, 1, &VARIANT_STATS_VERSION);
+  array.put_metadata("version", TILEDB_UINT32, 1, &ALLELE_COUNT_VERSION);
 
   // Add array to root group
-  // Group assests use full paths for tiledb cloud, relative paths otherwise
+  // Group assets use full paths for tiledb cloud, relative paths otherwise
   auto relative = !utils::starts_with(root_uri, "tiledb://");
   auto array_uri = get_uri(root_uri, relative);
   LOG_DEBUG("Adding array '{}' to group '{}'", array_uri, root_uri);
   Group root_group(ctx, root_uri, TILEDB_WRITE);
-  root_group.add_member(array_uri, relative, VARIANT_STATS_ARRAY);
+  root_group.add_member(array_uri, relative, ALLELE_COUNT_ARRAY);
 }
 
-void VariantStats::init(
+void AlleleCount::init(
     std::shared_ptr<Context> ctx, const std::string& root_uri) {
   std::lock_guard<std::mutex> lock(query_lock_);
-  LOG_DEBUG("VariantStats: Open array");
+  LOG_DEBUG("AlleleCount: Open array");
 
   // Open array
   auto uri = get_uri(root_uri);
@@ -126,7 +127,7 @@ void VariantStats::init(
     array_ = std::make_unique<Array>(*ctx, uri, TILEDB_WRITE);
     enabled_ = true;
   } catch (const tiledb::TileDBError& ex) {
-    LOG_DEBUG("VariantStats: Ingestion task disabled");
+    LOG_DEBUG("AlleleCount: Ingestion task disabled");
     enabled_ = false;
     return;
   }
@@ -135,13 +136,13 @@ void VariantStats::init(
   query_->set_layout(TILEDB_GLOBAL_ORDER);
 }
 
-void VariantStats::finalize() {
+void AlleleCount::finalize() {
   if (!enabled_) {
     return;
   }
 
   std::lock_guard<std::mutex> lock(query_lock_);
-  LOG_DEBUG("VariantStats: Finalize query with {} records", contig_records_);
+  LOG_DEBUG("AlleleCount: Finalize query with {} records", contig_records_);
   contig_records_ = 0;
   query_->finalize();
 
@@ -157,7 +158,7 @@ void VariantStats::finalize() {
       samples.pop_back();
     }
     LOG_DEBUG(
-        "VariantStats: fragment_num = {} uri = {} samples = {}",
+        "AlleleCount: fragment_num = {} uri = {} samples = {}",
         frag_num,
         uri,
         samples);
@@ -168,13 +169,13 @@ void VariantStats::finalize() {
   }
 }
 
-void VariantStats::close() {
+void AlleleCount::close() {
   if (!enabled_) {
     return;
   }
 
   std::lock_guard<std::mutex> lock(query_lock_);
-  LOG_DEBUG("VariantStats: Close array");
+  LOG_DEBUG("AlleleCount: Close array");
 
   if (query_ != nullptr) {
     query_->finalize();
@@ -189,12 +190,12 @@ void VariantStats::close() {
   enabled_ = false;
 }
 
-std::string VariantStats::get_uri(const std::string& root_uri, bool relative) {
+std::string AlleleCount::get_uri(const std::string& root_uri, bool relative) {
   auto root = relative ? "" : root_uri;
-  return utils::uri_join(root, VARIANT_STATS_ARRAY);
+  return utils::uri_join(root, ALLELE_COUNT_ARRAY);
 }
 
-void VariantStats::consolidate_commits(
+void AlleleCount::consolidate_commits(
     std::shared_ptr<Context> ctx,
     const std::vector<std::string>& tiledb_config,
     const std::string& root_uri) {
@@ -204,17 +205,18 @@ void VariantStats::consolidate_commits(
     Query query{*ctx, array};
     auto est_bytes = query.est_result_size("pos");
     if (est_bytes == 0) {
-      LOG_DEBUG("VariantStats: Skip consolidate empty commits");
+      LOG_DEBUG("AlleleCount: Skip consolidate empty commits");
       return;
     }
   }
+
   Config cfg;
   utils::set_tiledb_config(tiledb_config, &cfg);
   cfg["sm.consolidation.mode"] = "commits";
   tiledb::Array::consolidate(*ctx, get_uri(root_uri), &cfg);
 }
 
-void VariantStats::consolidate_fragment_metadata(
+void AlleleCount::consolidate_fragment_metadata(
     std::shared_ptr<Context> ctx,
     const std::vector<std::string>& tiledb_config,
     const std::string& root_uri) {
@@ -228,16 +230,16 @@ void VariantStats::consolidate_fragment_metadata(
 //= public functions
 //===================================================================
 
-VariantStats::VariantStats() {
+AlleleCount::AlleleCount() {
 }
 
-VariantStats::~VariantStats() {
+AlleleCount::~AlleleCount() {
   if (dst_ != nullptr) {
     free(dst_);
   }
 }
 
-void VariantStats::flush() {
+void AlleleCount::flush() {
   if (!enabled_) {
     return;
   }
@@ -245,10 +247,9 @@ void VariantStats::flush() {
   // Update results for the last locus before flushing
   update_results();
 
-  int buffered_records = attr_buffers_[AC].size();
+  int buffered_records = count_buffer_.size();
 
   if (buffered_records == 0) {
-    LOG_DEBUG("VariantStats: flush called with 0 records ");
     return;
   }
 
@@ -257,26 +258,29 @@ void VariantStats::flush() {
     contig_records_ += buffered_records;
 
     LOG_DEBUG(
-        "VariantStats: flushing {} records from {}:{}-{}",
+        "AlleleCount: flushing {} records from {}:{}-{}",
         buffered_records,
         contig_buffer_.substr(0, contig_offsets_[1]),
         pos_buffer_.front(),
         pos_buffer_.back());
 
-    query_->set_data_buffer(COLUMN_STR[CONTIG], contig_buffer_)
-        .set_offsets_buffer(COLUMN_STR[CONTIG], contig_offsets_)
-        .set_data_buffer(COLUMN_STR[POS], pos_buffer_)
-        .set_data_buffer(COLUMN_STR[ALLELE], allele_buffer_)
-        .set_offsets_buffer(COLUMN_STR[ALLELE], allele_offsets_);
-
-    for (int i = 0; i < LAST_; i++) {
-      query_->set_data_buffer(ATTR_STR[i], attr_buffers_[i]);
-    }
+    query_->set_data_buffer(COLUMN_NAME[CONTIG], contig_buffer_)
+        .set_offsets_buffer(COLUMN_NAME[CONTIG], contig_offsets_)
+        .set_data_buffer(COLUMN_NAME[POS], pos_buffer_)
+        .set_data_buffer(COLUMN_NAME[REF], ref_buffer_)
+        .set_offsets_buffer(COLUMN_NAME[REF], ref_offsets_)
+        .set_data_buffer(COLUMN_NAME[ALT], alt_buffer_)
+        .set_offsets_buffer(COLUMN_NAME[ALT], alt_offsets_)
+        .set_data_buffer(COLUMN_NAME[FILTER], filter_buffer_)
+        .set_offsets_buffer(COLUMN_NAME[FILTER], filter_offsets_)
+        .set_data_buffer(COLUMN_NAME[GT], gt_buffer_)
+        .set_offsets_buffer(COLUMN_NAME[GT], gt_offsets_)
+        .set_data_buffer(COLUMN_NAME[COUNT], count_buffer_);
 
     auto st = query_->submit();
 
     if (st != Query::Status::COMPLETE) {
-      LOG_FATAL("VariantStats: error submitting TileDB write query");
+      LOG_FATAL("AlleleCount: error submitting TileDB write query");
     }
 
     // Insert sample names from this query into the set of fragment sample names
@@ -288,14 +292,18 @@ void VariantStats::flush() {
   contig_buffer_.clear();
   contig_offsets_.clear();
   pos_buffer_.clear();
-  allele_buffer_.clear();
-  allele_offsets_.clear();
-  for (int i = 0; i < LAST_; i++) {
-    attr_buffers_[i].clear();
-  }
+  ref_buffer_.clear();
+  ref_offsets_.clear();
+  alt_buffer_.clear();
+  alt_offsets_.clear();
+  filter_buffer_.clear();
+  filter_offsets_.clear();
+  gt_buffer_.clear();
+  gt_offsets_.clear();
+  count_buffer_.clear();
 }
 
-void VariantStats::process(
+void AlleleCount::process(
     bcf_hdr_t* hdr,
     const std::string& sample_name,
     const std::string& contig,
@@ -308,13 +316,10 @@ void VariantStats::process(
   // Check if locus has changed
   if (contig != contig_ || pos != pos_) {
     if (contig != contig_) {
-      LOG_DEBUG("VariantStats: new contig = {}", contig);
+      LOG_DEBUG("AlleleCount: new contig = {}", contig);
     } else if (pos < pos_) {
       LOG_ERROR(
-          "VariantStats: contig {} pos out of order {} < {}",
-          contig,
-          pos,
-          pos_);
+          "AlleleCount: contig {} pos out of order {} < {}", contig, pos, pos_);
     }
     update_results();
     contig_ = contig;
@@ -329,31 +334,8 @@ void VariantStats::process(
     return;
   }
 
-  // Add sample name to the set of sample name in this query
-  sample_names_.insert(sample_name);
-
-  // Update called for the REF allele
-  auto ref = rec->d.allele[0];
-  values_[ref][N_CALLED]++;
-
-  int gt0 = bcf_gt_allele(dst_[0]);
-  std::string allele0 = rec->d.allele[gt0];
-
-  // Increment allele count for GT[0]
-  values_[allele0][AC]++;
-
-  if (ngt == 2) {
-    int gt1 = bcf_gt_allele(dst_[1]);
-    std::string allele1 = rec->d.allele[gt1];
-
-    // Increment allele count for GT[1]
-    values_[allele1][AC]++;
-
-    // Update homozygote count, only diploid genotype calls are counted
-    if (gt0 == gt1) {
-      values_[allele1][N_HOM]++;
-    }
-  } else if (ngt > 2) {
+  // Only haploid and diploid are supported
+  if (ngt > 2) {
     LOG_FATAL(
         "Ploidy > 2 not supported: sample={} locus={}:{} ploidy={}",
         sample_name,
@@ -361,25 +343,97 @@ void VariantStats::process(
         pos,
         ngt);
   }
+
+  // Skip if homozygous ref or missing allele
+  if (bcf_gt_allele(dst_[0]) == 0 || bcf_gt_is_missing(dst_[0])) {
+    if (ngt == 1) {
+      return;  // haploid
+    } else if (bcf_gt_allele(dst_[1]) == 0 || bcf_gt_is_missing(dst_[1])) {
+      return;  // diploid
+    }
+  }
+
+  // Build FILTER value string
+  std::string filter;
+  for (int i = 0; i < rec->d.n_flt; i++) {
+    filter.append(bcf_hdr_int2id(hdr, BCF_DT_ID, rec->d.flt[i]));
+    if (i < rec->d.n_flt - 1) {
+      filter.append(";");
+    }
+  }
+  if (filter.empty()) {
+    filter = ".";
+  }
+
+  // Build ALT and GT strings
+  // Sort ALT alleles and normalize GT
+  //  - haploid GT = 1
+  //  - diploid GT = 0,1 or 1,1 or 1,2
+  std::string alt;
+  std::string gt;
+  if (ngt == 1) {
+    // haploid
+    int gt0 = bcf_gt_allele(dst_[0]);
+    alt = rec->d.allele[gt0];
+    gt = "1";
+  } else {
+    // diploid
+    int gt0 = bcf_gt_allele(dst_[0]);
+    int gt1 = bcf_gt_allele(dst_[1]);
+    std::string_view alt0{rec->d.allele[gt0]};
+    std::string_view alt1{rec->d.allele[gt1]};
+
+    if (!gt0 || !gt1) {
+      gt = "0,1";
+      alt = gt0 ? alt0 : alt1;
+    } else if (gt0 == gt1) {
+      gt = "1,1";
+      alt = alt0;
+    } else {
+      gt = "1,2";
+      if (alt0 < alt1) {
+        alt.append(alt0).append(",").append(alt1);
+      } else {
+        alt.append(alt1).append(",").append(alt0);
+      }
+    }
+  }
+
+  // Build key = "ref:alt:filter:gt"
+  std::string key(rec->d.allele[0]);
+  key.append(":").append(alt).append(":").append(filter).append(":").append(gt);
+
+  // Increment count
+  count_[key]++;
+
+  // Add sample name to the set of sample name in this query
+  sample_names_.insert(sample_name);
 }
 
 //===================================================================
 //= private functions
 //===================================================================
 
-void VariantStats::update_results() {
-  if (values_.size() > 0) {
-    for (auto& [allele, value] : values_) {
+void AlleleCount::update_results() {
+  if (count_.size() > 0) {
+    for (auto& [key, count] : count_) {
       contig_offsets_.push_back(contig_buffer_.size());
       contig_buffer_ += contig_;
       pos_buffer_.push_back(pos_);
-      allele_offsets_.push_back(allele_buffer_.size());
-      allele_buffer_ += allele;
-      for (int i = 0; i < LAST_; i++) {
-        attr_buffers_[i].push_back(value[i]);
-      }
+
+      auto tokens = utils::split(key, ":");
+      ref_offsets_.push_back(ref_buffer_.size());
+      ref_buffer_ += tokens[0];
+      alt_offsets_.push_back(alt_buffer_.size());
+      alt_buffer_ += tokens[1];
+      filter_offsets_.push_back(filter_buffer_.size());
+      filter_buffer_ += tokens[2];
+      gt_offsets_.push_back(gt_buffer_.size());
+      gt_buffer_ += tokens[3];
+
+      count_buffer_.push_back(count);
     }
-    values_.clear();
+    count_.clear();
   }
 }
 

--- a/libtiledbvcf/src/dataset/allele_count.cc
+++ b/libtiledbvcf/src/dataset/allele_count.cc
@@ -199,13 +199,18 @@ void AlleleCount::consolidate_commits(
     std::shared_ptr<Context> ctx,
     const std::vector<std::string>& tiledb_config,
     const std::string& root_uri) {
+  // Return if the array does not exist
+  tiledb::VFS vfs(*ctx);
+  if (!vfs.is_dir(get_uri(root_uri))) {
+    return;
+  }
+
+  // Return if array is empty
+  // TODO: remove after https://github.com/TileDB-Inc/TileDB/pull/3389
   {
-    // TODO: remove after https://github.com/TileDB-Inc/TileDB/pull/3389
-    Array array{*ctx, get_uri(root_uri), TILEDB_READ};
-    Query query{*ctx, array};
-    auto est_bytes = query.est_result_size("pos");
-    if (est_bytes == 0) {
-      LOG_DEBUG("AlleleCount: Skip consolidate empty commits");
+    FragmentInfo fragment_info(*ctx, get_uri(root_uri));
+    fragment_info.load();
+    if (fragment_info.fragment_num() == 0) {
       return;
     }
   }
@@ -220,6 +225,12 @@ void AlleleCount::consolidate_fragment_metadata(
     std::shared_ptr<Context> ctx,
     const std::vector<std::string>& tiledb_config,
     const std::string& root_uri) {
+  // Return if the array does not exist
+  tiledb::VFS vfs(*ctx);
+  if (!vfs.is_dir(get_uri(root_uri))) {
+    return;
+  }
+
   Config cfg;
   utils::set_tiledb_config(tiledb_config, &cfg);
   cfg["sm.consolidation.mode"] = "fragment_meta";

--- a/libtiledbvcf/src/dataset/allele_count.h
+++ b/libtiledbvcf/src/dataset/allele_count.h
@@ -24,8 +24,8 @@
  * THE SOFTWARE.
  */
 
-#ifndef TILEDB_VCF_VARIANT_STATS_H
-#define TILEDB_VCF_VARIANT_STATS_H
+#ifndef TILEDB_VCF_ALLELE_COUNT_H
+#define TILEDB_VCF_ALLELE_COUNT_H
 
 #include <atomic>
 #include <map>
@@ -39,7 +39,7 @@
 namespace tiledb::vcf {
 
 /**
- * @brief The VariantStats class adds useful variant stats to arrays at
+ * @brief The AlleleCount class adds useful variant stats to arrays at
  * ingestion time.
  *
  * The variant stats arrays contain data that is used to efficiently compute
@@ -62,7 +62,7 @@ namespace tiledb::vcf {
  * sample data from the array.
  */
 
-class VariantStats {
+class AlleleCount {
  public:
   //===================================================================
   //= public static
@@ -136,9 +136,9 @@ class VariantStats {
   //===================================================================
   //= public non-static
   //===================================================================
-  VariantStats();
+  AlleleCount();
 
-  ~VariantStats();
+  ~AlleleCount();
 
   /**
    * @brief Add a record to the stats computation buffer.
@@ -171,20 +171,15 @@ class VariantStats {
   //===================================================================
 
   // Array config
-  inline static const std::string VARIANT_STATS_ARRAY = "variant_stats";
+  inline static const std::string ALLELE_COUNT_ARRAY = "allele_count";
 
   // Array version
-  inline static const int VARIANT_STATS_VERSION = 1;
+  inline static const int ALLELE_COUNT_VERSION = 1;
 
   // Array columns
-  enum ColumnNames { CONTIG, POS, ALLELE };
-  inline static const std::vector<std::string> COLUMN_STR = {
-      "contig", "pos", "allele"};
-
-  // Array attributes
-  enum Attr { AC = 0, N_HOM, N_CALLED, LAST_ };
-  inline static const std::vector<std::string> ATTR_STR = {
-      "ac", "n_hom", "n_called"};
+  enum Columns { CONTIG, POS, REF, ALT, FILTER, GT, COUNT };
+  inline static const std::vector<std::string> COLUMN_NAME = {
+      "contig", "pos", "ref", "alt", "filter", "gt", "count"};
 
   // Number of records in the fragment
   inline static std::atomic_int contig_records_ = 0;
@@ -211,8 +206,9 @@ class VariantStats {
   // Set of sample names in this query (per thread)
   std::set<std::string> sample_names_;
 
-  // Stats per allele at the current locus: map allele -> (map attr -> value)
-  std::map<std::string, std::unordered_map<int, int32_t>> values_;
+  // Counts grouped by "key" at the current locus.
+  // Use map to keep dimension keys sorted and maintain global order.
+  std::map<std::string, int32_t> count_;
 
   // Contig of the current locus
   std::string contig_;
@@ -229,14 +225,32 @@ class VariantStats {
   // Buffer for positions
   std::vector<int32_t> pos_buffer_;
 
-  // Buffer for alleles
-  std::string allele_buffer_;
+  // Buffer for ref
+  std::string ref_buffer_;
 
-  // Buffer for allele offsets
-  std::vector<uint64_t> allele_offsets_;
+  // Buffer for ref offsets
+  std::vector<uint64_t> ref_offsets_;
 
-  // Buffer for attribute values: map Attr -> value
-  std::unordered_map<int, std::vector<int32_t>> attr_buffers_;
+  // Buffer for alt
+  std::string alt_buffer_;
+
+  // Buffer for alt offsets
+  std::vector<uint64_t> alt_offsets_;
+
+  // Buffer for filter
+  std::string filter_buffer_;
+
+  // Buffer for filter offsets
+  std::vector<uint64_t> filter_offsets_;
+
+  // Buffer for gt
+  std::string gt_buffer_;
+
+  // Buffer for gt offsets
+  std::vector<uint64_t> gt_offsets_;
+
+  // Buffer for count values
+  std::vector<int32_t> count_buffer_;
 
   // Reusable htslib buffer for bcf_get_* functions
   int* dst_ = nullptr;

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -33,6 +33,7 @@
 #include <tiledb/tiledb_experimental>  // for the new group api
 
 #include "base64/base64.h"
+#include "dataset/allele_count.h"
 #include "dataset/tiledbvcfdataset.h"
 #include "dataset/variant_stats.h"
 #include "utils/logger_public.h"
@@ -214,6 +215,8 @@ void TileDBVCFDataset::create(const CreationParams& params) {
   create_empty_metadata(ctx, params.uri, metadata, params.checksum);
   create_empty_data_array(
       ctx, params.uri, metadata, params.checksum, params.allow_duplicates);
+
+  AlleleCount::create(ctx, params.uri, params.checksum);
   VariantStats::create(ctx, params.uri, params.checksum);
 
   write_metadata_v4(ctx, params.uri, metadata);
@@ -2112,6 +2115,7 @@ void TileDBVCFDataset::consolidate_data_array_commits(
 void TileDBVCFDataset::consolidate_commits(const UtilsParams& params) {
   consolidate_data_array_commits(params);
   consolidate_vcf_header_array_commits(params);
+  AlleleCount::consolidate_commits(ctx_, params.tiledb_config, root_uri_);
   VariantStats::consolidate_commits(ctx_, params.tiledb_config, root_uri_);
 }
 
@@ -2135,6 +2139,8 @@ void TileDBVCFDataset::consolidate_fragment_metadata(
     const UtilsParams& params) {
   consolidate_data_array_fragment_metadata(params);
   consolidate_vcf_header_array_fragment_metadata(params);
+  AlleleCount::consolidate_fragment_metadata(
+      ctx_, params.tiledb_config, root_uri_);
   VariantStats::consolidate_fragment_metadata(
       ctx_, params.tiledb_config, root_uri_);
 }

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -216,8 +216,12 @@ void TileDBVCFDataset::create(const CreationParams& params) {
   create_empty_data_array(
       ctx, params.uri, metadata, params.checksum, params.allow_duplicates);
 
-  AlleleCount::create(ctx, params.uri, params.checksum);
-  VariantStats::create(ctx, params.uri, params.checksum);
+  if (params.enable_allele_count) {
+    AlleleCount::create(ctx, params.uri, params.checksum);
+  }
+  if (params.enable_variant_stats) {
+    VariantStats::create(ctx, params.uri, params.checksum);
+  }
 
   write_metadata_v4(ctx, params.uri, metadata);
 

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -62,6 +62,8 @@ struct CreationParams {
   tiledb_filter_type_t checksum = TILEDB_FILTER_CHECKSUM_SHA256;
   bool allow_duplicates = true;
   std::string vcf_uri;
+  bool enable_allele_count = false;
+  bool enable_variant_stats = false;
 };
 
 /** Arguments/params for dataset registration. */

--- a/libtiledbvcf/src/dataset/variant_stats.cc
+++ b/libtiledbvcf/src/dataset/variant_stats.cc
@@ -198,16 +198,22 @@ void VariantStats::consolidate_commits(
     std::shared_ptr<Context> ctx,
     const std::vector<std::string>& tiledb_config,
     const std::string& root_uri) {
+  // Return if the array does not exist
+  tiledb::VFS vfs(*ctx);
+  if (!vfs.is_dir(get_uri(root_uri))) {
+    return;
+  }
+
+  // Return if array is empty
+  // TODO: remove after https://github.com/TileDB-Inc/TileDB/pull/3389
   {
-    // TODO: remove after https://github.com/TileDB-Inc/TileDB/pull/3389
-    Array array{*ctx, get_uri(root_uri), TILEDB_READ};
-    Query query{*ctx, array};
-    auto est_bytes = query.est_result_size("pos");
-    if (est_bytes == 0) {
-      LOG_DEBUG("VariantStats: Skip consolidate empty commits");
+    FragmentInfo fragment_info(*ctx, get_uri(root_uri));
+    fragment_info.load();
+    if (fragment_info.fragment_num() == 0) {
       return;
     }
   }
+
   Config cfg;
   utils::set_tiledb_config(tiledb_config, &cfg);
   cfg["sm.consolidation.mode"] = "commits";
@@ -218,6 +224,12 @@ void VariantStats::consolidate_fragment_metadata(
     std::shared_ptr<Context> ctx,
     const std::vector<std::string>& tiledb_config,
     const std::string& root_uri) {
+  // Return if the array does not exist
+  tiledb::VFS vfs(*ctx);
+  if (!vfs.is_dir(get_uri(root_uri))) {
+    return;
+  }
+
   Config cfg;
   utils::set_tiledb_config(tiledb_config, &cfg);
   cfg["sm.consolidation.mode"] = "fragment_meta";

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -381,7 +381,7 @@ void Reader::read() {
   } else {
     LOG_INFO(fmt::format(
         std::locale(""),
-        "Done. Exported {:L} records in {} seconds.",
+        "Done. Exported {:L} records in {:.3f} seconds.",
         read_state_.last_num_records_exported,
         utils::chrono_duration(start_all)));
   }
@@ -978,11 +978,12 @@ bool Reader::read_current_batch() {
   do {
     // Run query and get status
     auto query_start_timer = std::chrono::steady_clock::now();
-    LOG_DEBUG("TileDB query started. (VmRSS = {})", utils::memory_usage_str());
+    LOG_INFO("TileDB query started. (VmRSS = {})", utils::memory_usage_str());
     auto query_status = query->submit();
     LOG_INFO(
-        "TileDB query completed in {} sec.",
-        utils::chrono_duration(query_start_timer));
+        "TileDB query completed in {:.3f} sec. (VmRSS = {})",
+        utils::chrono_duration(query_start_timer),
+        utils::memory_usage_str());
 
     read_state_.query_results.set_results(*dataset_, buffers_a.get(), *query);
 
@@ -1026,7 +1027,7 @@ bool Reader::read_current_batch() {
     if (params_.enable_progress_estimation &&
         read_state_.query_estimated_num_records > 0) {
       LOG_INFO(
-          "Processed {} cells in {} sec. Reported {} cells. Approximately "
+          "Processed {} cells in {:.3f} sec. Reported {} cells. Approximately "
           "{:.1f}% completed with query cells.",
           read_state_.query_results.num_cells(),
           utils::chrono_duration(processing_start_timer),
@@ -1038,7 +1039,7 @@ bool Reader::read_current_batch() {
                   100.0));
     } else {
       LOG_INFO(
-          "Processed {} cells in {} sec. Reported {} cells.",
+          "Processed {} cells in {:.3f} sec. Reported {} cells.",
           read_state_.query_results.num_cells(),
           utils::chrono_duration(processing_start_timer),
           read_state_.last_num_records_exported - old_num_exported);
@@ -1761,7 +1762,7 @@ void Reader::prepare_regions_v4(
         params_.regions_file_uri, &pre_partition_regions_list);
     LOG_INFO(fmt::format(
         std::locale(""),
-        "Parsed bed file into {:L} regions in {} seconds.",
+        "Parsed bed file into {:L} regions in {:.3f} seconds.",
         pre_partition_regions_list.size(),
         utils::chrono_duration(start_bed_file_parse)));
   }
@@ -1802,7 +1803,7 @@ void Reader::prepare_regions_v4(
 
     LOG_DEBUG(fmt::format(
         std::locale(""),
-        "Sorted {:L} regions in {} seconds.",
+        "Sorted {:L} regions in {:.3f} seconds.",
         regions->size(),
         utils::chrono_duration(start_region_sort)));
   }
@@ -2012,7 +2013,7 @@ void Reader::prepare_regions_v3(
         params_.regions_file_uri, &pre_partition_regions_list);
     LOG_DEBUG(fmt::format(
         std::locale(""),
-        "Parsed bed file into {:L} regions in {} seconds.",
+        "Parsed bed file into {:L} regions in {:.3f} seconds.",
         pre_partition_regions_list.size(),
         utils::chrono_duration(start_bed_file_parse)));
   }
@@ -2057,7 +2058,7 @@ void Reader::prepare_regions_v3(
     Region::sort(dataset_->metadata().contig_offsets, regions);
     LOG_DEBUG(fmt::format(
         std::locale(""),
-        "Sorted {:L} regions in {} seconds.",
+        "Sorted {:L} regions in {:.3f} seconds.",
         regions->size(),
         utils::chrono_duration(start_region_sort)));
   }
@@ -2140,7 +2141,7 @@ void Reader::prepare_regions_v2(
         params_.regions_file_uri, &pre_partition_regions_list);
     LOG_DEBUG(fmt::format(
         std::locale(""),
-        "Parsed bed file into {:L} regions in {} seconds.",
+        "Parsed bed file into {:L} regions in {:.3f} seconds.",
         pre_partition_regions_list.size(),
         utils::chrono_duration(start_bed_file_parse)));
   }
@@ -2187,7 +2188,7 @@ void Reader::prepare_regions_v2(
     Region::sort(dataset_->metadata().contig_offsets, regions);
     LOG_DEBUG(fmt::format(
         std::locale(""),
-        "Sorted {:L} regions in {} seconds.",
+        "Sorted {:L} regions in {:.3f} seconds.",
         regions->size(),
         utils::chrono_duration(start_region_sort)));
   }

--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -45,6 +45,7 @@ Writer::Writer() {
 
 Writer::~Writer() {
   utils::free_htslib_tiledb_context();
+  AlleleCount::close();
   VariantStats::close();
 }
 
@@ -129,6 +130,7 @@ void Writer::init(const IngestionParams& params) {
   creation_params_.checksum = TILEDB_FILTER_CHECKSUM_SHA256;
   creation_params_.allow_duplicates = true;
 
+  AlleleCount::init(ctx_, params.uri);
   VariantStats::init(ctx_, params.uri);
 }
 
@@ -466,6 +468,7 @@ void Writer::ingest_samples() {
       "All finalize tasks successfully completed. Waited for {} sec.",
       utils::chrono_duration(t0));
 
+  AlleleCount::close();
   VariantStats::close();
   array_->close();
 
@@ -954,6 +957,7 @@ std::pair<uint64_t, uint64_t> Writer::ingest_samples_v4(
                 TRY_CATCH_THROW(finalize_tasks_.emplace_back(std::async(
                     std::launch::async, finalize_query, std::move(query_))));
 
+                AlleleCount::finalize();
                 VariantStats::finalize();
               }
 
@@ -1063,6 +1067,7 @@ std::pair<uint64_t, uint64_t> Writer::ingest_samples_v4(
   // Write anchors stored in the anchor worker.
   anchors_ingested += write_anchors(anchor_worker);
 
+  AlleleCount::finalize();
   VariantStats::finalize();
 
   // Start new query for new fragment for next contig

--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -1380,5 +1380,13 @@ void Writer::set_contig_mode(int contig_mode) {
       static_cast<IngestionParams::ContigMode>(contig_mode);
 }
 
+void Writer::set_enable_allele_count(bool enable) {
+  creation_params_.enable_allele_count = enable;
+}
+
+void Writer::set_enable_variant_stats(bool enable) {
+  creation_params_.enable_variant_stats = enable;
+}
+
 }  // namespace vcf
 }  // namespace tiledb

--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -392,7 +392,7 @@ void Writer::ingest_samples() {
           &scratch_space_a));
 
   LOG_DEBUG(
-      "Initialization completed in {} seconds.",
+      "Initialization completed in {:.3f} seconds.",
       utils::chrono_duration(start_all));
   uint64_t records_ingested = 0, anchors_ingested = 0;
   uint64_t samples_ingested = 0;

--- a/libtiledbvcf/src/write/writer.h
+++ b/libtiledbvcf/src/write/writer.h
@@ -358,6 +358,16 @@ class Writer {
   /** Set contig ingestion mode. */
   void set_contig_mode(int contig_mode);
 
+  /**
+    Enable the allele count ingestion task
+  */
+  void set_enable_allele_count(bool enable);
+
+  /**
+    Enable the variant stats ingestion task
+  */
+  void set_enable_variant_stats(bool enable);
+
  private:
   /* ********************************* */
   /*          PRIVATE ATTRIBUTES       */

--- a/libtiledbvcf/src/write/writer_worker.h
+++ b/libtiledbvcf/src/write/writer_worker.h
@@ -89,6 +89,7 @@ class WriterWorker {
    */
   virtual bool resume() = 0;
 
+  /** Flush ingestion tasks. */
   virtual void flush_ingestion_tasks() {
   }
 

--- a/libtiledbvcf/src/write/writer_worker_v4.cc
+++ b/libtiledbvcf/src/write/writer_worker_v4.cc
@@ -258,6 +258,7 @@ bool WriterWorkerV4::resume() {
 }
 
 void WriterWorkerV4::flush_ingestion_tasks() {
+  ac_.flush();
   vs_.flush();
 }
 
@@ -300,8 +301,9 @@ bool WriterWorkerV4::buffer_record(const RecordHeapV4::Node& node) {
   const uint32_t pos = r->pos;
   const uint32_t end_pos = VCFUtils::get_end_pos(hdr, r, &val_);
 
-  // Process only NodeType::Record
+  // Ingestion tasks process only NodeType::Record
   if (node.type == RecordHeapV4::NodeType::Record) {
+    ac_.process(hdr, sample_name, contig, pos, r);
     vs_.process(hdr, sample_name, contig, pos, r);
   }
 

--- a/libtiledbvcf/src/write/writer_worker_v4.h
+++ b/libtiledbvcf/src/write/writer_worker_v4.h
@@ -36,6 +36,7 @@
 #include <htslib/vcf.h>
 #include <tiledb/tiledb>
 
+#include "dataset/allele_count.h"
 #include "dataset/attribute_buffer_set.h"
 #include "dataset/tiledbvcfdataset.h"
 #include "dataset/variant_stats.h"
@@ -140,6 +141,10 @@ class WriterWorkerV4 : public WriterWorker {
   /** Record heap for storing anchors. */
   RecordHeapV4 anchor_heap_;
 
+  // Allele count ingestion task object
+  AlleleCount ac_;
+
+  // Variant stats ingestion task object
   VariantStats vs_;
 
   /**

--- a/libtiledbvcf/test/run-cli-tests.sh
+++ b/libtiledbvcf/test/run-cli-tests.sh
@@ -452,8 +452,8 @@ cd -
 # -------------------------------------------------------------------
 rm -rf task.tdb
 $tilevcf create -u task.tdb --enable-allele-count --enable-variant-stats --log-level debug || exit 1
-test -e task/allele_count || exit 1
-test -e task/variant_stats || exit 1
+test -e task.tdb/allele_count || exit 1
+test -e task.tdb/variant_stats || exit 1
 
 # -------------------------------------------------------------------
 

--- a/libtiledbvcf/test/run-cli-tests.sh
+++ b/libtiledbvcf/test/run-cli-tests.sh
@@ -448,6 +448,15 @@ bcftools view -H tiledb.vcf
 cd -
 # -------------------------------------------------------------------
 
+# ingestion task enable
+# -------------------------------------------------------------------
+rm -rf task.tdb
+$tilevcf create -u task.tdb --enable-allele-count --enable-variant-stats --log-level debug || exit 1
+test -e task/allele_count || exit 1
+test -e task/variant_stats || exit 1
+
+# -------------------------------------------------------------------
+
 # Expected failures
 echo ""
 echo "** Expected failure error messages follow:"


### PR DESCRIPTION
This PR adds optional ingestion tasks to efficiently compute allele count and allele frequency. 

Ingestion tasks create arrays containing useful statistics at ingestion time. This approach is very efficient because ingestion is already reading every VCF record.

**NOTE:** The ingestion task must be enabled at array creation time.

**Python**
```python
ds = tiledbvcf.Dataset(uri, mode="w")
ds.create_dataset(enable_allele_count=True, enable_variant_stats=True)
```

**CLI**
```bash
tiledbvcf create -u vcf.tdb --enable-allele-count --enable-variant-stats
```

Ingestion task overview:
* The `allele_count` task creates an array of called allele counts, for example:
```
         pos                    ref                                                alt filter   gt  count
0    5041703                     TA                                  T,TAAAAAAAAAAAAAA   PASS  1,2      1
1    5041703                     TA                                T,TAAAAAAAAAAAAAAAA   PASS  1,2      1
2    5041703                    TAA                                               T,TA   PASS  1,2      1
3    5046753                      G                                              C,GCC   PASS  1,2     11
```
* The `variant_stats` task creates an array used to compute allele frequencies, for example:
```
pos	       allele   ac          an          af
43036308       C        781         1026        0.761209
               T        245         1026        0.238791
43036324       A        1218        3708        0.328479
               G        2490        3708        0.671521
```