### PR TITLE
Add zstd compression to the sample dimension

### DIFF
--- a/libtiledbvcf/src/cli/tiledbvcf.cc
+++ b/libtiledbvcf/src/cli/tiledbvcf.cc
@@ -420,6 +420,10 @@ void add_create(CLI::App& app) {
       [args](int count) { args->allow_duplicates = false; },
       "Allow records with duplicate start positions to be written to the "
       "array.");
+  cmd->add_flag(
+      "--compress-sample-dim",
+      args->compress_sample_dim,
+      "Add zstd compression to the sample dimension.");
 
   cmd->option_defaults()->group("Ingestion task options");
   cmd->add_flag(

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -222,7 +222,12 @@ void TileDBVCFDataset::create(const CreationParams& params) {
   // Create arrays and subgroups and add them to the root group
   create_empty_metadata(ctx, params.uri, metadata, params.checksum);
   create_empty_data_array(
-      ctx, params.uri, metadata, params.checksum, params.allow_duplicates);
+      ctx,
+      params.uri,
+      metadata,
+      params.checksum,
+      params.allow_duplicates,
+      params.compress_sample_dim);
 
   if (params.enable_allele_count) {
     AlleleCount::create(ctx, params.uri, params.checksum);
@@ -309,7 +314,8 @@ void TileDBVCFDataset::create_empty_data_array(
     const std::string& root_uri,
     const Metadata& metadata,
     const tiledb_filter_type_t& checksum,
-    const bool allow_duplicates) {
+    const bool allow_duplicates,
+    const bool compress_sample_dim) {
   ArraySchema schema(ctx, TILEDB_SPARSE);
   schema.set_capacity(metadata.tile_capacity);
   schema.set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
@@ -330,8 +336,10 @@ void TileDBVCFDataset::create_empty_data_array(
   contig_coord_filters.add_filter({ctx, TILEDB_FILTER_RLE});
   pos_coord_filters.add_filter({ctx, TILEDB_FILTER_DOUBLE_DELTA})
       .add_filter(compression);
-  sample_coord_filters.add_filter({ctx, TILEDB_FILTER_DICTIONARY})
-      .add_filter(compression);
+  sample_coord_filters.add_filter({ctx, TILEDB_FILTER_DICTIONARY});
+  if (compress_sample_dim) {
+    sample_coord_filters.add_filter(compression);
+  }
 
   str_attr_filters.add_filter(compression);
   int_attr_filters.add_filter({ctx, TILEDB_FILTER_BYTESHUFFLE})

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -330,7 +330,8 @@ void TileDBVCFDataset::create_empty_data_array(
   contig_coord_filters.add_filter({ctx, TILEDB_FILTER_RLE});
   pos_coord_filters.add_filter({ctx, TILEDB_FILTER_DOUBLE_DELTA})
       .add_filter(compression);
-  sample_coord_filters.add_filter({ctx, TILEDB_FILTER_DICTIONARY});
+  sample_coord_filters.add_filter({ctx, TILEDB_FILTER_DICTIONARY})
+      .add_filter(compression);
 
   str_attr_filters.add_filter(compression);
   int_attr_filters.add_filter({ctx, TILEDB_FILTER_BYTESHUFFLE})

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -65,6 +65,7 @@ struct CreationParams {
   std::string vcf_uri;
   bool enable_allele_count = false;
   bool enable_variant_stats = false;
+  bool compress_sample_dim = false;
 };
 
 /** Arguments/params for dataset registration. */
@@ -834,7 +835,8 @@ class TileDBVCFDataset {
       const std::string& root_uri,
       const Metadata& metadata,
       const tiledb_filter_type_t& checksum,
-      const bool allow_duplicates);
+      const bool allow_duplicates,
+      const bool compress_sample_dim);
 
   /**
    * Creates the empty sample header array for a new dataset.


### PR DESCRIPTION
Provide a `tiledbvcf create` option to use dictionary + zstd compression on the sample dimension, instead of dictionary encoding only. This option improves the compression ratio.

```
  --compress-sample-dim                 Add zstd compression to the sample dimension.
```