### PR TITLE
Import pyarrow-hotfix

### DIFF
--- a/apis/python/src/tiledbvcf/__init__.py
+++ b/apis/python/src/tiledbvcf/__init__.py
@@ -1,5 +1,6 @@
 # Initialize pyarrow first.
 import pyarrow
+import pyarrow_hotfix
 
 import ctypes
 import os

--- a/ci/gha-win-env.yml
+++ b/ci/gha-win-env.yml
@@ -14,6 +14,7 @@ dependencies:
   - numpy
   - pandas<2.0
   - pyarrow=9.0
+  - pyarrow-hotfix
   - pybind11
   - python
   - rpdb

--- a/ci/nightly/requirements.txt
+++ b/ci/nightly/requirements.txt
@@ -1,6 +1,7 @@
 numpy
 pandas
 pyarrow==11
+pyarrow-hotfix
 pybind11
 setuptools
 setuptools_scm

--- a/docker/Dockerfile-py
+++ b/docker/Dockerfile-py
@@ -34,6 +34,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
 RUN pip install --no-cache-dir \
     pandas \
     pyarrow \
+    pyarrow-hotfix \
     setuptools_scm \
     tiledb
 


### PR DESCRIPTION
Until we can install `pyarrow >=14.0.2` in the cloud conda environments, we should ensure that pyarrow-hotfix is installed and imported. From its [PyPI](https://pypi.org/project/pyarrow-hotfix/) Usage section:

> `pyarrow_hotfix` must be imported in your application or library code for it to take effect

xref: https://github.com/TileDB-Inc/tiledb-vcf-feedstock/pull/115

Also, I noticed that pyarrow isn't included in `setup_requires`

https://github.com/TileDB-Inc/TileDB-VCF/blob/b3df71ea2796c878c3c8c34e3a393accc5cc6ea2/apis/python/setup.py#L284-L292

Which seems unlikely to be true given that pyarrow is imported in `setup.py`:

https://github.com/TileDB-Inc/TileDB-VCF/blob/b3df71ea2796c878c3c8c34e3a393accc5cc6ea2/apis/python/setup.py#L243

In general, is there a reason that `setup_requires`, `install_requires`, and `test_requires` aren't overly utilized in this repo? I expected to see at least pyarrow in `install_requires` and dask in `test_requires`.