### PR TITLE
Group usage fix and improvements

### DIFF
--- a/libtiledbvcf/src/read/delete_exporter.h
+++ b/libtiledbvcf/src/read/delete_exporter.h
@@ -47,8 +47,9 @@ class DeleteExporter : public Exporter {
       : ac_(true)
       , vs_(true) {
     need_headers_ = true;
-    ac_.init(ctx, root_uri);
-    vs_.init(ctx, root_uri);
+    Group group(*ctx, root_uri, TILEDB_READ);
+    ac_.init(ctx, group);
+    vs_.init(ctx, group);
   }
 
   ~DeleteExporter() = default;
@@ -86,7 +87,7 @@ class DeleteExporter : public Exporter {
    * @brief Flush and close the stats array writers.
    *
    */
-  void close() {
+  void close() override {
     ac_.flush();
     ac_.close();
     vs_.flush();

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -184,8 +184,8 @@ void Reader::set_buffer_validity_bitmap(
 
 void Reader::init_af_filter() {
   if (!af_filter_ && !params_.af_filter.empty()) {
-    af_filter_ =
-        std::make_unique<VariantStatsReader>(ctx_, dataset_->root_uri());
+    Group group(*ctx_, dataset_->root_uri(), TILEDB_READ);
+    af_filter_ = std::make_unique<VariantStatsReader>(ctx_, group);
     af_filter_->set_condition(params_.af_filter);
   }
 }

--- a/libtiledbvcf/src/stats/allele_count.h
+++ b/libtiledbvcf/src/stats/allele_count.h
@@ -69,6 +69,14 @@ class AlleleCount {
   //= public static
   //===================================================================
   /**
+   * @brief Get the URI from TileDB-VCF dataset group
+   *
+   * @param group TileDB-VCF dataset group
+   * @return std::string Array URI
+   */
+  static std::string get_uri(const Group& group);
+
+  /**
    * @brief Create the array.
    *
    * @param ctx TileDB context
@@ -81,11 +89,10 @@ class AlleleCount {
   /**
    * @brief Check if the array exists.
    *
-   * @param ctx TileDB context
-   * @param root_uri TileDB-VCF dataset uri
+   * @param group TileDB-VCF dataset group
    * @return true If the array exists
    */
-  static bool exists(std::shared_ptr<Context> ctx, const std::string& root_uri);
+  static bool exists(const Group& group);
 
   /**
    * @brief Open array and create query object.
@@ -94,9 +101,9 @@ class AlleleCount {
    * expected array.
    *
    * @param ctx TileDB context
-   * @param root_uri TileDB-VCF dataset uri
+   * @param group TileDB-VCF dataset group
    */
-  static void init(std::shared_ptr<Context> ctx, const std::string& root_uri);
+  static void init(std::shared_ptr<Context> ctx, const Group& group);
 
   /**
    * @brief Finalize the currently open write query.
@@ -111,61 +118,39 @@ class AlleleCount {
   static void close();
 
   /**
-   * @brief Get the uri for the array
-   *
-   * @param root_uri
-   * @return std::string
-   */
-  static std::string get_uri(
-      const std::string& root_uri, bool relative = false);
-
-  /**
    * @brief Consolidate commits
    *
    * @param ctx TileDB context
-   * @param tiledb_config TileDB config
-   * @param root_uri URI for the VCF dataset
+   * @param group TileDB-VCF dataset group
    */
   static void consolidate_commits(
-      std::shared_ptr<Context> ctx,
-      const std::vector<std::string>& tiledb_config,
-      const std::string& root_uri);
+      std::shared_ptr<Context> ctx, const Group& group);
 
   /**
    * @brief Consolidate fragment metadata
    *
    * @param ctx TileDB context
-   * @param tiledb_config TileDB config
-   * @param root_uri URI for the VCF dataset
+   * @param group TileDB-VCF dataset group
    */
   static void consolidate_fragment_metadata(
-      std::shared_ptr<Context> ctx,
-      const std::vector<std::string>& tiledb_config,
-      const std::string& root_uri);
+      std::shared_ptr<Context> ctx, const Group& group);
 
   /**
    * @brief Vacuum commits
    *
    * @param ctx TileDB context
-   * @param tiledb_config TileDB config
-   * @param root_uri URI for the VCF dataset
+   * @param group TileDB-VCF dataset group
    */
-  static void vacuum_commits(
-      std::shared_ptr<Context> ctx,
-      const std::vector<std::string>& tiledb_config,
-      const std::string& root_uri);
+  static void vacuum_commits(std::shared_ptr<Context> ctx, const Group& group);
 
   /**
    * @brief Vacuum fragment metadata
    *
    * @param ctx TileDB context
-   * @param tiledb_config TileDB config
-   * @param root_uri URI for the VCF dataset
+   * @param group TileDB-VCF dataset group
    */
   static void vacuum_fragment_metadata(
-      std::shared_ptr<Context> ctx,
-      const std::vector<std::string>& tiledb_config,
-      const std::string& root_uri);
+      std::shared_ptr<Context> ctx, const Group& group);
 
   //===================================================================
   //= public non-static
@@ -204,7 +189,16 @@ class AlleleCount {
   //= private static
   //===================================================================
 
-  // Array config
+  /**
+   * @brief Get the URI for the array from the root URI
+   *
+   * @param root_uri TileDB-VCF dataset URI
+   * @return std::string Array URI
+   */
+  static std::string get_uri(
+      const std::string& root_uri, bool relative = false);
+
+  // Array URI basename
   inline static const std::string ALLELE_COUNT_ARRAY = "allele_count";
 
   // Array version

--- a/libtiledbvcf/src/stats/variant_stats.h
+++ b/libtiledbvcf/src/stats/variant_stats.h
@@ -69,10 +69,17 @@ class VariantStats {
   //= public static
   //===================================================================
   /**
+   * @brief Get the URI from TileDB-VCF dataset group
+   *
+   * @param group TileDB-VCF dataset group
+   * @return std::string Array URI
+   */
+  static std::string get_uri(const Group& group);
+
+  /**
    * @brief Create the array.
    *
-   * @param ctx TileDB context
-   * @param root_uri TileDB-VCF dataset uri
+   * @param group TileDB-VCF dataset group
    * @param checksum TileDB checksum filter
    */
   static void create(
@@ -81,11 +88,10 @@ class VariantStats {
   /**
    * @brief Check if the array exists.
    *
-   * @param ctx TileDB context
-   * @param root_uri TileDB-VCF dataset uri
+   * @param group TileDB-VCF dataset group
    * @return true If the array exists
    */
-  static bool exists(std::shared_ptr<Context> ctx, const std::string& root_uri);
+  static bool exists(const Group& group);
 
   /**
    * @brief Open array and create query object.
@@ -94,9 +100,9 @@ class VariantStats {
    * expected array.
    *
    * @param ctx TileDB context
-   * @param root_uri TileDB-VCF dataset uri
+   * @param group TileDB-VCF dataset group
    */
-  static void init(std::shared_ptr<Context> ctx, const std::string& root_uri);
+  static void init(std::shared_ptr<Context> ctx, const Group& group);
 
   /**
    * @brief Finalize the currently open write query.
@@ -111,60 +117,39 @@ class VariantStats {
   static void close();
 
   /**
-   * @brief Get the uri for the array
-   *
-   * @param root_uri
-   * @return std::string
-   */
-  static std::string get_uri(std::string_view root_uri, bool relative = false);
-
-  /**
    * @brief Consolidate commits
    *
    * @param ctx TileDB context
-   * @param tiledb_config TileDB config
-   * @param root_uri URI for the VCF dataset
+   * @param group TileDB-VCF dataset group
    */
   static void consolidate_commits(
-      std::shared_ptr<Context> ctx,
-      const std::vector<std::string>& tiledb_config,
-      const std::string& root_uri);
+      std::shared_ptr<Context> ctx, const Group& group);
 
   /**
    * @brief Consolidate fragment metadata
    *
    * @param ctx TileDB context
-   * @param tiledb_config TileDB config
-   * @param root_uri URI for the VCF dataset
+   * @param group TileDB-VCF dataset group
    */
   static void consolidate_fragment_metadata(
-      std::shared_ptr<Context> ctx,
-      const std::vector<std::string>& tiledb_config,
-      const std::string& root_uri);
+      std::shared_ptr<Context> ctx, const Group& group);
 
   /**
    * @brief Vacuum commits
    *
    * @param ctx TileDB context
-   * @param tiledb_config TileDB config
-   * @param root_uri URI for the VCF dataset
+   * @param group TileDB-VCF dataset group
    */
-  static void vacuum_commits(
-      std::shared_ptr<Context> ctx,
-      const std::vector<std::string>& tiledb_config,
-      const std::string& root_uri);
+  static void vacuum_commits(std::shared_ptr<Context> ctx, const Group& group);
 
   /**
    * @brief Vacuum fragment metadata
    *
    * @param ctx TileDB context
-   * @param tiledb_config TileDB config
-   * @param root_uri URI for the VCF dataset
+   * @param group TileDB-VCF dataset group
    */
   static void vacuum_fragment_metadata(
-      std::shared_ptr<Context> ctx,
-      const std::vector<std::string>& tiledb_config,
-      const std::string& root_uri);
+      std::shared_ptr<Context> ctx, const Group& group);
 
   //===================================================================
   //= public non-static
@@ -203,7 +188,16 @@ class VariantStats {
   //= private static
   //===================================================================
 
-  // Array config
+  /**
+   * @brief Get the URI for the array from the root URI
+   *
+   * @param root_uri TileDB-VCF dataset URI
+   * @return std::string Array URI
+   */
+  static std::string get_uri(
+      const std::string& root_uri, bool relative = false);
+
+  // Array URI basename
   inline static const std::string VARIANT_STATS_ARRAY = "variant_stats";
 
   // Array version

--- a/libtiledbvcf/src/stats/variant_stats_reader.cc
+++ b/libtiledbvcf/src/stats/variant_stats_reader.cc
@@ -32,8 +32,8 @@
 namespace tiledb::vcf {
 
 VariantStatsReader::VariantStatsReader(
-    std::shared_ptr<Context> ctx, std::string_view root_uri) {
-  auto uri = VariantStats::get_uri(root_uri);
+    std::shared_ptr<Context> ctx, const Group& group) {
+  auto uri = VariantStats::get_uri(group);
   LOG_DEBUG("[VariantStatsReader] Opening array {}", uri);
   array_ = std::make_shared<Array>(*ctx, uri, TILEDB_READ);
 }

--- a/libtiledbvcf/src/stats/variant_stats_reader.h
+++ b/libtiledbvcf/src/stats/variant_stats_reader.h
@@ -129,9 +129,9 @@ class VariantStatsReader {
    * @brief Construct a new Variant Stats Reader object
    *
    * @param ctx TileDB context
-   * @param root_uri URI of the VCF dataset
+   * @param group TileDB-VCF dataset group
    */
-  VariantStatsReader(std::shared_ptr<Context> ctx, std::string_view root_uri);
+  VariantStatsReader(std::shared_ptr<Context> ctx, const Group& group);
 
   VariantStatsReader() = delete;
   VariantStatsReader(const VariantStatsReader&) = delete;

--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -130,8 +130,9 @@ void Writer::init(const IngestionParams& params) {
   creation_params_.checksum = TILEDB_FILTER_CHECKSUM_SHA256;
   creation_params_.allow_duplicates = true;
 
-  AlleleCount::init(ctx_, params.uri);
-  VariantStats::init(ctx_, params.uri);
+  Group group(*ctx_, params.uri, TILEDB_READ);
+  AlleleCount::init(ctx_, group);
+  VariantStats::init(ctx_, group);
 }
 
 void Writer::set_tiledb_config(const std::string& config_str) {


### PR DESCRIPTION
1. Get stats array URIs from the dataset group.
2. Do not add the empty `metadata` group to the dataset group.
3. Add dataset group metadata: `dataset_type` = `vcf`

[sc-24573]
[sc-23915]
[sc-23729]