### PR TITLE
Enable LIBTILEDBVCF_PATH to be set as an environment variable

### DIFF
--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -41,7 +41,7 @@ import sys
 
 TILEDBVCF_DEBUG_BUILD = False
 TILEDBVCF_S3 = True
-LIBTILEDBVCF_PATH = None
+LIBTILEDBVCF_PATH = os.environ.get("LIBTILEDBVCF_PATH", None)
 DOWNLOAD_TILEDB_PREBUILT = True
 
 args = sys.argv[:]

--- a/ci/nightly/build-tiledbvcf-py.sh
+++ b/ci/nightly/build-tiledbvcf-py.sh
@@ -2,13 +2,16 @@
 set -ex
 
 # Build (and test) tiledbvcf-py assuming source code directory is
-# ./TileDB-VCF/apis/python
+# ./TileDB-VCF/apis/python and libtiledbvcf shared library installed in
+# $GITHUB_WORKSPACE/install/
 
 export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/install/lib:${LD_LIBRARY_PATH-}
 echo "LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
 
+export LIBTILEDBVCF_PATH=$GITHUB_WORKSPACE/install/
+
 cd TileDB-VCF/apis/python
-python setup.py install --libtiledbvcf=$GITHUB_WORKSPACE/install/
+python setup.py install
 python -c "import tiledbvcf; print(tiledbvcf.version)"
 
 pytest


### PR DESCRIPTION
It is easy to pass `--libtiledbvcf` to `python setup.py install`, but this is trickier when trying to build with `pip install`. This PR adds the additional option of specifying the env var `LIBTILEDBVCF_PATH`, though `--libtiledbvcf` takes precedence

This is similar to what is currently done in [TileDB-Py](https://github.com/TileDB-Inc/TileDB-Py/blob/dev/setup.py#L577-L579) and [TileDB-SOMA](https://github.com/single-cell-data/TileDB-SOMA/blob/7a0d937718077310fde128840a972230007b7694/apis/python/setup.py#L43-L60)