### PR TITLE
change to use preprocessor '&&' operator

### DIFF
--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -1084,7 +1084,7 @@ std::unordered_map<uint32_t, SafeBCFHdr> TileDBVCFDataset::fetch_vcf_headers_v4(
   uint64_t header_data_element = 0;
   uint64_t sample_offset_element = 0;
   uint64_t sample_data_element = 0;
-#if TILEDB_VERSION_MAJOR == 2 and TILEDB_VERSION_MINOR < 2
+#if TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR < 2
   std::pair<uint64_t, uint64_t> header_est_size =
       query.est_result_size_var("header");
   header_offset_element =


### PR DESCRIPTION
change to use preprocessor '&&' operator as 'and' is incorrectly handled by some msvc versions