### PR TITLE
Finalize stats arrays to optimize fragment layout

### DIFF
--- a/ci/azure-linux_mac.yml
+++ b/ci/azure-linux_mac.yml
@@ -154,9 +154,10 @@ steps:
 
         # Install mamba for faster environment creation
         conda install -y mamba -n base -c conda-forge
+        ls -l $CONDA/bin
 
         pushd $BUILD_REPOSITORY_LOCALPATH/apis/python
-        mamba env create --file conda-env.yml
+        $CONDA/bin/mamba env create --file conda-env.yml
         # Note that 'conda init' doesn't seem to work directly.
         source $CONDA/etc/profile.d/conda.sh
         conda activate tiledbvcf-py

--- a/ci/azure-linux_mac.yml
+++ b/ci/azure-linux_mac.yml
@@ -154,7 +154,6 @@ steps:
 
         # Install mamba for faster environment creation
         conda install -y mamba -n base -c conda-forge
-        ls -l $CONDA/bin
 
         pushd $BUILD_REPOSITORY_LOCALPATH/apis/python
         $CONDA/bin/mamba env create --file conda-env.yml

--- a/ci/azure-linux_mac.yml
+++ b/ci/azure-linux_mac.yml
@@ -152,8 +152,11 @@ steps:
           sudo chown -R $USER $CONDA
         fi
 
+        # Install mamba for faster environment creation
+        conda install -y mamba -n base -c conda-forge
+
         pushd $BUILD_REPOSITORY_LOCALPATH/apis/python
-        conda env create --file conda-env.yml
+        mamba env create --file conda-env.yml
         # Note that 'conda init' doesn't seem to work directly.
         source $CONDA/etc/profile.d/conda.sh
         conda activate tiledbvcf-py


### PR DESCRIPTION
During ingestion, finalize the stats arrays so each fragment contains data from one chromosome or data from a set of pseudo contigs.

Add `mamba` to speed up python CI.