### PR TITLE
Reduce memory usage and improve perf when reading VCF headers

### DIFF
--- a/libtiledbvcf/src/stats/column_buffer.h
+++ b/libtiledbvcf/src/stats/column_buffer.h
@@ -47,9 +47,9 @@ using namespace tiledb;
  *
  */
 class ColumnBuffer {
-  inline static const size_t DEFAULT_ALLOC_BYTES = 1 << 26;  // 64 MiB
+  inline static const size_t DEFAULT_ALLOC_BYTES = 1 << 27;  // 128 MiB
   inline static const std::string CONFIG_KEY_INIT_BYTES =
-      "soma.init_buffer_bytes";
+      "vcf.init_buffer_bytes";
 
  public:
   //===================================================================


### PR DESCRIPTION
Read VCF headers with the `ManagedQuery` API which:
1. Reduces memory usage by reserving buffer space using `std::vector<T>::reserve()` instead of allocating and populating user buffers. The `ManagedQuery` uses the actual amount of memory required, while the previous implementation used the entire estimated buffer size, which was pessimistic.
2. Improves performance by avoiding populating the estimated buffer size with empty data.

This PR also resolves an edge case where reading the first sample would fail if the first sample was previously deleted.