### PR TITLE
Handle '=' in tiledb config values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,11 +58,15 @@ docs:
 check-format:
 	@./ci/run-clang-format.sh . clang-format 0 \
 		`find libtiledbvcf/src -name "*.cc" -or -name "*.h"`
+	@./ci/run-clang-format.sh . clang-format 0 \
+		`find libtiledbvcf/test -name "*.cc" -or -name "*.h"`
 
 .PHONY: format
 format:
 	 @./ci/run-clang-format.sh . clang-format 1 \
 		`find libtiledbvcf/src -name "*.cc" -or -name "*.h"`
+	 @./ci/run-clang-format.sh . clang-format 1 \
+		`find libtiledbvcf/test -name "*.cc" -or -name "*.h"`
 
 # clean
 # -------------------------------------------------------------------

--- a/libtiledbvcf/src/utils/utils.cc
+++ b/libtiledbvcf/src/utils/utils.cc
@@ -299,14 +299,16 @@ void set_tiledb_config_map(
     const std::vector<std::string>& params,
     std::unordered_map<std::string, std::string>* cfg) {
   for (const auto& s : params) {
-    auto kv = utils::split(s, '=');
-    if (kv.size() != 2)
+    auto pos = s.find('=');
+    if (pos == std::string::npos) {
       throw std::runtime_error(
           "Error setting TileDB config parameter; bad value '" + s + "'");
-
-    utils::trim(&kv[0]);
-    utils::trim(&kv[1]);
-    cfg->emplace(kv[0], kv[1]);
+    }
+    auto key = s.substr(0, pos);
+    auto value = s.substr(pos + 1);
+    utils::trim(&key);
+    utils::trim(&value);
+    cfg->emplace(key, value);
   }
 }
 
@@ -319,13 +321,16 @@ void set_tiledb_config(
     const std::vector<std::string>& params, tiledb_config_t* cfg) {
   tiledb_error_t* err;
   for (const auto& s : params) {
-    auto kv = utils::split(s, '=');
-    if (kv.size() != 2)
+    auto pos = s.find('=');
+    if (pos == std::string::npos) {
       throw std::runtime_error(
           "Error setting TileDB config parameter; bad value '" + s + "'");
-    utils::trim(&kv[0]);
-    utils::trim(&kv[1]);
-    tiledb_config_set(cfg, kv[0].c_str(), kv[1].c_str(), &err);
+    }
+    auto key = s.substr(0, pos);
+    auto value = s.substr(pos + 1);
+    utils::trim(&key);
+    utils::trim(&value);
+    tiledb_config_set(cfg, key.c_str(), value.c_str(), &err);
     tiledb::impl::check_config_error(err);
   }
 }

--- a/libtiledbvcf/test/run-cli-tests.sh
+++ b/libtiledbvcf/test/run-cli-tests.sh
@@ -499,6 +499,10 @@ $tilevcf utils vacuum commits -u ${uri} --log-level trace
 $tilevcf utils vacuum fragment_meta -u ${uri} --log-level trace
 $tilevcf utils vacuum fragments -u ${uri} --log-level trace
 
+# test tiledb-config parsing
+# -------------------------------------------------------------------
+$tilevcf create -u tmp --tiledb-config vfs.azure.storage_sas_token=?sv=123456789== || exit 1
+
 # Expected failures
 echo ""
 echo "** Expected failure error messages follow:"

--- a/libtiledbvcf/test/src/unit-c-api-reader.cc
+++ b/libtiledbvcf/test/src/unit-c-api-reader.cc
@@ -92,7 +92,7 @@ static std::string INPUT_ARRAYS_DIR_V2 =
 
 #define SET_BUFF_SAMPLE_NAME(r, nr)                     \
   std::vector<int32_t> sample_name_offsets((nr) + 1);   \
-  std::vector<char> sample_name((nr)*10);               \
+  std::vector<char> sample_name((nr) * 10);             \
   REQUIRE(                                              \
       tiledb_vcf_reader_set_buffer_values(              \
           (reader),                                     \
@@ -108,7 +108,7 @@ static std::string INPUT_ARRAYS_DIR_V2 =
 
 #define SET_BUFF_CONTIG(r, nr)                                                \
   std::vector<int32_t> contig_offsets((nr) + 1);                              \
-  std::vector<char> contig((nr)*10);                                          \
+  std::vector<char> contig((nr) * 10);                                        \
   REQUIRE(                                                                    \
       tiledb_vcf_reader_set_buffer_values(                                    \
           (reader), "contig", sizeof(char) * contig.size(), contig.data()) == \
@@ -123,7 +123,7 @@ static std::string INPUT_ARRAYS_DIR_V2 =
 #define SET_BUFF_ALLELES(r, nr)                          \
   std::vector<int32_t> alleles_offsets(2 * (nr) + 1);    \
   std::vector<int32_t> alleles_list_offsets((nr) + 1);   \
-  std::vector<char> alleles((nr)*20);                    \
+  std::vector<char> alleles((nr) * 20);                  \
   REQUIRE(                                               \
       tiledb_vcf_reader_set_buffer_values(               \
           (reader),                                      \
@@ -147,7 +147,7 @@ static std::string INPUT_ARRAYS_DIR_V2 =
   std::vector<int32_t> filters_offsets(2 * (nr) + 1);     \
   std::vector<int32_t> filters_list_offsets((nr) + 1);    \
   std::vector<uint8_t> filters_bitmap((nr) / 8 + 1);      \
-  std::vector<char> filters((nr)*20);                     \
+  std::vector<char> filters((nr) * 20);                   \
   REQUIRE(                                                \
       tiledb_vcf_reader_set_buffer_values(                \
           (reader),                                       \
@@ -175,7 +175,7 @@ static std::string INPUT_ARRAYS_DIR_V2 =
 
 #define SET_BUFF_INFO(r, nr)                                            \
   std::vector<int32_t> info_offsets((nr) + 1);                          \
-  std::vector<char> info((nr)*100);                                     \
+  std::vector<char> info((nr) * 100);                                   \
   REQUIRE(                                                              \
       tiledb_vcf_reader_set_buffer_values(                              \
           (reader), "info", sizeof(char) * info.size(), info.data()) == \
@@ -189,7 +189,7 @@ static std::string INPUT_ARRAYS_DIR_V2 =
 
 #define SET_BUFF_FORMAT(r, nr)                                             \
   std::vector<int32_t> format_offsets((nr) + 1);                           \
-  std::vector<char> format((nr)*100);                                      \
+  std::vector<char> format((nr) * 100);                                    \
   REQUIRE(                                                                 \
       tiledb_vcf_reader_set_buffer_values(                                 \
           (reader), "fmt", sizeof(char) * format.size(), format.data()) == \
@@ -203,7 +203,7 @@ static std::string INPUT_ARRAYS_DIR_V2 =
 
 #define SET_BUFF_FMT_GT(r, nr)                                               \
   std::vector<int32_t> fmt_GT_offsets((nr) + 1);                             \
-  std::vector<int> fmt_GT((nr)*2);                                           \
+  std::vector<int> fmt_GT((nr) * 2);                                         \
   REQUIRE(                                                                   \
       tiledb_vcf_reader_set_buffer_values(                                   \
           (reader), "fmt_GT", sizeof(int) * fmt_GT.size(), fmt_GT.data()) == \
@@ -422,7 +422,8 @@ TEST_CASE("C API: Reader set config", "[capi][query]") {
 
   SECTION("- Valid options") {
     const char* config =
-        "sm.compute_concurrency_level=4, vfs.s3.proxy_host=abc.def.ghi";
+        "sm.compute_concurrency_level=4, vfs.s3.proxy_host=abc.def.ghi, "
+        "vfs.azure.storage_sas_token=?sv=123456789==";
     REQUIRE(
         tiledb_vcf_reader_set_tiledb_config(reader, config) == TILEDB_VCF_OK);
   }

--- a/libtiledbvcf/test/src/unit-c-api-reader.cc
+++ b/libtiledbvcf/test/src/unit-c-api-reader.cc
@@ -92,7 +92,7 @@ static std::string INPUT_ARRAYS_DIR_V2 =
 
 #define SET_BUFF_SAMPLE_NAME(r, nr)                     \
   std::vector<int32_t> sample_name_offsets((nr) + 1);   \
-  std::vector<char> sample_name((nr) * 10);             \
+  std::vector<char> sample_name((nr)*10);               \
   REQUIRE(                                              \
       tiledb_vcf_reader_set_buffer_values(              \
           (reader),                                     \
@@ -108,7 +108,7 @@ static std::string INPUT_ARRAYS_DIR_V2 =
 
 #define SET_BUFF_CONTIG(r, nr)                                                \
   std::vector<int32_t> contig_offsets((nr) + 1);                              \
-  std::vector<char> contig((nr) * 10);                                        \
+  std::vector<char> contig((nr)*10);                                          \
   REQUIRE(                                                                    \
       tiledb_vcf_reader_set_buffer_values(                                    \
           (reader), "contig", sizeof(char) * contig.size(), contig.data()) == \
@@ -123,7 +123,7 @@ static std::string INPUT_ARRAYS_DIR_V2 =
 #define SET_BUFF_ALLELES(r, nr)                          \
   std::vector<int32_t> alleles_offsets(2 * (nr) + 1);    \
   std::vector<int32_t> alleles_list_offsets((nr) + 1);   \
-  std::vector<char> alleles((nr) * 20);                  \
+  std::vector<char> alleles((nr)*20);                    \
   REQUIRE(                                               \
       tiledb_vcf_reader_set_buffer_values(               \
           (reader),                                      \
@@ -147,7 +147,7 @@ static std::string INPUT_ARRAYS_DIR_V2 =
   std::vector<int32_t> filters_offsets(2 * (nr) + 1);     \
   std::vector<int32_t> filters_list_offsets((nr) + 1);    \
   std::vector<uint8_t> filters_bitmap((nr) / 8 + 1);      \
-  std::vector<char> filters((nr) * 20);                   \
+  std::vector<char> filters((nr)*20);                     \
   REQUIRE(                                                \
       tiledb_vcf_reader_set_buffer_values(                \
           (reader),                                       \
@@ -175,7 +175,7 @@ static std::string INPUT_ARRAYS_DIR_V2 =
 
 #define SET_BUFF_INFO(r, nr)                                            \
   std::vector<int32_t> info_offsets((nr) + 1);                          \
-  std::vector<char> info((nr) * 100);                                   \
+  std::vector<char> info((nr)*100);                                     \
   REQUIRE(                                                              \
       tiledb_vcf_reader_set_buffer_values(                              \
           (reader), "info", sizeof(char) * info.size(), info.data()) == \
@@ -189,7 +189,7 @@ static std::string INPUT_ARRAYS_DIR_V2 =
 
 #define SET_BUFF_FORMAT(r, nr)                                             \
   std::vector<int32_t> format_offsets((nr) + 1);                           \
-  std::vector<char> format((nr) * 100);                                    \
+  std::vector<char> format((nr)*100);                                      \
   REQUIRE(                                                                 \
       tiledb_vcf_reader_set_buffer_values(                                 \
           (reader), "fmt", sizeof(char) * format.size(), format.data()) == \
@@ -203,7 +203,7 @@ static std::string INPUT_ARRAYS_DIR_V2 =
 
 #define SET_BUFF_FMT_GT(r, nr)                                               \
   std::vector<int32_t> fmt_GT_offsets((nr) + 1);                             \
-  std::vector<int> fmt_GT((nr) * 2);                                         \
+  std::vector<int> fmt_GT((nr)*2);                                           \
   REQUIRE(                                                                   \
       tiledb_vcf_reader_set_buffer_values(                                   \
           (reader), "fmt_GT", sizeof(int) * fmt_GT.size(), fmt_GT.data()) == \


### PR DESCRIPTION
Fix an issue parsing '=' in tiledb config values, as described in #603.