### PR TITLE
Release python GIL

### DIFF
--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -94,7 +94,10 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("create_dataset", &Writer::create_dataset)
       .def("register_samples", &Writer::register_samples)
       .def("set_verbose", &Writer::set_verbose)
-      .def("ingest_samples", &Writer::ingest_samples)
+      .def(
+          "ingest_samples",
+          &Writer::ingest_samples,
+          py::call_guard<py::gil_scoped_release>())
       .def("get_schema_version", &Writer::get_schema_version)
       .def("set_tiledb_config", &Writer::set_tiledb_config)
       .def("set_sample_batch_size", &Writer::set_sample_batch_size)

--- a/apis/python/src/tiledbvcf/binding/reader.cc
+++ b/apis/python/src/tiledbvcf/binding/reader.cc
@@ -225,6 +225,9 @@ void Reader::read(const bool release_buffs) {
   alloc_buffers(release_buffs);
   set_buffers();
 
+  // Release python GIL after we're done accessing python objects.
+  py::gil_scoped_release release;
+
   check_error(reader, tiledb_vcf_reader_read(reader));
   tiledb_vcf_read_status_t status;
   check_error(reader, tiledb_vcf_reader_get_status(reader, &status));

--- a/apis/python/src/tiledbvcf/binding/reader.cc
+++ b/apis/python/src/tiledbvcf/binding/reader.cc
@@ -225,10 +225,12 @@ void Reader::read(const bool release_buffs) {
   alloc_buffers(release_buffs);
   set_buffers();
 
-  // Release python GIL after we're done accessing python objects.
-  py::gil_scoped_release release;
+  {
+    // Release python GIL while reading data from TileDB
+    py::gil_scoped_release release;
+    check_error(reader, tiledb_vcf_reader_read(reader));
+  }
 
-  check_error(reader, tiledb_vcf_reader_read(reader));
   tiledb_vcf_read_status_t status;
   check_error(reader, tiledb_vcf_reader_get_status(reader, &status));
   if (status != TILEDB_VCF_COMPLETED && status != TILEDB_VCF_INCOMPLETE)


### PR DESCRIPTION
Release the python GIL, to allow other python threads to run while libtiledbvcf is reading/writing TileDB arrays.