### PR TITLE
Pin setuptools_scm<8.0.0 to build arrow from source in Dockerfile

### DIFF
--- a/docker/Dockerfile-py
+++ b/docker/Dockerfile-py
@@ -51,7 +51,11 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
 
 # avoid --home to prevent issues with singularity
 # TODO: remove cython pin after updating the arrow version
-RUN pip install --no-cache-dir 'cython<3' 'pandas>=1.5.0,<2.0.0' tiledb==0.21.2
+RUN pip install --no-cache-dir \
+    'cython<3' \
+    'pandas>=1.5.0,<2.0.0' \
+    'setuptools_scm<8.0.0' \
+    tiledb==0.21.2
 
 # Build arrow
 ENV ARROW_HOME=/usr/local


### PR DESCRIPTION
The Docker build started failing during the step to build arrow from source. This is a known issue that was reported a few days ago in https://github.com/apache/arrow/issues/37803 and fixed by pinning `setuptools_scm<8.0.0` in PR https://github.com/apache/arrow/pull/37819

