### PR TITLE
Update to c++17

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -41,6 +41,7 @@ stages:
             DOWNLOAD_TILEDB_PREBUILT: ON
             #SDKROOT: '/Applications/Xcode_10.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk'
             ARTIFACT_NAME: macos
+            MACOSX_DEPLOYMENT_TARGET: '10.15'
       pool:
         vmImage: $(imageName)
       steps:
@@ -96,6 +97,7 @@ stages:
               BUILD_PYTHON_API: ON
               BUILD_SPARK_API: ON
               #SDKROOT: '/Applications/Xcode_10.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk'
+              MACOSX_DEPLOYMENT_TARGET: '10.15'
 
         pool:
           vmImage: $(imageName)

--- a/apis/java/CMakeLists.txt
+++ b/apis/java/CMakeLists.txt
@@ -37,8 +37,8 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-# Set C++11 as required standard for all C++ targets.
-set(CMAKE_CXX_STANDARD 11)
+# Set C++17 as required standard for all C++ targets.
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF) # Don't use GNU extensions
 

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -224,14 +224,14 @@ class BuildExtCmd(build_ext):
 
     def build_extensions(self):
         if sys.platform != "win32":
-            opts = ["-std=c++11", "-g"]
+            opts = ["-std=c++17", "-g"]
             if TILEDBVCF_DEBUG_BUILD:
                 opts.extend(["-O0"])
             else:
                 opts.extend(["-O2"])
         else:  # windows
-            # Note: newer versions of msvc cl may not recognize -std:c++11
-            opts = ["-std:c++11", "-Zi"]
+            # Note: newer versions of msvc cl may not recognize -std:c++17
+            opts = ["-std:c++17", "-Zi"]
             if TILEDBVCF_DEBUG_BUILD:
                 opts.extend(["-Od"])
             else:

--- a/apis/spark/CMakeLists.txt
+++ b/apis/spark/CMakeLists.txt
@@ -37,7 +37,7 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-# Set C++11 as required standard for all C++ targets.
+# Set C++17 as required standard for all C++ targets.
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF) # Don't use GNU extensions

--- a/apis/spark3/CMakeLists.txt
+++ b/apis/spark3/CMakeLists.txt
@@ -37,8 +37,8 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-# Set C++11 as required standard for all C++ targets.
-set(CMAKE_CXX_STANDARD 11)
+# Set C++17 as required standard for all C++ targets.
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF) # Don't use GNU extensions
 


### PR DESCRIPTION
motivation: libarrow migrated to c++17 [about a year ago](https://github.com/apache/arrow/commit/9d6598108c4fd93be89f8f5becaa7cb66f929fe7)

xref: #537

cc: @gspowley @awenocur @Shelnutt2 @ihnorton 