### PR TITLE
Iterate over polyploid calls

### DIFF
--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -1298,14 +1298,18 @@ bool Reader::process_query_results_v4() {
         // If the allele is in GT, consider it in the pass computation
         // TODO: when supporting greater than diploid organisms, expand the
         // following boolean statement into a loop
-        if (!is_ref && ((gt.size() > 0 && allele_index == gt[0]) ||
-                        (gt.size() > 1 && allele_index == gt[1]))) {
-          pass = pass || allele_passes;
-        } else {
-          LOG_TRACE("  ignore allele {} not in GT", allele_index);
+        {
+          bool matches_any_allele = false;
+          for (unsigned int i = 0; i < gt.size(); i++) {
+            matches_any_allele = matches_any_allele || allele_index == gt[i];
+          }
+          if (!is_ref && matches_any_allele) {
+            pass = pass || allele_passes;
+          } else {
+            LOG_TRACE("  ignore allele {} not in GT", allele_index);
+          }
+          allele_index++;
         }
-        allele_index++;
-
         // build vector of IAF values for annotation
         // add annotation to read_state_.query_results
         //  - build vector of AFs matching the order of the VCF record

--- a/libtiledbvcf/src/stats/allele_count.cc
+++ b/libtiledbvcf/src/stats/allele_count.cc
@@ -426,16 +426,6 @@ void AlleleCount::process(
     return;
   }
 
-  // Only haploid and diploid are supported
-  if (ngt > 2) {
-    LOG_FATAL(
-        "Ploidy > 2 not supported: sample={} locus={}:{} ploidy={}",
-        sample_name,
-        contig,
-        pos,
-        ngt);
-  }
-
   // Skip if homozygous ref or alleles are missing
   if (ngt == 1) {
     if (gt0 == 0 || gt0_missing) {

--- a/libtiledbvcf/src/stats/variant_stats.cc
+++ b/libtiledbvcf/src/stats/variant_stats.cc
@@ -396,16 +396,6 @@ void VariantStats::process(
     return;
   }
 
-  // Only haploid and diploid are supported
-  if (ngt > 2) {
-    LOG_FATAL(
-        "Ploidy > 2 not supported: sample={} locus={}:{} ploidy={}",
-        sample_name,
-        contig,
-        pos,
-        ngt);
-  }
-
   std::vector<int> gt(ngt);
   std::vector<int> gt_missing(ngt);
   for (int i = 0; i < ngt; i++) {

--- a/libtiledbvcf/test/inputs/polyploid/first.vcf
+++ b/libtiledbvcf/test/inputs/polyploid/first.vcf
@@ -1,0 +1,13 @@
+##fileformat=VCFv4.2
+##FILTER=<ID=PASS,Description="All filters passed">
+##ALT=<ID=NON_REF,Description="Represents any possible alternative allele at this location">
+##INFO=<ID=ExcessHet,Number=1,Type=Float,Description="Phred-scaled p-value for exact test of excess heterozygosity">
+##FORMAT=<ID=AB,Number=1,Type=Float,Description="Allele balance for each het genotype">
+##FORMAT=<ID=AD,Number=.,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##contig=<ID=chr1>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	first
+chr1	1	.	T	C,<NON_REF>	829.77	.	ExcessHet=3.0103	GT	0/1
+chr1	2	.	G	GTTTA,T,<NON_REF>	1042.73	.	ExcessHet=4.8532	GT	0/1
+chr1	3	.	C	A,G	10.032	.	ExcessHet=2.0134	GT	2/2
+chr1	4	.	G	GTTTA,<NON_REF>	1042.73	.	ExcessHet=4.8532	GT	0/0

--- a/libtiledbvcf/test/inputs/polyploid/second.vcf
+++ b/libtiledbvcf/test/inputs/polyploid/second.vcf
@@ -1,0 +1,13 @@
+##fileformat=VCFv4.2
+##FILTER=<ID=PASS,Description="All filters passed">
+##ALT=<ID=NON_REF,Description="Represents any possible alternative allele at this location">
+##INFO=<ID=ExcessHet,Number=1,Type=Float,Description="Phred-scaled p-value for exact test of excess heterozygosity">
+##FORMAT=<ID=AB,Number=1,Type=Float,Description="Allele balance for each het genotype">
+##FORMAT=<ID=AD,Number=.,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##contig=<ID=chr1>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	second
+chr1	1	.	T	C,<NON_REF>	829.77	.	ExcessHet=3.0103	GT	0/0/1/1
+chr1	2	.	G	GTTTA,T,<NON_REF>	343.73	.	ExcessHet=2.8532	GT	0/0/1/1
+chr1	3	.	C	A,G	10.032	.	ExcessHet=8.34	GT	2/2/2/2
+chr1	4	.	G	GTTTA,<NON_REF>	343.73	.	ExcessHet=2.8532	GT	0/0/1/1

--- a/libtiledbvcf/test/inputs/polyploid/third.vcf
+++ b/libtiledbvcf/test/inputs/polyploid/third.vcf
@@ -1,0 +1,13 @@
+##fileformat=VCFv4.2
+##FILTER=<ID=PASS,Description="All filters passed">
+##ALT=<ID=NON_REF,Description="Represents any possible alternative allele at this location">
+##INFO=<ID=ExcessHet,Number=1,Type=Float,Description="Phred-scaled p-value for exact test of excess heterozygosity">
+##FORMAT=<ID=AB,Number=1,Type=Float,Description="Allele balance for each het genotype">
+##FORMAT=<ID=AD,Number=.,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##contig=<ID=chr1>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	third
+chr1	1	.	T	C,<NON_REF>	829.77	.	ExcessHet=3.0103	GT	0/0/0/0/0/0/1/1
+chr1	2	.	G	GTTTA,T,<NON_REF>	343.73	.	ExcessHet=2.8532	GT	0/0/0/0/0/1/1/1
+chr1	3	.	C	A,T	10.032	.	ExcessHet=8.34	GT	0/0/0/0/1/1/1/1
+chr1	4	.	G	GTTTA,<NON_REF>	343.73	.	ExcessHet=2.8532	GT	0/0/0/0/0/0/0/0

--- a/libtiledbvcf/test/run-cli-tests.sh
+++ b/libtiledbvcf/test/run-cli-tests.sh
@@ -476,6 +476,19 @@ test ! -e ${upload_dir}/outputs/eighth.vcf || exit 1
 
 [ $(bcftools view -H ${upload_dir}/outputs/second.vcf  | wc -l) == "1" ] || exit 1
 
+rm -rf ${upload_dir}/outputs
+
+# test ingesting polyploid calls
+
+mkdir -p ${upload_dir}/outputs
+
+cp -R ${input_dir}/polyploid ${upload_dir}
+for file in ${upload_dir}/polyploid/*.vcf;do bcftools view --no-version -Oz -o "${file}".gz "${file}"; done
+for file in ${upload_dir}/polyploid/*.gz;do bcftools index "${file}"; done
+$tilevcf create -u ${upload_dir}/polyploid_test --enable-variant-stats --enable-allele-count --log-level trace
+$tilevcf store -u ${upload_dir}/polyploid_test --log-level trace ${upload_dir}/polyploid/*.vcf.gz
+$tilevcf export -u ${upload_dir}/polyploid_test -d ${upload_dir}/outputs -Ov --af-filter '< 0.8' --log-level trace
+
 # test consolidate and vacuum
 # -------------------------------------------------------------------
 uri=${upload_dir}/pre_test


### PR DESCRIPTION
Genotypes are being handled with hard-coded logic for diploid calls. Ensure that this be abstracted out as an iteration.