### PR TITLE
Add nightly build (linux only for now)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,17 +40,21 @@ jobs:
       - name: Build libtiledb
         run: bash TileDB-VCF/ci/nightly/build-libtiledb.sh
       - name: Build libtiledbvcf
-        run: bash  TileDB-VCF/ci/nightly/build-libtiledbvcf.sh
+        run: bash TileDB-VCF/ci/nightly/build-libtiledbvcf.sh
       - name: Confirm linking
         run: |
           ldd install/lib/libtiledb.so
           ldd install/lib/libtiledbvcf.so | grep tile
+      - name: Install bcftools (for tests)
+        run: sudo apt install bcftools
+      - name: Test libtiledbvcf
+        run: bash TileDB-VCF/ci/nightly/test-libtiledbvcf.sh
       - name: Setup conda env
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: TileDB-VCF/ci/nightly/environment.yaml
           cache-environment: true
-      - name: Build tiledbvcf-py
+      - name: Build (and test) tiledbvcf-py
         # need -l to activate conda env
         shell: bash -l {0}
         run: bash TileDB-VCF/ci/nightly/build-tiledbvcf-py.sh

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,72 @@
+name: Nightly build against nightly libtiledb
+# High-level notes:
+# * Installs libtiledb and libtiledbvcf into ./install/
+# * Manually updates library path so that tiledbvcf-py can link to
+#   the shared objects in ./install/
+# * conda is only used to install Python dependencies
+on:
+  push:
+    paths:
+      - '.github/workflows/nightly.yml'
+      - 'ci/nightly/**'
+  pull_request:
+    paths:
+      - '.github/workflows/nightly.yml'
+      - 'ci/nightly/**'
+  schedule:
+    - cron: "0 3 * * *" # Every night at 3 AM UTC (10 PM EST; 11 PM EDT)
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os }}-libtiledb-${{ matrix.libtiledb_version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        libtiledb_version: [release-2.17, dev]
+        os: [ubuntu-latest]
+    steps:
+      - name: Clone TileDB
+        uses: actions/checkout@v3
+        with:
+          repository: TileDB-Inc/TileDB
+          ref: ${{ matrix.libtiledb_version }}
+          path: TileDB
+      - name: Clone TileDB-VCF
+        uses: actions/checkout@v3
+        with:
+          path: TileDB-VCF
+          fetch-depth: 0 # fetch everything for python setuptools_scm
+      - name: Build libtiledb
+        run: bash TileDB-VCF/ci/nightly/build-libtiledb.sh
+      - name: Build libtiledbvcf
+        run: bash  TileDB-VCF/ci/nightly/build-libtiledbvcf.sh
+      - name: Confirm linking
+        run: |
+          ldd install/lib/libtiledb.so
+          ldd install/lib/libtiledbvcf.so | grep tile
+      - name: Setup conda env
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: TileDB-VCF/ci/nightly/environment.yaml
+          cache-environment: true
+      - name: Build tiledbvcf-py
+        # need -l to activate conda env
+        shell: bash -l {0}
+        run: bash TileDB-VCF/ci/nightly/build-tiledbvcf-py.sh
+  issue:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    needs: build
+    if: ( failure() || cancelled() ) && github.repository_owner == 'TileDB-Inc' && github.event_name == 'schedule'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Open Issue
+        uses: TileDB-Inc/github-actions/open-issue@main
+        with:
+          name: nightly build
+          label: nightly-failure
+          assignee: awenocur,gspowley,ihnorton,Shelnutt2
+        env:
+          TZ: "America/New_York"

--- a/ci/nightly/build-libtiledb.sh
+++ b/ci/nightly/build-libtiledb.sh
@@ -8,7 +8,8 @@ cmake -S TileDB -B build-libtiledb \
   -D CMAKE_INSTALL_PREFIX:PATH=$GITHUB_WORKSPACE/install/ \
   -D TILEDB_WERROR=ON \
   -D TILEDB_SERIALIZATION=ON \
-  -D TILEDB_VCPKG=OFF
+  -D TILEDB_VCPKG=OFF \
+  -D TILEDB_S3=ON
 
 cmake --build build-libtiledb -j2 --config Release
 

--- a/ci/nightly/build-libtiledb.sh
+++ b/ci/nightly/build-libtiledb.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -ex
+
+# Build libtiledb assuming source code directory is ./TileDB
+
+cmake -S TileDB -B build-libtiledb \
+  -D CMAKE_BUILD_TYPE=Release \
+  -D CMAKE_INSTALL_PREFIX:PATH=$GITHUB_WORKSPACE/install/ \
+  -D TILEDB_WERROR=ON \
+  -D TILEDB_SERIALIZATION=ON \
+  -D TILEDB_VCPKG=OFF
+
+cmake --build build-libtiledb -j2 --config Release
+
+cmake --build build-libtiledb --config Release --target install-tiledb

--- a/ci/nightly/build-libtiledbvcf.sh
+++ b/ci/nightly/build-libtiledbvcf.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -ex
+
+# Build libtiledbvcf assuming source code directory is ./TileDB-VCF/libtiledbvcf
+
+cmake -S TileDB-VCF/libtiledbvcf -B build-libtiledbvcf \
+  -D CMAKE_BUILD_TYPE=Release \
+  -D CMAKE_INSTALL_PREFIX:PATH=$GITHUB_WORKSPACE/install/ \
+  -D OVERRIDE_INSTALL_PREFIX=OFF \
+  -D TILEDB_WERROR=OFF
+
+cmake --build build-libtiledbvcf -j2 --config Release
+
+cmake --build build-libtiledbvcf --config Release --target install-libtiledbvcf
+
+./install/bin/tiledbvcf version

--- a/ci/nightly/build-tiledbvcf-py.sh
+++ b/ci/nightly/build-tiledbvcf-py.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -ex
 
-# Build tiledbvcf-py assuming source code directory is ./TileDB-VCF/apis/python
+# Build (and test) tiledbvcf-py assuming source code directory is
+# ./TileDB-VCF/apis/python
 
 export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/install/lib:${LD_LIBRARY_PATH-}
 echo "LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
@@ -9,3 +10,5 @@ echo "LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
 cd TileDB-VCF/apis/python
 python setup.py install --libtiledbvcf=$GITHUB_WORKSPACE/install/
 python -c "import tiledbvcf; print(tiledbvcf.version)"
+
+pytest

--- a/ci/nightly/build-tiledbvcf-py.sh
+++ b/ci/nightly/build-tiledbvcf-py.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -ex
+
+# Build tiledbvcf-py assuming source code directory is ./TileDB-VCF/apis/python
+
+export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/install/lib:${LD_LIBRARY_PATH-}
+echo "LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
+
+cd TileDB-VCF/apis/python
+python setup.py install --libtiledbvcf=$GITHUB_WORKSPACE/install/
+python -c "import tiledbvcf; print(tiledbvcf.version)"

--- a/ci/nightly/environment.yaml
+++ b/ci/nightly/environment.yaml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
+  # build
   - numpy
   - pandas
   - pyarrow=9
@@ -12,3 +13,7 @@ dependencies:
   - setuptools_scm
   - setuptools_scm_git_archive
   - wheel
+  # test
+  - dask
+  - pytest
+  - tiledb-py

--- a/ci/nightly/environment.yaml
+++ b/ci/nightly/environment.yaml
@@ -1,0 +1,14 @@
+name: py4vcf
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - numpy
+  - pandas
+  - pyarrow=9
+  - pybind11
+  - python=3.9
+  - setuptools
+  - setuptools_scm
+  - setuptools_scm_git_archive
+  - wheel

--- a/ci/nightly/test-libtiledbvcf.sh
+++ b/ci/nightly/test-libtiledbvcf.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -ex
+
+# Test libtiledbvcf assuming source code directory is ./TileDB-VCF/libtiledbvcf
+# and build directory is build-libtiledbvcf
+
+make -j2 -C build-libtiledbvcf/libtiledbvcf tiledb_vcf_unit
+./build-libtiledbvcf/libtiledbvcf/test/tiledb_vcf_unit
+
+# cli tests (require bcftools)
+# USAGE: run-cli-tests.sh <build-dir> <inputs-dir>
+TileDB-VCF/libtiledbvcf/test/run-cli-tests.sh build-libtiledbvcf TileDB-VCF/libtiledbvcf/test/inputs


### PR DESCRIPTION
Nightly build against nightly libtiledb. Will add macOS and Windows builds in the future. The main blocker is finding a compatible pyarrow. I've tried multiple versions of pyarrow, installed via either pip or conda, and I can't find an option that successfully builds for both Linux and macOS.

cc: @ihnorton, @awenocur 