### PR TITLE
Initialize VFS plugin for htslib in dataset create path

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -33,7 +33,7 @@ stages:
             DOWNLOAD_TILEDB_PREBUILT: OFF
             ARTIFACT_NAME: linux_tiledb_source_build
           macos:
-            imageName: 'macOS-10.15'
+            imageName: 'macOS-11'
             python.version: '3.7'
             CXX: clang++
             BUILD_PYTHON_API: ON
@@ -90,7 +90,7 @@ stages:
               BUILD_PYTHON_API: ON
               BUILD_SPARK_API: ON
             mac:
-              imageName: 'macOS-10.15'
+              imageName: 'macOS-11'
               python.version: '3.7'
               CXX: clang++
               BUILD_PYTHON_API: ON

--- a/apis/java/build.gradle
+++ b/apis/java/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'io.tiledb'
-version '0.19.1'
+version '0.19.2'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/apis/spark/build.gradle
+++ b/apis/spark/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'io.tiledb'
-version '0.19.1'
+version '0.19.2'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/apis/spark3/build.gradle
+++ b/apis/spark3/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'io.tiledb'
-version '0.19.1'
+version '0.19.2'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -189,7 +189,10 @@ std::vector<std::string> TileDBVCFDataset::get_vcf_attributes(std::string uri) {
 void TileDBVCFDataset::create(const CreationParams& params) {
   LOG_TRACE("Create dataset: {}", params.uri);
 
+  // Add VFS plugin to htslib, so we can read VCF attributes through VFS
+  // (for example, when reading a VCF file from s3 with an ARN)
   utils::init_htslib();
+
   // Set htslib global config and context based on user passed TileDB config
   // options
   utils::set_htslib_tiledb_context(params.tiledb_config);

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -189,6 +189,10 @@ std::vector<std::string> TileDBVCFDataset::get_vcf_attributes(std::string uri) {
 void TileDBVCFDataset::create(const CreationParams& params) {
   LOG_TRACE("Create dataset: {}", params.uri);
 
+  // Set htslib global config and context based on user passed TileDB config
+  // options
+  utils::set_htslib_tiledb_context(params.tiledb_config);
+
   Config cfg;
   utils::set_tiledb_config(params.tiledb_config, &cfg);
   Context ctx(cfg);

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -189,6 +189,7 @@ std::vector<std::string> TileDBVCFDataset::get_vcf_attributes(std::string uri) {
 void TileDBVCFDataset::create(const CreationParams& params) {
   LOG_TRACE("Create dataset: {}", params.uri);
 
+  utils::init_htslib();
   // Set htslib global config and context based on user passed TileDB config
   // options
   utils::set_htslib_tiledb_context(params.tiledb_config);


### PR DESCRIPTION
Initialize VFS plugin for htslib in dataset create path, so we can read VCF attributes from a VCF file that needs additional access rights.