### PR TITLE
Handle one missing allele in stats arrays

### DIFF
--- a/libtiledbvcf/test/inputs/stats/first.vcf
+++ b/libtiledbvcf/test/inputs/stats/first.vcf
@@ -11,3 +11,5 @@ chr1	1	.	T	C,<NON_REF>	829.77	.	ExcessHet=3.0103	GT	0/1
 chr1	2	.	G	GTTTA,T,<NON_REF>	1042.73	.	ExcessHet=4.8532	GT	0/1
 chr1	3	.	C	A,G	10.032	.	ExcessHet=2.0134	GT	2/2
 chr1	4	.	G	GTTTA,<NON_REF>	1042.73	.	ExcessHet=4.8532	GT	1/1
+chr2	1	.	G	GTTTA	1042.73	.	ExcessHet=4.8532	GT	./1
+chr2	1	.	G	GTTTA	1042.73	.	ExcessHet=4.8532	GT	1/.

--- a/libtiledbvcf/test/run-cli-tests.sh
+++ b/libtiledbvcf/test/run-cli-tests.sh
@@ -8,7 +8,7 @@ if [[ $# -lt 2 ]]; then
     exit 1
 fi
 # Enable tracing
-set -x
+set -ex
 
 build_dir=$PWD/$1
 input_dir=$PWD/$2
@@ -485,11 +485,12 @@ echo "** End expected error messages."
 clean_up
 
 #test ingesting with stats enabled, and querying with IAF
+# also test ingesting stats where one allele is missing (chr2 in first.vcf)
 mkdir -p ${upload_dir}/outputs
 cp -R ${input_dir}/stats ${upload_dir}
 for file in ${upload_dir}/stats/*.vcf;do bcftools view --no-version -Oz -o "${file}".gz "${file}"; done
 for file in ${upload_dir}/stats/*.gz;do bcftools index "${file}"; done
-$tilevcf create -u ${upload_dir}/pre_test --enable-variant-stats --log-level trace
+$tilevcf create -u ${upload_dir}/pre_test --enable-variant-stats --enable-allele-count --log-level trace
 $tilevcf store -u ${upload_dir}/pre_test --log-level trace ${upload_dir}/stats/*.vcf.gz
 $tilevcf export -u ${upload_dir}/pre_test -d ${upload_dir}/outputs -Ov --af-filter '< 0.2' --log-level trace
 test ! -e ${upload_dir}/outputs/first.vcf || exit 1


### PR DESCRIPTION
During stats ingestion, handle the case where one allele is missing, for example GT=".|1" or GT="1|.".