### PR TITLE
Disable dask query-planning

### DIFF
--- a/apis/python/src/tiledbvcf/dask_functions.py
+++ b/apis/python/src/tiledbvcf/dask_functions.py
@@ -1,4 +1,6 @@
 import dask
+
+dask.config.set({"dataframe.query-planning": False})
 import dask.dataframe
 
 import pyarrow as pa

--- a/apis/python/tests/test_dask.py
+++ b/apis/python/tests/test_dask.py
@@ -5,6 +5,8 @@ import pytest
 import tiledbvcf
 
 import dask
+
+dask.config.set({"dataframe.query-planning": False})
 import dask.distributed
 
 # Directory containing this file

--- a/documentation/how-to/perform-distributed-queries-with-dask.md
+++ b/documentation/how-to/perform-distributed-queries-with-dask.md
@@ -10,6 +10,8 @@ You can use the `tiledbvcf` package's Dask integration to partition read operati
 import tiledbvcf
 import dask
 
+dask.config.set({'dataframe.query-planning': False})
+
 ds = tiledbvcf.Dataset('my-large-dataset', mode='r')
 dask_df = ds.read_dask(attrs=['sample_name', 'pos_start', 'pos_end'],
                        bed_file='very-large-bedfile.bed',


### PR DESCRIPTION
Closes #671 

[dask 2024.3.0](https://docs.dask.org/en/stable/changelog.html#v2024-3-0), released two days ago on 2024-03-11, changed the default behavior of `dask.dataframe` to require the package dask-expr, but didn't add dask-expr to its default dependencies  

So our options are 1) install dask-expr for all our CI jobs, or 2) disable query-planning. According to @awenocur, we are dropping support for dask in the next couple of months, so the choice doesn't matter much. I chose option 2 since it required fewer edits.

xref: first discovered in #669 (such bad timing on my part; opened that PR the day dask broke our CI), solution confirmed in #670

