### PR TITLE
Create new query after finalize in stats ingestion tasks

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -57,7 +57,7 @@ stages:
     jobs:
       - job: Build
         pool:
-          vmImage: 'ubuntu-18.04'
+          vmImage: 'ubuntu-22.04'
         strategy:
           matrix:
             cli:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   backport:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     name: Backport
     steps:
       - name: Backport

--- a/apis/python/tests/test_tiledbvcf.py
+++ b/apis/python/tests/test_tiledbvcf.py
@@ -962,7 +962,6 @@ def test_disable_ingestion_tasks(tmp_path):
             df = A.query(attrs=["allele", "ac"], dims=["pos"]).df[contig, region]
 
 
-@pytest.mark.skip
 def test_ingestion_tasks(tmp_path):
     # Create the dataset
     uri = os.path.join(tmp_path, "dataset")

--- a/libtiledbvcf/src/dataset/allele_count.cc
+++ b/libtiledbvcf/src/dataset/allele_count.cc
@@ -189,6 +189,8 @@ void AlleleCount::close() {
     array_ = nullptr;
   }
 
+  // Release the context shared_ptr
+  ctx_ = nullptr;
   enabled_ = false;
 }
 

--- a/libtiledbvcf/src/dataset/allele_count.cc
+++ b/libtiledbvcf/src/dataset/allele_count.cc
@@ -132,6 +132,7 @@ void AlleleCount::init(
 
   query_ = std::make_unique<Query>(*ctx, *array_);
   query_->set_layout(TILEDB_GLOBAL_ORDER);
+  ctx_ = ctx;
 }
 
 void AlleleCount::finalize() {
@@ -165,6 +166,9 @@ void AlleleCount::finalize() {
 
     fragment_sample_names_.clear();
   }
+
+  query_ = std::make_unique<Query>(*ctx_, *array_);
+  query_->set_layout(TILEDB_GLOBAL_ORDER);
 }
 
 void AlleleCount::close() {

--- a/libtiledbvcf/src/dataset/allele_count.h
+++ b/libtiledbvcf/src/dataset/allele_count.h
@@ -185,6 +185,9 @@ class AlleleCount {
   // Number of records in the fragment
   inline static std::atomic_int contig_records_ = 0;
 
+  // TileDB context pointer
+  inline static std::shared_ptr<Context> ctx_ = nullptr;
+
   // TileDB array pointer
   inline static std::unique_ptr<Array> array_ = nullptr;
 

--- a/libtiledbvcf/src/dataset/variant_stats.cc
+++ b/libtiledbvcf/src/dataset/variant_stats.cc
@@ -188,6 +188,8 @@ void VariantStats::close() {
     array_ = nullptr;
   }
 
+  // Release the context shared_ptr
+  ctx_ = nullptr;
   enabled_ = false;
 }
 

--- a/libtiledbvcf/src/dataset/variant_stats.cc
+++ b/libtiledbvcf/src/dataset/variant_stats.cc
@@ -131,6 +131,7 @@ void VariantStats::init(
 
   query_ = std::make_unique<Query>(*ctx, *array_);
   query_->set_layout(TILEDB_GLOBAL_ORDER);
+  ctx_ = ctx;
 }
 
 void VariantStats::finalize() {
@@ -164,6 +165,9 @@ void VariantStats::finalize() {
 
     fragment_sample_names_.clear();
   }
+
+  query_ = std::make_unique<Query>(*ctx_, *array_);
+  query_->set_layout(TILEDB_GLOBAL_ORDER);
 }
 
 void VariantStats::close() {

--- a/libtiledbvcf/src/dataset/variant_stats.h
+++ b/libtiledbvcf/src/dataset/variant_stats.h
@@ -190,6 +190,9 @@ class VariantStats {
   // Number of records in the fragment
   inline static std::atomic_int contig_records_ = 0;
 
+  // TileDB context pointer
+  inline static std::shared_ptr<Context> ctx_ = nullptr;
+
   // TileDB array pointer
   inline static std::unique_ptr<Array> array_ = nullptr;
 


### PR DESCRIPTION
Create a new query after each finalize call instead of reusing the query in the `variant_stats` and `allele_count` ingestion tasks.