### PR TITLE
Memory usage and latency improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,105 @@
+# This Makefile captures common developer build and test use cases.
+
+MAKEFLAGS += --no-print-directory
+
+# print help by default
+help:
+
+# install 
+# -------------------------------------------------------------------
+
+# set default variable values, if non-null
+build ?= Release
+
+.PHONY: install
+install: clean
+	mkdir -p libtiledbvcf/build && \
+		cd libtiledbvcf/build && \
+		cmake .. -DCMAKE_BUILD_TYPE=${build} && \
+		make -j && make install-libtiledbvcf
+	cd apis/python && python setup.py install
+
+# incremental compile and update python install
+# -------------------------------------------------------------------
+.PHONY: update
+update:
+	cd libtiledbvcf/build && make -j && make install-libtiledbvcf
+	cd apis/python && python setup.py install
+
+# test
+# -------------------------------------------------------------------
+.PHONY: test
+test:
+	cd libtiledbvcf/build && make check
+	cd libtiledbvcf/test && ./run-cli-tests.sh ../build/ ./inputs/
+	cd apis/java && ./gradlew assemble test
+	cd apis/spark && ./gradlew assemble test
+	pytest apis/python
+	python -c "import tiledbvcf; print(tiledbvcf.version)"
+
+# format
+# -------------------------------------------------------------------
+.PHONY: check-format
+check-format:
+	@./ci/run-clang-format.sh . clang-format 0 \
+		`find libtiledbvcf/src -name "*.cc" -or -name "*.h"`
+
+.PHONY: format
+format:
+	 @./ci/run-clang-format.sh . clang-format 1 \
+		`find libtiledbvcf/src -name "*.cc" -or -name "*.h"`
+
+# clean
+# -------------------------------------------------------------------
+.PHONY: clean
+clean:
+	@rm -rf libtiledbvcf/build dist
+
+.PHONY: cleaner
+cleaner:
+	@printf "*** dry-run mode: remove -n to actually remove files\n"
+	git clean -ffdx -e .vscode -n
+
+# help
+# -------------------------------------------------------------------
+define HELP
+Usage: make rule [options]
+
+Rules:
+  install [options]   Build C++ library and install python module
+  update              Incrementally build C++ library and update python module
+  test                Run tests
+  check-format        Run C++ format check
+  format              Run C++ format
+  clean               Remove build artifacts
+
+Options:
+  build=BUILD_TYPE    Cmake build type = Release|Debug|RelWithDebInfo|Coverage [Release]
+  prefix=PREFIX       Install location [${PWD}/dist]
+  tiledb=TILEDB_DIST  Absolute path to custom TileDB build 
+
+Examples:
+  Install Release build
+
+    make install
+
+  Install Debug build of libtiledbvcf and libtiledb
+
+    make install build=Debug
+
+  Install Release build with custom libtiledb
+
+    make install tiledb=$$PWD/../TileDB/dist
+
+  Incrementally build C++ changes and update the python module
+
+    make update
+
+
+endef 
+export HELP
+
+.PHONY: help
+help:
+	@printf "$${HELP}"
+

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -1270,6 +1270,8 @@ bool Reader::process_query_results_v4() {
     }
 
     if (apply_af_filter) {
+      af_filter_->wait();
+
       auto csv_alleles = results.buffers()->alleles().value(i);
       auto alleles = utils::split(std::string(csv_alleles));
       LOG_TRACE("alleles = {}", csv_alleles);
@@ -2553,8 +2555,7 @@ void Reader::set_output_dir(const std::string& output_dir) {
 }
 
 bool Reader::af_filter_enabled() {
-  init_af_filter();
-  return af_filter_ ? af_filter_->enable_af() : false;
+  return !params_.af_filter.empty();
 }
 
 void Reader::set_af_filter(const std::string& af_filter) {

--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -431,7 +431,9 @@ class Reader {
   void set_output_dir(const std::string& output_dir);
 
   /**
-   * returns whether the AF filter is set or enabled
+   * @brief Check if the AF filter is enabled.
+   *
+   * @return true if the AF filter is enabled
    */
   bool af_filter_enabled();
 

--- a/libtiledbvcf/src/stats/variant_stats_reader.h
+++ b/libtiledbvcf/src/stats/variant_stats_reader.h
@@ -130,8 +130,13 @@ class VariantStatsReader {
    *
    * @param ctx TileDB context
    * @param group TileDB-VCF dataset group
+   * @param async_query If true, query variant stats in parallel with the data
+   * array.
    */
-  VariantStatsReader(std::shared_ptr<Context> ctx, const Group& group);
+  VariantStatsReader(
+      std::shared_ptr<Context> ctx,
+      const Group& group,
+      bool async_query = true);
 
   VariantStatsReader() = delete;
   VariantStatsReader(const VariantStatsReader&) = delete;
@@ -156,16 +161,23 @@ class VariantStatsReader {
    * @brief Set an AF filtering constraint
    *
    * @param condition filtering constraint to set
-   * @return true if AF filtering is enabled
    */
   void set_condition(std::string condition);
 
   /**
-   * @brief Enable AF filtering.
+   * @brief Wait until the AF computation is complete.
+   *
+   */
+  void wait();
+
+  /**
+   * @brief Check if AF filtering is enabled.
    *
    * @return true if AF filtering is enabled
    */
-  bool enable_af();
+  bool is_enabled() {
+    return !condition_.empty();
+  }
 
   /**
    * @brief Check if the allele at the given position passes the allele filter.
@@ -195,8 +207,8 @@ class VariantStatsReader {
   // Allele frequency map
   AFMap af_map_;
 
-  // If true, query variant stats in parallel with data array.
-  bool async_query_ = false;
+  // If true, query variant stats in parallel with the data array.
+  bool async_query_ = true;
 
   // Future for compute thread
   std::future<void> compute_future_;


### PR DESCRIPTION
* Reduce memory usage when fetching the one VCF header.
* Enable async mode for AF filtering to allow the variant stats query to run in parallel with the VCF data query.
* Add developer convenience `Makefile` for common commands