### PR TITLE
Validate GT value in stats ingestion

### DIFF
--- a/libtiledbvcf/src/stats/allele_count.cc
+++ b/libtiledbvcf/src/stats/allele_count.cc
@@ -407,9 +407,24 @@ void AlleleCount::process(
   }
 
   int gt0 = bcf_gt_allele(dst_[0]);
-  int gt1 = bcf_gt_allele(dst_[1]);
+  int gt1 = ngt == 2 ? bcf_gt_allele(dst_[1]) : 0;
   int gt0_missing = bcf_gt_is_missing(dst_[0]);
-  int gt1_missing = bcf_gt_is_missing(dst_[1]);
+  int gt1_missing = ngt == 2 ? bcf_gt_is_missing(dst_[1]) : 1;
+  int n_allele = rec->n_allele;
+
+  // Skip if GT value is not a valid allele
+  if (gt0 >= n_allele || gt1 >= n_allele) {
+    LOG_WARN(
+        "AlleleCount: skipping invalid GT value: sample={} locus={}:{} "
+        "gt={}/{} n_allele={}",
+        sample_name,
+        contig,
+        pos + 1,
+        gt0,
+        gt1,
+        n_allele);
+    return;
+  }
 
   // Only haploid and diploid are supported
   if (ngt > 2) {

--- a/libtiledbvcf/src/stats/variant_stats.cc
+++ b/libtiledbvcf/src/stats/variant_stats.cc
@@ -410,6 +410,21 @@ void VariantStats::process(
   int gt1 = ngt == 2 ? bcf_gt_allele(dst_[1]) : 0;
   int gt0_missing = bcf_gt_is_missing(dst_[0]);
   int gt1_missing = ngt == 2 ? bcf_gt_is_missing(dst_[1]) : 1;
+  int n_allele = rec->n_allele;
+
+  // Skip if GT value is not a valid allele
+  if (gt0 >= n_allele || gt1 >= n_allele) {
+    LOG_WARN(
+        "VariantStats: skipping invalid GT value: sample={} locus={}:{} "
+        "gt={}/{} n_allele={}",
+        sample_name,
+        contig,
+        pos + 1,
+        gt0,
+        gt1,
+        n_allele);
+    return;
+  }
 
   // Skip if alleles are missing
   if (ngt == 1) {

--- a/libtiledbvcf/test/inputs/stats/first.vcf
+++ b/libtiledbvcf/test/inputs/stats/first.vcf
@@ -13,3 +13,5 @@ chr1	3	.	C	A,G	10.032	.	ExcessHet=2.0134	GT	2/2
 chr1	4	.	G	GTTTA,<NON_REF>	1042.73	.	ExcessHet=4.8532	GT	1/1
 chr2	1	.	G	GTTTA	1042.73	.	ExcessHet=4.8532	GT	./1
 chr2	1	.	G	GTTTA	1042.73	.	ExcessHet=4.8532	GT	1/.
+chr2	3	.	G	GTTTA	1042.73	.	ExcessHet=4.8532	GT	1/1
+chrX	3	BadGT	G	GTTTA	1042.73	.	ExcessHet=4.8532	GT	1/2


### PR DESCRIPTION
During VCF ingestion, validate that GT is in the range of the provided ALT alleles when updating the stats arrays.