### PR TITLE
Add read_allele_frequency to python API

### DIFF
--- a/apis/python/src/tiledbvcf/__init__.py
+++ b/apis/python/src/tiledbvcf/__init__.py
@@ -38,3 +38,4 @@ except ImportError:
     pass
 
 from .version import version
+from .allele_frequency import read_allele_frequency

--- a/apis/python/src/tiledbvcf/allele_frequency.py
+++ b/apis/python/src/tiledbvcf/allele_frequency.py
@@ -1,0 +1,50 @@
+import pandas
+
+
+def _calc_af(df) -> pandas.DataFrame:
+    """
+    Consolidate AC and compute AN, AF
+
+    :param pandas.Dataframe df
+    """
+    # Allele Count (AC) = sum of all AC at the same locus
+    # This step consolidates ACs from all ingested batches
+    df = df.groupby(["pos", "allele"], sort=True).sum(numeric_only=True)
+
+    # Allele Number (AN) = sum of AC at the same locus
+    an = df.groupby(["pos"], sort=True).ac.sum().rename("an")
+    df = df.join(an, how="inner").reset_index()
+
+    # Allele Frequency (AF) = AC / AN
+    df["af"] = df.ac / df.an
+    return df
+
+
+def read_allele_frequency(dataset_uri: str, region: str) -> pandas.DataFrame():
+    """
+    Read variant status
+
+    :param dataset_uri: dataset URI
+    :param region: genomics region to read
+    """
+    import tiledb
+
+    # Get the variant stats uri
+    with tiledb.Group(dataset_uri) as g:
+        alleles_uri = g["variant_stats"].uri
+
+        try:
+            contig = region.split(":")[0]
+            start, end = map(int, region.split(":")[1].split("-"))
+            region_slice = slice(start, end)
+        except Exception as e:
+            raise ValueError(
+                f"Invalid region: {region}. Expected format: contig:start-end"
+            ) from e
+
+        with tiledb.open(alleles_uri) as A:
+            df = A.query(attrs=["ac", "allele"], dims=["pos", "contig"]).df[
+                contig, region_slice
+            ]
+
+        return _calc_af(df)


### PR DESCRIPTION
Add `read_allele_frequency` to read and compute allele frequency from the variant stats array.

Example:
```python
import tiledbvcf

dataset_uri = "VCF_DATASET_URI"
region = "1:840000-850000"
df = tiledbvcf.read_allele_frequency(dataset_uri, region)

# df contents
      pos                                             allele      ac      an   af
0  840035                                                  T  200000  200000  1.0
1  842056                                                  A  200000  200000  1.0
2  843214                                                  C  100000  200000  0.5
3  843214                  CCTGCCCGGTCCTTCTGACCAGCCGAGAGAGTA  100000  200000  0.5
4  844297                                                  A  200000  200000  1.0
5  844297  ACCGGGTCAGGCCCCCCGGGCGCACCGTTGCTGGTATATGCGGTGA...       0  200000  0.0
6  844786                                                  G  200000  200000  1.0
7  844786  TGGTCGGGGTCAGGCCCCCGGGCGCATCTTTGCTGGTATATGCGGT...       0  200000  0.0


```