### PR TITLE
Pre-allocate htslib buffer to avoid realloc failures

### DIFF
--- a/libtiledbvcf/src/vcf/vcf_merger.cc
+++ b/libtiledbvcf/src/vcf/vcf_merger.cc
@@ -10,9 +10,15 @@ namespace vcf {
 VCFMerger::VCFMerger()
     : hdr_(nullptr, bcf_hdr_destroy)
     , rec_(bcf_init(), bcf_destroy) {
+  // Allocate buffer for htslib
+  ndst_ = HTSLIB_BUFFER_SIZE;
+  dst_ = (int*)malloc(ndst_);
 }
 
 VCFMerger::~VCFMerger() {
+  if (dst_) {
+    free(dst_);
+  }
 }
 
 void VCFMerger::init(
@@ -64,10 +70,6 @@ void VCFMerger::close() {
       "VCFMerger closed: {} records in {} records out",
       write_count_,
       read_count_);
-
-  if (dst_) {
-    free(dst_);
-  }
 }
 
 void VCFMerger::write(const std::string& sample_name, SafeBCFRec rec) {

--- a/libtiledbvcf/src/vcf/vcf_merger.h
+++ b/libtiledbvcf/src/vcf/vcf_merger.h
@@ -152,6 +152,8 @@ class VCFMerger {
   }
 
  private:
+  inline static const int HTSLIB_BUFFER_SIZE = 8192;
+
   struct SampleRecord {
     SafeBCFRec record;
     int sample_num = -1;


### PR DESCRIPTION
Pre-allocate a large buffer to avoid htslib realloc failures during combined VCF export. The pre-allocated buffer size of 8192 bytes is much larger then the buffer needed while combining VCF samples from a portion of the NYGC 1000 genome dataset, which was < 256 bytes.

Another option would be to let htslib allocate buffers each time they are needed, but this could create memory fragmentation issues.

