### PR TITLE
Bump macOS nightly release branch to 2.20

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        libtiledb_version: [release-2.19, dev]
+        libtiledb_version: [release-2.20, dev]
     env:
       MACOSX_DEPLOYMENT_TARGET: 10.15
     steps:


### PR DESCRIPTION
Follow-up to #666