### PR TITLE
Check for an exact sample range match when resuming ingestion

### DIFF
--- a/libtiledbvcf/cmake/Modules/FindTileDB_EP.cmake
+++ b/libtiledbvcf/cmake/Modules/FindTileDB_EP.cmake
@@ -48,20 +48,20 @@ else()
     # Try to download prebuilt artifacts unless the user specifies to build from source
     if(DOWNLOAD_TILEDB_PREBUILT)
         if (WIN32) # Windows
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.11.0/tiledb-windows-x86_64-2.11.0-34e5dbc.zip")
-          SET(DOWNLOAD_SHA1 "ae60d7bea72472716cb85631c27f8d2ddc7d7dd7")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.11.3/tiledb-windows-x86_64-2.11.3-a55a910.zip")
+          SET(DOWNLOAD_SHA1 "0bd042b1c56da9fc1c20b2156e942c23ba1865ac")
         elseif(APPLE) # OSX
 
           if (CMAKE_OSX_ARCHITECTURES STREQUAL x86_64 OR CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(AMD64|amd64)|(^i.86$)")
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.11.0/tiledb-macos-x86_64-2.11.0-34e5dbc.tar.gz")
-            SET(DOWNLOAD_SHA1 "56e865574404cb11cbd631c7c25ab0cfd413f9b3")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.11.3/tiledb-macos-x86_64-2.11.3-a55a910.tar.gz")
+            SET(DOWNLOAD_SHA1 "f0f091f8401cb1b4060fb3068fe7fc4afdc262b7")
           elseif (CMAKE_OSX_ARCHITECTURES STREQUAL arm64 OR CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.11.0/tiledb-macos-arm64-2.11.0-34e5dbc.tar.gz")
-            SET(DOWNLOAD_SHA1 "f5f409579ca1210478155238c1e929a4c7d5ca68")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.11.3/tiledb-macos-arm64-2.11.3-a55a910.tar.gz")
+            SET(DOWNLOAD_SHA1 "6e62360b154af399cc00e74ce6098ef977e04848")
           endif()
         else() # Linux
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.11.0/tiledb-linux-x86_64-2.11.0-34e5dbc.tar.gz")
-          SET(DOWNLOAD_SHA1 "c2eb91e352905728edfeb8dc0a6fbfd7bc69ef66")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.11.3/tiledb-linux-x86_64-2.11.3-a55a910.tar.gz")
+          SET(DOWNLOAD_SHA1 "5c2f44d9ca9b34e61230fd0f0a763f0fffa04702")
         endif()
 
         ExternalProject_Add(ep_tiledb
@@ -83,8 +83,8 @@ else()
     else() # Build from source
         ExternalProject_Add(ep_tiledb
           PREFIX "externals"
-          URL "https://github.com/TileDB-Inc/TileDB/archive/2.11.0.zip"
-          URL_HASH SHA1=47eef9c8196fd1104ce65cb2f79f4a818d36aa1c
+          URL "https://github.com/TileDB-Inc/TileDB/archive/2.11.3.zip"
+          URL_HASH SHA1=f159b1677d9d0471c8f97fe4b0492cef156730f2
           DOWNLOAD_NAME "tiledb.zip"
           CMAKE_ARGS
             -DCMAKE_INSTALL_PREFIX=${EP_INSTALL_PREFIX}

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -2407,20 +2407,20 @@ std::unordered_map<
     std::pair<std::string, std::string>,
     std::vector<std::pair<std::string, std::string>>,
     tiledb::vcf::pair_hash>
-TileDBVCFDataset::fragment_contig_sample_list() {
+TileDBVCFDataset::fragment_sample_contig_list() {
   if (metadata_.version == Version::V2 || metadata_.version == Version::V3)
     throw std::runtime_error(
         "Fragment contig sample listing not supported for v2/v3 datasets");
 
   assert(metadata_.version == Version::V4);
-  return fragment_contig_sample_list_v4();
+  return fragment_sample_contig_list_v4();
 }
 
 std::unordered_map<
     std::pair<std::string, std::string>,
     std::vector<std::pair<std::string, std::string>>,
     tiledb::vcf::pair_hash>
-TileDBVCFDataset::fragment_contig_sample_list_v4() {
+TileDBVCFDataset::fragment_sample_contig_list_v4() {
   const auto fragment_info = data_array_fragment_info();
   std::unordered_map<
       std::pair<std::string, std::string>,
@@ -2434,12 +2434,12 @@ TileDBVCFDataset::fragment_contig_sample_list_v4() {
         fragment_sample_range.first, fragment_sample_range.second);
     auto contigs = std::make_pair(
         fragment_contig_range.first, fragment_contig_range.second);
-    if (results.find(contigs) == results.end()) {
+    if (results.find(samples) == results.end()) {
       results.emplace(
-          contigs, std::vector<std::pair<std::string, std::string>>{samples});
+          samples, std::vector<std::pair<std::string, std::string>>{contigs});
     } else {
-      auto& vec = results.at(contigs);
-      vec.emplace_back(samples);
+      auto& vec = results.at(samples);
+      vec.emplace_back(contigs);
     }
   }
 

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -683,12 +683,12 @@ class TileDBVCFDataset {
       std::pair<std::string, std::string>,
       std::vector<std::pair<std::string, std::string>>,
       tiledb::vcf::pair_hash>
-  fragment_contig_sample_list();
+  fragment_sample_contig_list();
   std::unordered_map<
       std::pair<std::string, std::string>,
       std::vector<std::pair<std::string, std::string>>,
       tiledb::vcf::pair_hash>
-  fragment_contig_sample_list_v4();
+  fragment_sample_contig_list_v4();
 
  private:
   /* ********************************* */

--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -105,7 +105,7 @@ void Writer::init(const IngestionParams& params) {
       params.tiledb_stats_enabled_vcf_header_array);
 
   dataset_->open(
-      params.uri, params.tiledb_config, !params.load_data_array_fragment_info);
+      params.uri, params.tiledb_config, params.load_data_array_fragment_info);
 
   // Set htslib global config and context based on user passed TileDB config
   // options
@@ -782,27 +782,27 @@ std::pair<uint64_t, uint64_t> Writer::ingest_samples_v4(
 
       // Loop over existing fragments
       for (const auto& [contigs, samples] : existing_contig_sample_fragments) {
-        LOG_TRACE(
-            "Resume check: {} in ({}, {})",
+        LOG_DEBUG(
+            "Resume: check if contig {} contained in existing ({}, {})",
             contig,
             contigs.first,
             contigs.second);
-        // If contig contained in a fragment
+        // If the batch contig is contained in the fragment's contig range,
+        // check for an exact match in sample ranges
         if (contig >= contigs.first && contig <= contigs.second) {
           // Loop over sample non-empty domains for the contig
           for (auto& sample_range : samples) {
-            // If the fragment samples are contained within the batch sample
-            // range, skip this region
-            LOG_TRACE(
-                "Resume check: ({}, {}) in ({}, {})",
+            LOG_DEBUG(
+                "Resume: check if sample domain ({}, {}) "
+                "matches existing ({}, {})",
                 sample_range.first,
                 sample_range.second,
                 first_sample_name,
                 last_sample_name);
-            if ((sample_range.first >= first_sample_name &&
-                 sample_range.first <= last_sample_name) &&
-                (sample_range.second >= first_sample_name &&
-                 sample_range.second <= last_sample_name)) {
+            // If the batch sample range exactly matches the fragment's sample
+            // range, skip this region
+            if (sample_range.first == first_sample_name &&
+                sample_range.second == last_sample_name) {
               skip = true;
               break;
             }
@@ -821,7 +821,7 @@ std::pair<uint64_t, uint64_t> Writer::ingest_samples_v4(
         it++;
       }
     }
-    LOG_DEBUG("Resume: regions after resume check = {}", regions.size());
+    LOG_DEBUG("Resume: regions after resume check = {}", regions_v4.size());
   }
 
   // If there were no regions in the VCF files return early
@@ -1050,8 +1050,9 @@ std::pair<uint64_t, uint64_t> Writer::ingest_samples_v4(
     }
     if (records_ingested > prev_records) {
       LOG_INFO(
-          "Ingestion rate = {:.3f} records/sec",
-          (records_ingested - prev_records) / utils::chrono_duration(start));
+          "Ingestion rate = {:.3f} records/sec (VmRSS = {})",
+          (records_ingested - prev_records) / utils::chrono_duration(start),
+          utils::memory_usage_str());
     }
   }
 


### PR DESCRIPTION
The resume ingestion logic was changed in #434 to check for an overlap between sample names in the batch being ingested and sample names in existing fragments. This approach does not work when sample names are not sorted.

This PR checks for an exact match between the ingested batch's sample range and the sample range of all existing fragments. If a match is found, and the contig is contained in an existing fragment for the sample range, the contig is skipped.
