### PR TITLE
Load VCF headers when required for in-memory exports

### DIFF
--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -786,16 +786,11 @@ bool Reader::next_read_batch_v4() {
     // Fetch new headers for new sample batch
     if (read_state_.need_headers) {
       read_state_.current_hdrs.clear();
-      if (params_.export_to_disk) {
-        read_state_.current_hdrs = dataset_->fetch_vcf_headers_v4(
-            read_state_.current_sample_batches,
-            &read_state_.current_hdrs_lookup,
-            read_state_.all_samples,
-            false);
-      } else {
-        read_state_.current_hdrs = dataset_->fetch_vcf_headers_v4(
-            {}, &read_state_.current_hdrs_lookup, false, true);
-      }
+      read_state_.current_hdrs = dataset_->fetch_vcf_headers_v4(
+          read_state_.current_sample_batches,
+          &read_state_.current_hdrs_lookup,
+          read_state_.all_samples,
+          false);
       if (params_.export_combined_vcf) {
         static_cast<PVCFExporter*>(exporter_.get())
             ->init(read_state_.current_hdrs_lookup, read_state_.current_hdrs);


### PR DESCRIPTION
PR #479 stopped loading the VCF headers for all in-memory exports and relied on the "first" VCF header to decode FILTER, INFO, and FORMAT fields.

PR #479 works fine when all samples have the same VCF header. However, it causes an issue when samples have different FILTER lists because the filter_id (stored as an int) needs the original VCF header when decoding back to the FILTER string.

This PR reverts the change in #479.