### PR TITLE
Allow calls with missing genotypes to pass the IAF filter

### DIFF
--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -1285,6 +1285,7 @@ bool Reader::process_query_results_v4() {
 
       // If all GT are missing, then pass the record, otherwise check
       // if any of the alleles in GT pass the AF filter.
+      // Note: GT == -1 represents a missing value (from htslib).
       bool pass = true;
       for (unsigned int i = 0; i < gt.size(); i++) {
         pass = pass && gt[i] == -1;

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -1283,8 +1283,12 @@ bool Reader::process_query_results_v4() {
 
       auto gt = results.buffers()->gt(i);
 
-      // Check if any of the alleles in GT pass the AF filter
-      bool pass = false;
+      // If all GT are missing, then pass the record, otherwise check
+      // if any of the alleles in GT pass the AF filter.
+      bool pass = true;
+      for (unsigned int i = 0; i < gt.size(); i++) {
+        pass = pass && gt[i] == -1;
+      }
 
       read_state_.query_results.af_values.clear();
       int allele_index = 0;

--- a/libtiledbvcf/test/inputs/gvcf-export/s0.vcf
+++ b/libtiledbvcf/test/inputs/gvcf-export/s0.vcf
@@ -1,0 +1,7 @@
+##fileformat=VCFv4.4
+##FILTER=<ID=PASS,Description="All filters passed">
+##INFO=<ID=END,Number=1,Type=Integer,Description="End">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##contig=<ID=chr1>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	s0
+chr1	100	.	A	<NON_REF>	100.0	.	END=200	GT	./.

--- a/libtiledbvcf/test/inputs/gvcf-export/s1.vcf
+++ b/libtiledbvcf/test/inputs/gvcf-export/s1.vcf
@@ -1,0 +1,7 @@
+##fileformat=VCFv4.4
+##FILTER=<ID=PASS,Description="All filters passed">
+##INFO=<ID=END,Number=1,Type=Integer,Description="End">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##contig=<ID=chr1>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	s1
+chr1	100	.	A	<NON_REF>	200.0	.	END=200	GT	0/0

--- a/libtiledbvcf/test/inputs/gvcf-export/s2.vcf
+++ b/libtiledbvcf/test/inputs/gvcf-export/s2.vcf
@@ -1,0 +1,7 @@
+##fileformat=VCFv4.4
+##FILTER=<ID=PASS,Description="All filters passed">
+##INFO=<ID=END,Number=1,Type=Integer,Description="End">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##contig=<ID=chr1>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	s2
+chr1	100	.	A	T	300.0	.	END=100	GT	1/1

--- a/libtiledbvcf/test/inputs/gvcf-export/s3.vcf
+++ b/libtiledbvcf/test/inputs/gvcf-export/s3.vcf
@@ -1,0 +1,7 @@
+##fileformat=VCFv4.4
+##FILTER=<ID=PASS,Description="All filters passed">
+##INFO=<ID=END,Number=1,Type=Integer,Description="End">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##contig=<ID=chr1>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	s3
+chr1	149	.	TC	T	400.0	.	END=150	GT	0/1

--- a/libtiledbvcf/test/inputs/gvcf-export/s4.vcf
+++ b/libtiledbvcf/test/inputs/gvcf-export/s4.vcf
@@ -1,0 +1,7 @@
+##fileformat=VCFv4.4
+##FILTER=<ID=PASS,Description="All filters passed">
+##INFO=<ID=END,Number=1,Type=Integer,Description="End">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##contig=<ID=chr1>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	s4
+chr1	150	.	C	G	500.0	.	END=150	GT	1/1


### PR DESCRIPTION
This fixes an issue where a variant with all GT values missing (for example, a gVCF block) would not pass the IAF filter.