### PR TITLE
Remove trailing README.md from link to obtain rendered page

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -29,7 +29,7 @@ A C++ library for efficient storage and retrieval of genomic variant-call data u
 
 The [documentation website][vcf] provides comprehensive usage examples but here are a few quick exercises to get you started.
 
-We'll use a dataset that includes 20 synthetic samples, each one containing over 20 million variants. We host a publicly accessible version of this dataset on S3, so if you have TileDB-VCF installed and you'd like to follow along just swap out the `uri`'s below for `s3://tiledb-inc-demo-data/tiledbvcf-arrays/v4/vcf-samples-20`. And if you *don't* have TileDB-VCF installed yet, you can use our [Docker images](docker/README.md) to test things out.
+We'll use a dataset that includes 20 synthetic samples, each one containing over 20 million variants. We host a publicly accessible version of this dataset on S3, so if you have TileDB-VCF installed and you'd like to follow along just swap out the `uri`'s below for `s3://tiledb-inc-demo-data/tiledbvcf-arrays/v4/vcf-samples-20`. And if you *don't* have TileDB-VCF installed yet, you can use our [Docker images](docker/) to test things out.
 
 ### CLI
 


### PR DESCRIPTION
The introductory documentation has a link in the 'Quick Start' section which comes up as the actual `README.md` markdown, as opposed to the rendered page. Compare
- current https://tiledb-inc.github.io/TileDB-VCF/documentation/docker/README.md
- proposed https://tiledb-inc.github.io/TileDB-VCF/documentation/docker/

The PR just removes the trailing README.md.