### PR TITLE
chore: [sc-20180] Upgrade TileDB-VCF to TileDB 2.11

### DIFF
--- a/apis/java/build.gradle
+++ b/apis/java/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'io.tiledb'
-version '0.18.0'
+version '0.19.0'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/apis/spark/build.gradle
+++ b/apis/spark/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'io.tiledb'
-version '0.18.0'
+version '0.19.0'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/apis/spark3/build.gradle
+++ b/apis/spark3/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'io.tiledb'
-version '0.18.0'
+version '0.19.0'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/libtiledbvcf/cmake/Modules/FindTileDB_EP.cmake
+++ b/libtiledbvcf/cmake/Modules/FindTileDB_EP.cmake
@@ -48,20 +48,20 @@ else()
     # Try to download prebuilt artifacts unless the user specifies to build from source
     if(DOWNLOAD_TILEDB_PREBUILT)
         if (WIN32) # Windows
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.10.3/tiledb-windows-x86_64-2.10.3-7a5d1cd.zip")
-          SET(DOWNLOAD_SHA1 "aa4030a55339d23ef25a0d9593dbad76e9246742")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.11.0/tiledb-windows-x86_64-2.11.0-34e5dbc.zip")
+          SET(DOWNLOAD_SHA1 "ae60d7bea72472716cb85631c27f8d2ddc7d7dd7")
         elseif(APPLE) # OSX
 
           if (CMAKE_OSX_ARCHITECTURES STREQUAL x86_64 OR CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(AMD64|amd64)|(^i.86$)")
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.10.3/tiledb-macos-x86_64-2.10.3-7a5d1cd.tar.gz")
-            SET(DOWNLOAD_SHA1 "897c17caec445f74114ac1c6e7d453d6f6d1c2e7")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.11.0/tiledb-macos-x86_64-2.11.0-34e5dbc.tar.gz")
+            SET(DOWNLOAD_SHA1 "56e865574404cb11cbd631c7c25ab0cfd413f9b3")
           elseif (CMAKE_OSX_ARCHITECTURES STREQUAL arm64 OR CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.10.3/tiledb-macos-arm64-2.10.3-7a5d1cd.tar.gz")
-            SET(DOWNLOAD_SHA1 "d37a2800ae47469a070fbdd4e90249ba776382e3")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.11.0/tiledb-macos-arm64-2.11.0-34e5dbc.tar.gz")
+            SET(DOWNLOAD_SHA1 "f5f409579ca1210478155238c1e929a4c7d5ca68")
           endif()
         else() # Linux
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.10.3/tiledb-linux-x86_64-2.10.3-7a5d1cd.tar.gz")
-          SET(DOWNLOAD_SHA1 "49387ad851693a748d17d638a7d716ad62ac8706")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.11.0/tiledb-linux-x86_64-2.11.0-34e5dbc.tar.gz")
+          SET(DOWNLOAD_SHA1 "c2eb91e352905728edfeb8dc0a6fbfd7bc69ef66")
         endif()
 
         ExternalProject_Add(ep_tiledb
@@ -83,8 +83,8 @@ else()
     else() # Build from source
         ExternalProject_Add(ep_tiledb
           PREFIX "externals"
-          URL "https://github.com/TileDB-Inc/TileDB/archive/2.10.3.zip"
-          URL_HASH SHA1=dae340e516371f9354b5b9d4ac0103726b340797
+          URL "https://github.com/TileDB-Inc/TileDB/archive/2.11.0.zip"
+          URL_HASH SHA1=47eef9c8196fd1104ce65cb2f79f4a818d36aa1c
           DOWNLOAD_NAME "tiledb.zip"
           CMAKE_ARGS
             -DCMAKE_INSTALL_PREFIX=${EP_INSTALL_PREFIX}

--- a/libtiledbvcf/src/dataset/allele_count.cc
+++ b/libtiledbvcf/src/dataset/allele_count.cc
@@ -24,8 +24,6 @@
  * THE SOFTWARE.
  */
 
-#include <tiledb/tiledb_experimental>  // for the new group api
-
 #include "dataset/allele_count.h"
 #include "utils/logger_public.h"
 #include "utils/utils.h"

--- a/libtiledbvcf/src/dataset/allele_count.h
+++ b/libtiledbvcf/src/dataset/allele_count.h
@@ -35,6 +35,7 @@
 
 #include <htslib/vcf.h>
 #include <tiledb/tiledb>
+#include <tiledb/tiledb_experimental>  // for the new group api
 
 namespace tiledb::vcf {
 

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -30,8 +30,6 @@
 #include <string>
 #include <vector>
 
-#include <tiledb/tiledb_experimental>  // for the new group api
-
 #include "base64/base64.h"
 #include "dataset/allele_count.h"
 #include "dataset/tiledbvcfdataset.h"

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -37,6 +37,7 @@
 #include <htslib/vcf.h>
 #include <future>
 #include <tiledb/tiledb>
+#include <tiledb/tiledb_experimental>  // for the new group api
 
 #include "utils/rwlock.h"
 #include "utils/sample_utils.h"

--- a/libtiledbvcf/src/dataset/variant_stats.cc
+++ b/libtiledbvcf/src/dataset/variant_stats.cc
@@ -24,8 +24,6 @@
  * THE SOFTWARE.
  */
 
-#include <tiledb/tiledb_experimental>  // for the new group api
-
 #include "dataset/variant_stats.h"
 #include "utils/logger_public.h"
 #include "utils/utils.h"

--- a/libtiledbvcf/src/dataset/variant_stats.h
+++ b/libtiledbvcf/src/dataset/variant_stats.h
@@ -35,6 +35,7 @@
 
 #include <htslib/vcf.h>
 #include <tiledb/tiledb>
+#include <tiledb/tiledb_experimental>  // for the new group api
 
 namespace tiledb::vcf {
 


### PR DESCRIPTION
Story details: https://app.shortcut.com/tiledb-inc/story/20180