### PR TITLE
Update dataset creation defaults

### DIFF
--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -112,5 +112,6 @@ PYBIND11_MODULE(libtiledbvcf, m) {
           "set_contigs_to_allow_merging", &Writer::set_contigs_to_allow_merging)
       .def("set_contig_mode", &Writer::set_contig_mode)
       .def("set_enable_allele_count", &Writer::set_enable_allele_count)
-      .def("set_enable_variant_stats", &Writer::set_enable_variant_stats);
+      .def("set_enable_variant_stats", &Writer::set_enable_variant_stats)
+      .def("set_compress_sample_dim", &Writer::set_compress_sample_dim);
 }

--- a/apis/python/src/tiledbvcf/binding/writer.cc
+++ b/apis/python/src/tiledbvcf/binding/writer.cc
@@ -341,4 +341,10 @@ void Writer::set_enable_variant_stats(bool enable) {
       writer, tiledb_vcf_writer_set_enable_variant_stats(writer, enable));
 }
 
+void Writer::set_compress_sample_dim(bool enable) {
+  auto writer = ptr.get();
+  check_error(
+      writer, tiledb_vcf_writer_set_compress_sample_dim(writer, enable));
+}
+
 }  // namespace tiledbvcfpy

--- a/apis/python/src/tiledbvcf/binding/writer.h
+++ b/apis/python/src/tiledbvcf/binding/writer.h
@@ -230,6 +230,11 @@ class Writer {
   */
   void set_enable_variant_stats(bool enable);
 
+  /**
+    Enable compression of the sample dimension
+  */
+  void set_compress_sample_dim(bool enable);
+
  private:
   /** Helper function to free a C writer instance */
   static void deleter(tiledb_vcf_writer_t* w);

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -376,6 +376,7 @@ class Dataset(object):
         allow_duplicates=True,
         enable_allele_count=False,
         enable_variant_stats=False,
+        compress_sample_dim=True,
     ):
         """Create a new dataset
 
@@ -393,6 +394,7 @@ class Dataset(object):
             positions to be written to the array.
         :param bool enable_allele_count: Enable the allele count ingestion task.
         :param bool enable_variant_stats: Enable the variant stats ingestion task.
+        :param bool compress_sample_dim: Enable compression on the sample dimension.
         """
         if self.mode != "w":
             raise Exception("Dataset not open in write mode")
@@ -423,6 +425,9 @@ class Dataset(object):
 
         if enable_variant_stats is not None:
             self.writer.set_enable_variant_stats(enable_variant_stats)
+            
+        if compress_sample_dim is not None:
+            self.writer.set_compress_sample_dim(compress_sample_dim)
 
         # Create is a no-op if the dataset already exists.
         # TODO: Inform user if dataset already exists?

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -425,7 +425,7 @@ class Dataset(object):
 
         if enable_variant_stats is not None:
             self.writer.set_enable_variant_stats(enable_variant_stats)
-            
+
         if compress_sample_dim is not None:
             self.writer.set_compress_sample_dim(compress_sample_dim)
 

--- a/apis/python/tests/test_tiledbvcf.py
+++ b/apis/python/tests/test_tiledbvcf.py
@@ -1349,4 +1349,3 @@ def test_sample_compression(tmp_path, compress):
             found_zstd = found_zstd or "Zstd" in str(filter)
             
     assert found_zstd == compress
-    

--- a/apis/python/tests/test_tiledbvcf.py
+++ b/apis/python/tests/test_tiledbvcf.py
@@ -33,7 +33,15 @@ def _check_dfs(expected, actual):
 
     for k in actual:
         assert_series(expected[k], actual[k])
-
+        
+def check_if_compatible(uri):
+    try:
+        with tiledb.open(uri):
+            return True
+    except tiledb.cc.TileDBError as e:
+        if "Incompatible format version" in str(e):
+            raise pytest.skip.Exception("Test skipped due to incompatible format version")
+        raise
 
 @pytest.fixture
 def test_ds():
@@ -978,6 +986,8 @@ def test_ingestion_tasks(tmp_path):
 
     # query allele_count array with TileDB
     ac_uri = os.path.join(tmp_path, "dataset", "allele_count")
+    
+    check_if_compatible(ac_uri)
 
     contig = "1"
     region = slice(69896)
@@ -1322,6 +1332,21 @@ def test_vcf_attrs(tmp_path):
     assert ds.attributes(attr_type="fmt") == []
     assert sorted(ds.attributes()) == sorted(queryable_attrs)
 
-
-if __name__ == "__main__":
-    test_allele_count("/tmp/gspowley-debug")
+@pytest.mark.parametrize("compress", [True, False])
+def test_sample_compression(tmp_path, compress):
+    # Create the dataset
+    dataset_uri = os.path.join(tmp_path, "sample_compression")
+    array_uri = os.path.join(dataset_uri, "data")
+    ds = tiledbvcf.Dataset(dataset_uri, mode="w")
+    ds.create_dataset(compress_sample_dim=compress)
+    
+    check_if_compatible(array_uri)
+    
+    # Check for the presence of the Zstd filter
+    found_zstd = False
+    with tiledb.open(array_uri) as A:
+        for filter in A.domain.dim("sample").filters:
+            found_zstd = found_zstd or "Zstd" in str(filter)
+            
+    assert found_zstd == compress
+    

--- a/apis/python/tests/test_tiledbvcf.py
+++ b/apis/python/tests/test_tiledbvcf.py
@@ -33,15 +33,19 @@ def _check_dfs(expected, actual):
 
     for k in actual:
         assert_series(expected[k], actual[k])
-        
+
+
 def check_if_compatible(uri):
     try:
         with tiledb.open(uri):
             return True
     except tiledb.cc.TileDBError as e:
         if "Incompatible format version" in str(e):
-            raise pytest.skip.Exception("Test skipped due to incompatible format version")
+            raise pytest.skip.Exception(
+                "Test skipped due to incompatible format version"
+            )
         raise
+
 
 @pytest.fixture
 def test_ds():
@@ -986,7 +990,7 @@ def test_ingestion_tasks(tmp_path):
 
     # query allele_count array with TileDB
     ac_uri = os.path.join(tmp_path, "dataset", "allele_count")
-    
+
     check_if_compatible(ac_uri)
 
     contig = "1"
@@ -1332,6 +1336,7 @@ def test_vcf_attrs(tmp_path):
     assert ds.attributes(attr_type="fmt") == []
     assert sorted(ds.attributes()) == sorted(queryable_attrs)
 
+
 @pytest.mark.parametrize("compress", [True, False])
 def test_sample_compression(tmp_path, compress):
     # Create the dataset
@@ -1339,13 +1344,13 @@ def test_sample_compression(tmp_path, compress):
     array_uri = os.path.join(dataset_uri, "data")
     ds = tiledbvcf.Dataset(dataset_uri, mode="w")
     ds.create_dataset(compress_sample_dim=compress)
-    
+
     check_if_compatible(array_uri)
-    
+
     # Check for the presence of the Zstd filter
     found_zstd = False
     with tiledb.open(array_uri) as A:
         for filter in A.domain.dim("sample").filters:
             found_zstd = found_zstd or "Zstd" in str(filter)
-            
+
     assert found_zstd == compress

--- a/ci/azure-linux_mac.yml
+++ b/ci/azure-linux_mac.yml
@@ -14,7 +14,7 @@ steps:
 
   - bash: |
       set -e pipefail
-      brew install clang-format
+      sudo apt install -y clang-format
       src=$BUILD_REPOSITORY_LOCALPATH/libtiledbvcf
       cd $BUILD_REPOSITORY_LOCALPATH
       ci/run-clang-format.sh $src clang-format 0 \
@@ -22,8 +22,8 @@ steps:
       apis=$BUILD_REPOSITORY_LOCALPATH/apis
       ci/run-clang-format.sh $apis clang-format 0 \
         $(find $apis -name "*.cc" -or -name "*.c" -or -name "*.h")
-    condition: eq(variables['Agent.OS'], 'Darwin')
-    displayName: 'Check formatting (macOS only)'
+    condition: eq(variables['Agent.OS'], 'Linux')
+    displayName: 'Check formatting (Linux only)'
 
   - bash: |
       set -e pipefail

--- a/ci/run-clang-format.sh
+++ b/ci/run-clang-format.sh
@@ -32,6 +32,8 @@ pushd "$SOURCE_DIR" || exit
 if [ "$APPLY_FIXES" == "1" ]; then
   $CLANG_FORMAT -i "$@"
 else
+  $CLANG_FORMAT --version
+  $CLANG_FORMAT --dry-run "$@"
   NUM_CORRECTIONS=$("$CLANG_FORMAT" --output-replacements-xml "$@" | grep --count offset)
   if [ "$NUM_CORRECTIONS" -gt "0" ]; then
     echo "clang-format suggested $NUM_CORRECTIONS changes, please run 'make format'!"

--- a/libtiledbvcf/src/c_api/tiledbvcf.cc
+++ b/libtiledbvcf/src/c_api/tiledbvcf.cc
@@ -1639,6 +1639,18 @@ int32_t tiledb_vcf_writer_set_enable_variant_stats(
   return TILEDB_VCF_OK;
 }
 
+int32_t tiledb_vcf_writer_set_compress_sample_dim(
+    tiledb_vcf_writer_t* writer, bool enable) {
+  if (sanity_check(writer) == TILEDB_VCF_ERR)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          writer, writer->writer_->set_compress_sample_dim(enable)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
 /* ********************************* */
 /*               ERROR               */
 /* ********************************* */

--- a/libtiledbvcf/src/c_api/tiledbvcf.h
+++ b/libtiledbvcf/src/c_api/tiledbvcf.h
@@ -1587,6 +1587,14 @@ TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_set_enable_allele_count(
 TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_set_enable_variant_stats(
     tiledb_vcf_writer_t* writer, bool enable);
 
+/**
+ * Sets enable for sample dimension compression
+ * @param writer VCF writer object
+ * @param enable enable/disable
+ */
+TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_set_compress_sample_dim(
+    tiledb_vcf_writer_t* writer, bool enable);
+
 /* ********************************* */
 /*               ERROR               */
 /* ********************************* */

--- a/libtiledbvcf/src/cli/tiledbvcf.cc
+++ b/libtiledbvcf/src/cli/tiledbvcf.cc
@@ -437,19 +437,20 @@ void add_create(CLI::App& app) {
       "Allow records with duplicate start positions to be written to the "
       "array.");
   cmd->add_flag(
-      "--compress-sample-dim",
+      "--compress-sample-dim,!--no-compress-sample-dim",
       args->compress_sample_dim,
-      "Add zstd compression to the sample dimension.");
+      "Enable/disable compression of the sample dimension. Enabled by "
+      "default.");
 
   cmd->option_defaults()->group("Ingestion task options");
   cmd->add_flag(
-      "--enable-allele-count",
+      "--enable-allele-count,!--disable-allele-count",
       args->enable_allele_count,
-      "Enable allele count ingestion task");
+      "Enable/disable allele count array creation. Enabled by default.");
   cmd->add_flag(
-      "--enable-variant-stats",
+      "--enable-variant-stats,!--disable-variant-stats",
       args->enable_variant_stats,
-      "Enable variant stats ingestion task");
+      "Enable/disable variant stats array creation. Enabled by default.");
 
   cmd->option_defaults()->group("TileDB options");
   cmd->add_option(
@@ -602,7 +603,7 @@ void add_store(CLI::App& app) {
 
   cmd->option_defaults()->group("Contig options");
   cmd->add_flag(
-      "--disable-contig-fragment-merging",
+      "!--disable-contig-fragment-merging",
       args->contig_fragment_merging,
       "Disable merging of contigs into fragments. Generally contig fragment "
       "merging is good, this is a performance optimization to reduce the "
@@ -784,7 +785,7 @@ void add_export(CLI::App& app) {
       "the format I:N where I is the partition index and N is the "
       "total number of partitions. Useful for batch exports.");
   cmd->add_flag(
-      "--disable-check-samples",
+      "!--disable-check-samples",
       args->check_samples_exist,
       "Disable validating that sample passed exist in dataset before "
       "executing query and error if any sample requested is not in the "

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -405,19 +405,19 @@ void TileDBVCFDataset::create_empty_data_array(
   auto real_start_pos = Attribute::create<uint32_t>(
       ctx, AttrNames::V4::real_start_pos, int_attr_filters);  // a0
   auto end_pos = Attribute::create<uint32_t>(
-      ctx, AttrNames::V4::end_pos, int_attr_filters);         // a1
+      ctx, AttrNames::V4::end_pos, int_attr_filters);  // a1
   auto qual = Attribute::create<float>(
-      ctx, AttrNames::V4::qual, float_attr_filters);          // a2
+      ctx, AttrNames::V4::qual, float_attr_filters);  // a2
   auto alleles = Attribute::create<std::vector<char>>(
-      ctx, AttrNames::V4::alleles, byte_attr_filters);        // a3
+      ctx, AttrNames::V4::alleles, byte_attr_filters);  // a3
   auto id = Attribute::create<std::vector<char>>(
-      ctx, AttrNames::V4::id, byte_attr_filters);             // a4
+      ctx, AttrNames::V4::id, byte_attr_filters);  // a4
   auto filters_ids = Attribute::create<std::vector<int32_t>>(
-      ctx, AttrNames::V4::filter_ids, int_attr_filters);      // a5
+      ctx, AttrNames::V4::filter_ids, int_attr_filters);  // a5
   auto info = Attribute::create<std::vector<uint8_t>>(
-      ctx, AttrNames::V4::info, byte_attr_filters);           // a6
+      ctx, AttrNames::V4::info, byte_attr_filters);  // a6
   auto fmt = Attribute::create<std::vector<uint8_t>>(
-      ctx, AttrNames::V4::fmt, byte_attr_filters);            // a7
+      ctx, AttrNames::V4::fmt, byte_attr_filters);  // a7
   schema.add_attributes(
       real_start_pos, end_pos, qual, alleles, id, filters_ids, info, fmt);
 

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -63,9 +63,9 @@ struct CreationParams {
   tiledb_filter_type_t checksum = TILEDB_FILTER_CHECKSUM_SHA256;
   bool allow_duplicates = true;
   std::string vcf_uri;
-  bool enable_allele_count = false;
-  bool enable_variant_stats = false;
-  bool compress_sample_dim = false;
+  bool enable_allele_count = true;
+  bool enable_variant_stats = true;
+  bool compress_sample_dim = true;
 };
 
 /** Arguments/params for dataset registration. */

--- a/libtiledbvcf/src/read/delete_exporter.cc
+++ b/libtiledbvcf/src/read/delete_exporter.cc
@@ -48,12 +48,8 @@ bool DeleteExporter::export_record(
 
   // Flush and finalize the stats array querys when moving to a new contig
   if (contig_ != query_region.seq_name && !contig_.empty()) {
-    ac_.flush();
     ac_.flush(true);
-    ac_.finalize();
-    vs_.flush();
     vs_.flush(true);
-    vs_.finalize();
   }
   contig_ = query_region.seq_name;
 

--- a/libtiledbvcf/src/read/delete_exporter.h
+++ b/libtiledbvcf/src/read/delete_exporter.h
@@ -87,13 +87,9 @@ class DeleteExporter : public Exporter {
    * @brief Flush and close the stats array writers.
    */
   void close() override {
-    ac_.flush();
     ac_.flush(true);
-    ac_.finalize();
     ac_.close();
-    vs_.flush();
     vs_.flush(true);
-    vs_.finalize();
     vs_.close();
   }
 

--- a/libtiledbvcf/src/stats/allele_count.h
+++ b/libtiledbvcf/src/stats/allele_count.h
@@ -106,13 +106,7 @@ class AlleleCount {
   static void init(std::shared_ptr<Context> ctx, const Group& group);
 
   /**
-   * @brief Finalize the currently open write query.
-   *
-   */
-  static void finalize();
-
-  /**
-   * @brief Finalize the query and close the array.
+   * @brief Close the array.
    *
    */
   static void close();
@@ -181,13 +175,24 @@ class AlleleCount {
   /**
    * @brief Write buffered stats to the TileDB array and reset the buffers.
    *
+   * If finalize is true, the query buffers are cleared and the query is
+   * finalized. Finalize should be called after all records have been
+   * processed for a contig or merged contig.
+   *
+   * @param finalize If true, finalize the query.
    */
-  void flush(bool clear = false);
+  void flush(bool finalize = false);
 
  private:
   //===================================================================
   //= private static
   //===================================================================
+
+  /**
+   * @brief Finalize the currently open write query.
+   *
+   */
+  static void finalize_query();
 
   /**
    * @brief Get the URI for the array from the root URI

--- a/libtiledbvcf/src/stats/variant_stats.h
+++ b/libtiledbvcf/src/stats/variant_stats.h
@@ -105,13 +105,7 @@ class VariantStats {
   static void init(std::shared_ptr<Context> ctx, const Group& group);
 
   /**
-   * @brief Finalize the currently open write query.
-   *
-   */
-  static void finalize();
-
-  /**
-   * @brief Finalize the query and close the array.
+   * @brief Close the array.
    *
    */
   static void close();
@@ -179,6 +173,12 @@ class VariantStats {
 
   /**
    * @brief Write buffered stats to the TileDB array and reset the buffers.
+   *
+   * If finalize is true, the query buffers are cleared and the query is
+   * finalized. Finalize should be called after all records have been
+   * processed for a contig or merged contig.
+   *
+   * @param finalize If true, finalize the query.
    */
   void flush(bool clear = false);
 
@@ -186,6 +186,12 @@ class VariantStats {
   //===================================================================
   //= private static
   //===================================================================
+
+  /**
+   * @brief Finalize the currently open write query.
+   *
+   */
+  static void finalize_query();
 
   /**
    * @brief Get the URI for the array from the root URI

--- a/libtiledbvcf/src/write/writer.h
+++ b/libtiledbvcf/src/write/writer.h
@@ -105,7 +105,7 @@ struct IngestionParams {
   // Max size of TileDB buffers before flushing. Defaults to 1GB
   uint32_t max_tiledb_buffer_size_mb = 1024;  // legacy option
   bool use_legacy_max_tiledb_buffer_size_mb =
-      false;                                  // if true, use legacy option
+      false;  // if true, use legacy option
   float ratio_output_flush =
       0.75;  // ratio of output buffer capacity that triggers a flush to TileDB
 
@@ -367,6 +367,9 @@ class Writer {
     Enable the variant stats ingestion task
   */
   void set_enable_variant_stats(bool enable);
+
+  /** Enable sample dimension compression. */
+  void set_compress_sample_dim(bool enable);
 
  private:
   /* ********************************* */

--- a/libtiledbvcf/src/write/writer_worker.h
+++ b/libtiledbvcf/src/write/writer_worker.h
@@ -90,7 +90,7 @@ class WriterWorker {
   virtual bool resume() = 0;
 
   /** Flush ingestion tasks. */
-  virtual void flush_ingestion_tasks(bool clear = false) {
+  virtual void flush_ingestion_tasks(bool finalize = false) {
   }
 
   /** Return a handle to the attribute buffers */

--- a/libtiledbvcf/src/write/writer_worker_v4.cc
+++ b/libtiledbvcf/src/write/writer_worker_v4.cc
@@ -257,9 +257,9 @@ bool WriterWorkerV4::resume() {
   return true;
 }
 
-void WriterWorkerV4::flush_ingestion_tasks(bool clear) {
-  ac_.flush(clear);
-  vs_.flush(clear);
+void WriterWorkerV4::flush_ingestion_tasks(bool finalize) {
+  ac_.flush(finalize);
+  vs_.flush(finalize);
 }
 
 void WriterWorkerV4::drain_anchors(WriterWorkerV4& anchor_worker) {

--- a/libtiledbvcf/src/write/writer_worker_v4.h
+++ b/libtiledbvcf/src/write/writer_worker_v4.h
@@ -104,7 +104,7 @@ class WriterWorkerV4 : public WriterWorker {
   void init_ingestion_tasks(std::shared_ptr<Context> ctx, std::string uri);
 
   /** Flush ingestion tasks. */
-  void flush_ingestion_tasks(bool clear = false);
+  void flush_ingestion_tasks(bool finalize = false);
 
   /** Drain local heap of anchors into the anchor worker. */
   void drain_anchors(WriterWorkerV4& anchor_worker);

--- a/libtiledbvcf/test/run-cli-tests.sh
+++ b/libtiledbvcf/test/run-cli-tests.sh
@@ -366,7 +366,7 @@ HG01762	1	13354	13389	T	12142	15000
 HG00280	1	17480	17486	A	17485	18000
 EOF
 ) || exit 1
-rm -f HG00280.vcf HG01762.vcf region-map.txt /tmp/pfx.tsv
+rm -f HG00280.vcf HG01762.vcf region-map.txt pfx.tsv
 
 # Check multiple register/store stages
 rm -rf ingested_1_2 HG00280.vcf HG01762.vcf
@@ -398,7 +398,7 @@ Statistics for dataset 'ingested_1_2':
 - Tile capacity: 10,000
 - Anchor gap: 1,000
 - Number of samples: 2
-- Extracted attributes: none
+- Extracted attributes: fmt_GT
 EOF
 ) || exit 1
 

--- a/libtiledbvcf/test/src/unit-vcf-iter.cc
+++ b/libtiledbvcf/test/src/unit-vcf-iter.cc
@@ -62,7 +62,7 @@ void check_iter_v2(
 
     bool b = vcf->next();
     if (i < expected.size() - 1)
-      REQUIRE(b);   // should be more records in vcf
+      REQUIRE(b);  // should be more records in vcf
     else
       REQUIRE(!b);  // should not be more records in vcf
   }


### PR DESCRIPTION
Update dataset creation to enable the following by default:
* Creation of the `allele_count` array.
* Creation of the `variant_stats` array.
* Zstd compression of the dictionary encoded sample dimension.

These options can be disabled from the CLI and python API.

The internal API for flush/finalize of the stats arrays was refactored, based on edge cases exposed in CI by always enabling these arrays.

[sc-11702]
[sc-28384]
