### PR TITLE
Minor updates to python API

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -3,8 +3,9 @@ project:
   type: website
   output-dir: docs
   render:
-    - "documentation"
+    # The first item will be the landing page
     - "documentation/index.md"
+    - "documentation"
     - "documentation/reference"
     - "examples/README.md"
     - "examples"

--- a/apis/python/tests/test_tiledbvcf.py
+++ b/apis/python/tests/test_tiledbvcf.py
@@ -766,6 +766,12 @@ def test_read_config():
     with pytest.raises(TypeError):
         cfg = tiledbvcf.ReadConfig(abc=123)
 
+    # Expect an exception when passing both cfg and tiledb_config
+    with pytest.raises(Exception):
+        cfg = tiledbvcf.ReadConfig()
+        tiledb_config = {"foo": "bar"}
+        ds = tiledbvcf.Dataset(uri, mode="r", cfg=cfg, tiledb_config=tiledb_config)
+
 
 # This test is skipped because running it in the same process as all the normal
 # tests will cause it to fail (the first context created in a process determines
@@ -945,7 +951,7 @@ def test_disable_ingestion_tasks(tmp_path):
     uri = os.path.join(tmp_path, "dataset")
     ds = tiledbvcf.Dataset(uri, mode="w")
     samples = [os.path.join(TESTS_INPUT_DIR, s) for s in ["small.bcf", "small3.bcf"]]
-    ds.create_dataset()
+    ds.create_dataset(enable_allele_count=False, enable_variant_stats=False)
     ds.ingest_samples(samples)
 
     # TODO: remove this workaround when sc-19721 is resolved


### PR DESCRIPTION
* Update some default values in the python API to match the defaults in C++, so we get the desired defaults.
* Add convenience arg `tiledb_config` to `Dataset` to allow passing a TileDB config without creating a `ReadConfig` object.
* Minor comment updates and code refactoring.
* Fix the doc landing page.