### PR TITLE
Improve consolidate and vacuum

### DIFF
--- a/libtiledbvcf/src/cli/tiledbvcf.cc
+++ b/libtiledbvcf/src/cli/tiledbvcf.cc
@@ -172,7 +172,7 @@ void do_utils_consolidate_commits(
   tiledb::Config cfg;
   utils::set_tiledb_config(args.tiledb_config, &cfg);
   TileDBVCFDataset dataset(cfg);
-  dataset.open(args.uri, args.tiledb_config);
+  LOG_DEBUG("Consoldate commits.");
   dataset.consolidate_commits(args);
   LOG_TRACE("Finished utils consolidate commits command.");
 }
@@ -185,7 +185,7 @@ void do_utils_consolidate_fragments(
   tiledb::Config cfg;
   utils::set_tiledb_config(args.tiledb_config, &cfg);
   TileDBVCFDataset dataset(cfg);
-  dataset.open(args.uri, args.tiledb_config);
+  LOG_DEBUG("Consoldate fragments.");
   dataset.consolidate_fragments(args);
   LOG_TRACE("Finished utils consolidate fragments command.");
 }
@@ -198,7 +198,7 @@ void do_utils_consolidate_fragment_metadata(
   tiledb::Config cfg;
   utils::set_tiledb_config(args.tiledb_config, &cfg);
   TileDBVCFDataset dataset(cfg);
-  dataset.open(args.uri, args.tiledb_config);
+  LOG_DEBUG("Consoldate fragment metadata.");
   dataset.consolidate_fragment_metadata(args);
   LOG_TRACE("Finished utils consolidate fragment metadata command.");
 }
@@ -210,7 +210,7 @@ void do_utils_vacuum_commits(const UtilsParams& args, const CLI::App& cmd) {
   tiledb::Config cfg;
   utils::set_tiledb_config(args.tiledb_config, &cfg);
   TileDBVCFDataset dataset(cfg);
-  dataset.open(args.uri, args.tiledb_config);
+  LOG_DEBUG("Vacuum commits.");
   dataset.vacuum_commits(args);
   LOG_TRACE("Finished utils vacuum commits command.");
 }
@@ -222,7 +222,7 @@ void do_utils_vacuum_fragments(const UtilsParams& args, const CLI::App& cmd) {
   tiledb::Config cfg;
   utils::set_tiledb_config(args.tiledb_config, &cfg);
   TileDBVCFDataset dataset(cfg);
-  dataset.open(args.uri, args.tiledb_config);
+  LOG_DEBUG("Vacuum fragments.");
   dataset.vacuum_fragments(args);
   LOG_TRACE("Finished utils vacuum fragments command.");
 }
@@ -235,7 +235,7 @@ void do_utils_vacuum_fragment_metadata(
   tiledb::Config cfg;
   utils::set_tiledb_config(args.tiledb_config, &cfg);
   TileDBVCFDataset dataset(cfg);
-  dataset.open(args.uri, args.tiledb_config);
+  LOG_DEBUG("Vacuum fragment metadata.");
   dataset.vacuum_fragment_metadata(args);
   LOG_TRACE("Finished utils vacuum fragment metadata command.");
 }

--- a/libtiledbvcf/src/dataset/allele_count.cc
+++ b/libtiledbvcf/src/dataset/allele_count.cc
@@ -209,16 +209,6 @@ void AlleleCount::consolidate_commits(
     return;
   }
 
-  // Return if array is empty
-  // TODO: remove after https://github.com/TileDB-Inc/TileDB/pull/3389
-  {
-    FragmentInfo fragment_info(*ctx, get_uri(root_uri));
-    fragment_info.load();
-    if (fragment_info.fragment_num() == 0) {
-      return;
-    }
-  }
-
   Config cfg;
   utils::set_tiledb_config(tiledb_config, &cfg);
   cfg["sm.consolidation.mode"] = "commits";
@@ -241,6 +231,37 @@ void AlleleCount::consolidate_fragment_metadata(
   tiledb::Array::consolidate(*ctx, get_uri(root_uri), &cfg);
 }
 
+void AlleleCount::vacuum_commits(
+    std::shared_ptr<Context> ctx,
+    const std::vector<std::string>& tiledb_config,
+    const std::string& root_uri) {
+  // Return if the array does not exist
+  tiledb::VFS vfs(*ctx);
+  if (!vfs.is_dir(get_uri(root_uri))) {
+    return;
+  }
+
+  Config cfg;
+  utils::set_tiledb_config(tiledb_config, &cfg);
+  cfg["sm.vacuum.mode"] = "commits";
+  tiledb::Array::vacuum(*ctx, get_uri(root_uri), &cfg);
+}
+
+void AlleleCount::vacuum_fragment_metadata(
+    std::shared_ptr<Context> ctx,
+    const std::vector<std::string>& tiledb_config,
+    const std::string& root_uri) {
+  // Return if the array does not exist
+  tiledb::VFS vfs(*ctx);
+  if (!vfs.is_dir(get_uri(root_uri))) {
+    return;
+  }
+
+  Config cfg;
+  utils::set_tiledb_config(tiledb_config, &cfg);
+  cfg["sm.vacuum.mode"] = "fragment_meta";
+  tiledb::Array::vacuum(*ctx, get_uri(root_uri), &cfg);
+}
 //===================================================================
 //= public functions
 //===================================================================

--- a/libtiledbvcf/src/dataset/allele_count.h
+++ b/libtiledbvcf/src/dataset/allele_count.h
@@ -134,6 +134,30 @@ class AlleleCount {
       const std::vector<std::string>& tiledb_config,
       const std::string& root_uri);
 
+  /**
+   * @brief Vacuum commits
+   *
+   * @param ctx TileDB context
+   * @param tiledb_config TileDB config
+   * @param root_uri URI for the VCF dataset
+   */
+  static void vacuum_commits(
+      std::shared_ptr<Context> ctx,
+      const std::vector<std::string>& tiledb_config,
+      const std::string& root_uri);
+
+  /**
+   * @brief Vacuum fragment metadata
+   *
+   * @param ctx TileDB context
+   * @param tiledb_config TileDB config
+   * @param root_uri URI for the VCF dataset
+   */
+  static void vacuum_fragment_metadata(
+      std::shared_ptr<Context> ctx,
+      const std::vector<std::string>& tiledb_config,
+      const std::string& root_uri);
+
   //===================================================================
   //= public non-static
   //===================================================================

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -2113,7 +2113,7 @@ void TileDBVCFDataset::consolidate_vcf_header_array_commits(
   Config cfg;
   utils::set_tiledb_config(params.tiledb_config, &cfg);
   cfg["sm.consolidation.mode"] = "commits";
-  tiledb::Array::consolidate(*ctx_, vcf_headers_uri(root_uri_), &cfg);
+  tiledb::Array::consolidate(*ctx_, vcf_headers_uri(params.uri), &cfg);
 }
 
 void TileDBVCFDataset::consolidate_data_array_commits(
@@ -2121,14 +2121,18 @@ void TileDBVCFDataset::consolidate_data_array_commits(
   Config cfg;
   utils::set_tiledb_config(params.tiledb_config, &cfg);
   cfg["sm.consolidation.mode"] = "commits";
-  tiledb::Array::consolidate(*ctx_, data_array_uri(root_uri_), &cfg);
+  tiledb::Array::consolidate(*ctx_, data_array_uri(params.uri), &cfg);
 }
 
 void TileDBVCFDataset::consolidate_commits(const UtilsParams& params) {
+  LOG_DEBUG("Consolidate data array commits.");
   consolidate_data_array_commits(params);
+  LOG_DEBUG("Consolidate vcf_header array commits.");
   consolidate_vcf_header_array_commits(params);
-  AlleleCount::consolidate_commits(ctx_, params.tiledb_config, root_uri_);
-  VariantStats::consolidate_commits(ctx_, params.tiledb_config, root_uri_);
+  LOG_DEBUG("Consolidate allele_count array commits.");
+  AlleleCount::consolidate_commits(ctx_, params.tiledb_config, params.uri);
+  LOG_DEBUG("Consolidate variant_stats array commits.");
+  VariantStats::consolidate_commits(ctx_, params.tiledb_config, params.uri);
 }
 
 void TileDBVCFDataset::consolidate_vcf_header_array_fragment_metadata(
@@ -2136,7 +2140,7 @@ void TileDBVCFDataset::consolidate_vcf_header_array_fragment_metadata(
   Config cfg;
   utils::set_tiledb_config(params.tiledb_config, &cfg);
   cfg["sm.consolidation.mode"] = "fragment_meta";
-  tiledb::Array::consolidate(*ctx_, vcf_headers_uri(root_uri_), &cfg);
+  tiledb::Array::consolidate(*ctx_, vcf_headers_uri(params.uri), &cfg);
 }
 
 void TileDBVCFDataset::consolidate_data_array_fragment_metadata(
@@ -2144,17 +2148,21 @@ void TileDBVCFDataset::consolidate_data_array_fragment_metadata(
   Config cfg;
   utils::set_tiledb_config(params.tiledb_config, &cfg);
   cfg["sm.consolidation.mode"] = "fragment_meta";
-  tiledb::Array::consolidate(*ctx_, data_array_uri(root_uri_), &cfg);
+  tiledb::Array::consolidate(*ctx_, data_array_uri(params.uri), &cfg);
 }
 
 void TileDBVCFDataset::consolidate_fragment_metadata(
     const UtilsParams& params) {
+  LOG_DEBUG("Consolidate data array fragment metadata.");
   consolidate_data_array_fragment_metadata(params);
+  LOG_DEBUG("Consolidate vcf_header array fragment metadata.");
   consolidate_vcf_header_array_fragment_metadata(params);
+  LOG_DEBUG("Consolidate allele_count array fragment metadata.");
   AlleleCount::consolidate_fragment_metadata(
-      ctx_, params.tiledb_config, root_uri_);
+      ctx_, params.tiledb_config, params.uri);
+  LOG_DEBUG("Consolidate variant_stats array fragment metadata.");
   VariantStats::consolidate_fragment_metadata(
-      ctx_, params.tiledb_config, root_uri_);
+      ctx_, params.tiledb_config, params.uri);
 }
 
 void TileDBVCFDataset::consolidate_vcf_header_array_fragments(
@@ -2162,7 +2170,7 @@ void TileDBVCFDataset::consolidate_vcf_header_array_fragments(
   Config cfg;
   utils::set_tiledb_config(params.tiledb_config, &cfg);
   cfg["sm.consolidation.mode"] = "fragments";
-  tiledb::Array::consolidate(*ctx_, vcf_headers_uri(root_uri_), &cfg);
+  tiledb::Array::consolidate(*ctx_, vcf_headers_uri(params.uri), &cfg);
 }
 
 void TileDBVCFDataset::consolidate_data_array_fragments(
@@ -2170,7 +2178,7 @@ void TileDBVCFDataset::consolidate_data_array_fragments(
   Config cfg;
   utils::set_tiledb_config(params.tiledb_config, &cfg);
   cfg["sm.consolidation.mode"] = "fragments";
-  tiledb::Array::consolidate(*ctx_, data_array_uri(root_uri_), &cfg);
+  tiledb::Array::consolidate(*ctx_, data_array_uri(params.uri), &cfg);
 }
 
 void TileDBVCFDataset::consolidate_fragments(const UtilsParams& params) {
@@ -2183,28 +2191,25 @@ void TileDBVCFDataset::vacuum_vcf_header_array_commits(
   Config cfg;
   utils::set_tiledb_config(params.tiledb_config, &cfg);
   cfg["sm.vacuum.mode"] = "commits";
-  // block until it's safe to close the array
-  lock_and_join_vcf_header_array();
-  vcf_header_array_->close();
-  tiledb::Array::vacuum(*ctx_, vcf_headers_uri(root_uri_), &cfg);
-  data_array_ = open_data_array(TILEDB_READ);
-  vcf_header_array_ = open_vcf_array(TILEDB_READ);
+  tiledb::Array::vacuum(*ctx_, vcf_headers_uri(params.uri), &cfg);
 }
 
 void TileDBVCFDataset::vacuum_data_array_commits(const UtilsParams& params) {
   Config cfg;
   utils::set_tiledb_config(params.tiledb_config, &cfg);
   cfg["sm.vacuum.mode"] = "commits";
-  // block until it's safe to close the array
-  lock_and_join_data_array();
-  data_array_->close();
-  tiledb::Array::vacuum(*ctx_, data_array_uri(root_uri_), &cfg);
-  data_array_ = open_data_array(TILEDB_READ);
+  tiledb::Array::vacuum(*ctx_, data_array_uri(params.uri), &cfg);
 }
 
 void TileDBVCFDataset::vacuum_commits(const UtilsParams& params) {
+  LOG_DEBUG("Vacuum data array commits.");
   vacuum_data_array_commits(params);
+  LOG_DEBUG("Vacuum vcf_header array commits.");
   vacuum_vcf_header_array_commits(params);
+  LOG_DEBUG("Vacuum allele_count array commits.");
+  AlleleCount::vacuum_commits(ctx_, params.tiledb_config, params.uri);
+  LOG_DEBUG("Vacuum variant_stats array commits.");
+  VariantStats::vacuum_commits(ctx_, params.tiledb_config, params.uri);
 }
 
 void TileDBVCFDataset::vacuum_vcf_header_array_fragment_metadata(
@@ -2212,12 +2217,7 @@ void TileDBVCFDataset::vacuum_vcf_header_array_fragment_metadata(
   Config cfg;
   utils::set_tiledb_config(params.tiledb_config, &cfg);
   cfg["sm.vacuum.mode"] = "fragment_meta";
-  // block until it's safe to close the array
-  lock_and_join_vcf_header_array();
-  vcf_header_array_->close();
-  tiledb::Array::vacuum(*ctx_, vcf_headers_uri(root_uri_), &cfg);
-  data_array_ = open_data_array(TILEDB_READ);
-  vcf_header_array_ = open_vcf_array(TILEDB_READ);
+  tiledb::Array::vacuum(*ctx_, vcf_headers_uri(params.uri), &cfg);
 }
 
 void TileDBVCFDataset::vacuum_data_array_fragment_metadata(
@@ -2225,16 +2225,19 @@ void TileDBVCFDataset::vacuum_data_array_fragment_metadata(
   Config cfg;
   utils::set_tiledb_config(params.tiledb_config, &cfg);
   cfg["sm.vacuum.mode"] = "fragment_meta";
-  // block until it's safe to close the array
-  lock_and_join_data_array();
-  data_array_->close();
-  tiledb::Array::vacuum(*ctx_, data_array_uri(root_uri_), &cfg);
-  data_array_ = open_data_array(TILEDB_READ);
+  tiledb::Array::vacuum(*ctx_, data_array_uri(params.uri), &cfg);
 }
 
 void TileDBVCFDataset::vacuum_fragment_metadata(const UtilsParams& params) {
+  LOG_DEBUG("Vacuum data array fragment metadata.");
   vacuum_data_array_fragment_metadata(params);
+  LOG_DEBUG("Vacuum vcf_header array fragment metadata.");
   vacuum_vcf_header_array_fragment_metadata(params);
+  LOG_DEBUG("Vacuum allele_count array fragment metadata.");
+  AlleleCount::vacuum_fragment_metadata(ctx_, params.tiledb_config, params.uri);
+  LOG_DEBUG("Vacuum variant_stats array fragment metadata.");
+  VariantStats::vacuum_fragment_metadata(
+      ctx_, params.tiledb_config, params.uri);
 }
 
 void TileDBVCFDataset::vacuum_vcf_header_array_fragments(
@@ -2242,22 +2245,14 @@ void TileDBVCFDataset::vacuum_vcf_header_array_fragments(
   Config cfg;
   utils::set_tiledb_config(params.tiledb_config, &cfg);
   cfg["sm.vacuum.mode"] = "fragments";
-  // block until it's safe to close the array
-  lock_and_join_vcf_header_array();
-  vcf_header_array_->close();
-  tiledb::Array::vacuum(*ctx_, vcf_headers_uri(root_uri_), &cfg);
-  vcf_header_array_ = open_vcf_array(TILEDB_READ);
+  tiledb::Array::vacuum(*ctx_, vcf_headers_uri(params.uri), &cfg);
 }
 
 void TileDBVCFDataset::vacuum_data_array_fragments(const UtilsParams& params) {
   Config cfg;
   utils::set_tiledb_config(params.tiledb_config, &cfg);
   cfg["sm.vacuum.mode"] = "fragments";
-  // block until it's safe to close the array
-  lock_and_join_data_array();
-  data_array_->close();
-  tiledb::Array::vacuum(*ctx_, data_array_uri(root_uri_), &cfg);
-  data_array_ = open_data_array(TILEDB_READ);
+  tiledb::Array::vacuum(*ctx_, data_array_uri(params.uri), &cfg);
 }
 
 void TileDBVCFDataset::vacuum_fragments(const UtilsParams& params) {

--- a/libtiledbvcf/src/dataset/variant_stats.cc
+++ b/libtiledbvcf/src/dataset/variant_stats.cc
@@ -208,16 +208,6 @@ void VariantStats::consolidate_commits(
     return;
   }
 
-  // Return if array is empty
-  // TODO: remove after https://github.com/TileDB-Inc/TileDB/pull/3389
-  {
-    FragmentInfo fragment_info(*ctx, get_uri(root_uri));
-    fragment_info.load();
-    if (fragment_info.fragment_num() == 0) {
-      return;
-    }
-  }
-
   Config cfg;
   utils::set_tiledb_config(tiledb_config, &cfg);
   cfg["sm.consolidation.mode"] = "commits";
@@ -238,6 +228,38 @@ void VariantStats::consolidate_fragment_metadata(
   utils::set_tiledb_config(tiledb_config, &cfg);
   cfg["sm.consolidation.mode"] = "fragment_meta";
   tiledb::Array::consolidate(*ctx, get_uri(root_uri), &cfg);
+}
+
+void VariantStats::vacuum_commits(
+    std::shared_ptr<Context> ctx,
+    const std::vector<std::string>& tiledb_config,
+    const std::string& root_uri) {
+  // Return if the array does not exist
+  tiledb::VFS vfs(*ctx);
+  if (!vfs.is_dir(get_uri(root_uri))) {
+    return;
+  }
+
+  Config cfg;
+  utils::set_tiledb_config(tiledb_config, &cfg);
+  cfg["sm.vacuum.mode"] = "commits";
+  tiledb::Array::vacuum(*ctx, get_uri(root_uri), &cfg);
+}
+
+void VariantStats::vacuum_fragment_metadata(
+    std::shared_ptr<Context> ctx,
+    const std::vector<std::string>& tiledb_config,
+    const std::string& root_uri) {
+  // Return if the array does not exist
+  tiledb::VFS vfs(*ctx);
+  if (!vfs.is_dir(get_uri(root_uri))) {
+    return;
+  }
+
+  Config cfg;
+  utils::set_tiledb_config(tiledb_config, &cfg);
+  cfg["sm.vacuum.mode"] = "fragment_meta";
+  tiledb::Array::vacuum(*ctx, get_uri(root_uri), &cfg);
 }
 
 //===================================================================

--- a/libtiledbvcf/src/dataset/variant_stats.h
+++ b/libtiledbvcf/src/dataset/variant_stats.h
@@ -134,6 +134,30 @@ class VariantStats {
       const std::vector<std::string>& tiledb_config,
       const std::string& root_uri);
 
+  /**
+   * @brief Vacuum commits
+   *
+   * @param ctx TileDB context
+   * @param tiledb_config TileDB config
+   * @param root_uri URI for the VCF dataset
+   */
+  static void vacuum_commits(
+      std::shared_ptr<Context> ctx,
+      const std::vector<std::string>& tiledb_config,
+      const std::string& root_uri);
+
+  /**
+   * @brief Vacuum fragment metadata
+   *
+   * @param ctx TileDB context
+   * @param tiledb_config TileDB config
+   * @param root_uri URI for the VCF dataset
+   */
+  static void vacuum_fragment_metadata(
+      std::shared_ptr<Context> ctx,
+      const std::vector<std::string>& tiledb_config,
+      const std::string& root_uri);
+
   //===================================================================
   //= public non-static
   //===================================================================

--- a/libtiledbvcf/test/src/unit-vcf-utils.cc
+++ b/libtiledbvcf/test/src/unit-vcf-utils.cc
@@ -122,6 +122,7 @@ TEST_CASE(
     TileDBVCFDataset dataset(std::make_shared<tiledb::Context>(ctx));
     dataset.open(dataset_uri);
     UtilsParams params;
+    params.uri = dataset_uri;
     dataset.consolidate_fragment_metadata(params);
   }
 
@@ -146,6 +147,7 @@ TEST_CASE(
     TileDBVCFDataset dataset(std::make_shared<tiledb::Context>(ctx));
     dataset.open(dataset_uri);
     UtilsParams params;
+    params.uri = dataset_uri;
     dataset.consolidate_fragments(params);
   }
 
@@ -170,6 +172,7 @@ TEST_CASE(
     TileDBVCFDataset dataset(std::make_shared<tiledb::Context>(ctx));
     dataset.open(dataset_uri);
     UtilsParams params;
+    params.uri = dataset_uri;
     dataset.vacuum_fragment_metadata(params);
   }
 
@@ -194,6 +197,7 @@ TEST_CASE(
     TileDBVCFDataset dataset(std::make_shared<tiledb::Context>(ctx));
     dataset.open(dataset_uri);
     UtilsParams params;
+    params.uri = dataset_uri;
     dataset.vacuum_fragments(params);
   }
 
@@ -292,6 +296,7 @@ TEST_CASE(
     TileDBVCFDataset dataset(std::make_shared<tiledb::Context>(ctx));
     dataset.open(dataset_uri);
     UtilsParams params;
+    params.uri = dataset_uri;
     dataset.consolidate_commits(params);
   }
 
@@ -316,6 +321,7 @@ TEST_CASE(
     TileDBVCFDataset dataset(std::make_shared<tiledb::Context>(ctx));
     dataset.open(dataset_uri);
     UtilsParams params;
+    params.uri = dataset_uri;
     dataset.vacuum_commits(params);
   }
 


### PR DESCRIPTION
* Make consolidation and vacuuming more efficient by not opening the array first.
* Remove fragment counting in stats array consolidation.
* Add stats array vacuuming.
