### PR TITLE
Sort reads during sample delete

### DIFF
--- a/ci/azure-linux_mac.yml
+++ b/ci/azure-linux_mac.yml
@@ -143,29 +143,23 @@ steps:
       set -ex pipefail
 
       if [[ "$BUILD_PYTHON_API" == "ON" ]]; then
-        # Add conda to PATH
-        echo "##vso[task.prependpath]$CONDA/bin"
-
+        # Install micromamba
         if [[ "$AGENT_OS" == "Darwin" ]]; then
-          # On Hosted macOS, the agent user doesn't have ownership of Miniconda's installation directory/
-          # We need to take ownership if we want to update conda or install packages globally
-          sudo chown -R $USER $CONDA
-        fi
-
-        if [[ "$AGENT_OS" == "Darwin" ]]; then
-           conda install -y libarchive=3.6.2=h6d8d9f1_0 -n base -c conda-forge
+          brew install micromamba
+          export PATH=$HOME/.micromamba/bin:$PATH
         else
-           conda install -y libarchive -n base -c conda-forge
+          curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
+          export PATH=$PWD/bin:$PATH
         fi
+        eval "$(micromamba shell hook --shell bash)"
+        micromamba --version
+        
+        # Create and activate the conda environment
+        pushd apis/python
+        micromamba create -f conda-env.yml -y
+        micromamba activate tiledbvcf-py
 
-        # Install mamba for faster environment creation
-        conda install -y mamba -n base -c conda-forge
-
-        pushd $BUILD_REPOSITORY_LOCALPATH/apis/python
-        $CONDA/bin/mamba env create --file conda-env.yml
-        # Note that 'conda init' doesn't seem to work directly.
-        source $CONDA/etc/profile.d/conda.sh
-        conda activate tiledbvcf-py
+        # Install and test the Python API
         python setup.py install --user
         python setup.py pytest
       fi

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -948,6 +948,7 @@ void Reader::init_exporter() {
               new TSVExporter(params_.output_path, params_.tsv_fields));
           break;
         case ExportFormat::Delete:
+          params_.sort_real_start_pos = true;
           exporter_.reset(new DeleteExporter(ctx_, params_.uri));
           break;
         default:


### PR DESCRIPTION
When deleting a sample, the records need to be read in sorted order so the stats arrays can be updated without violating the global order.
