### PR TITLE
Create sample stats during ingestion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode*
 *.swp
+dev/*
 dist/*
 libtiledbvcf/cmake-build-*/*
 libtiledbvcf/build/*

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ update:
 # -------------------------------------------------------------------
 .PHONY: test
 test:
-	cd libtiledbvcf/build && make check
+	cd libtiledbvcf/build && make -j check
 	cd libtiledbvcf/test && ./run-cli-tests.sh ../build/ ./inputs/
 	cd apis/java && ./gradlew assemble test
 	cd apis/spark && ./gradlew assemble test

--- a/apis/java/src/main/java/io/tiledb/libvcfnative/NativeLibLoader.java
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/NativeLibLoader.java
@@ -95,7 +95,7 @@ public class NativeLibLoader {
   /** Finds and loads native HTSlib. */
   static void loadNativeHTSLib() {
     String os = getOSClassifier();
-    String versionedLibName = os.startsWith("osx") ? "libhts.1.15.1.dylib" : "libhts.so.1.15.1";
+    String versionedLibName = os.startsWith("osx") ? "libhts.1.19.1.dylib" : "libhts.so.1.19.1";
     try {
       // Don't use name mapping to get the versioned htslib
       loadNativeLib(versionedLibName, false);

--- a/libtiledbvcf/cmake/Modules/FindHTSlib.cmake
+++ b/libtiledbvcf/cmake/Modules/FindHTSlib.cmake
@@ -66,9 +66,9 @@ if (NOT HTSLIB_FOUND)
     message(STATUS "Adding HTSlib as an external project")
     # Use explicit soname to avoid having to use library symlinks (easier for embedding).
     if (APPLE)
-      set(EXTRA_LDFLAGS "-Wl,-install_name,@rpath/libhts.1.15.1.dylib")
+      set(EXTRA_LDFLAGS "-Wl,-install_name,@rpath/libhts.1.19.1.dylib")
     else()
-      set(EXTRA_LDFLAGS "-Wl,-soname,libhts.so.1.15.1")
+      set(EXTRA_LDFLAGS "-Wl,-soname,libhts.so.1.19.1")
     endif()
     SET(CFLAGS "")
     string( TOUPPER "${CMAKE_BUILD_TYPE}" BUILD_TYPE)
@@ -121,8 +121,8 @@ if (NOT HTSLIB_FOUND)
 
       ExternalProject_Add(ep_htslib
         PREFIX "externals"
-        URL "https://github.com/samtools/htslib/releases/download/1.15.1/htslib-1.15.1.tar.bz2"
-        URL_HASH SHA1=e7cbd4bb059020c9486facc028f750ec0fb2e182
+        URL "https://github.com/samtools/htslib/releases/download/1.19.1/htslib-1.19.1.tar.bz2"
+        URL_HASH SHA1=98b00846d09890f8566c7bf60859ea551fa45da6
         UPDATE_COMMAND ""
         CONFIGURE_COMMAND
             autoheader

--- a/libtiledbvcf/src/CMakeLists.txt
+++ b/libtiledbvcf/src/CMakeLists.txt
@@ -57,9 +57,11 @@ set(TILEDB_VCF_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/read/read_query_results.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/read/reader.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/read/tsv_exporter.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/stats/array_buffers.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/stats/allele_count.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/stats/column_buffer.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/stats/managed_query.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/stats/sample_stats.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/stats/variant_stats.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/stats/variant_stats_reader.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/utils/bitmap.cc

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -35,6 +35,7 @@
 #include "read/export_format.h"
 #include "read/reader.h"
 #include "stats/allele_count.h"
+#include "stats/sample_stats.h"
 #include "stats/variant_stats.h"
 #include "utils/logger_public.h"
 #include "utils/sample_utils.h"
@@ -260,6 +261,8 @@ void TileDBVCFDataset::create(const CreationParams& params) {
   if (params.enable_variant_stats) {
     VariantStats::create(ctx, params.uri, params.checksum);
   }
+
+  SampleStats::create(ctx, params.uri, params.checksum);
 
   write_metadata_v4(ctx, params.uri, metadata);
 

--- a/libtiledbvcf/src/stats/array_buffers.cc
+++ b/libtiledbvcf/src/stats/array_buffers.cc
@@ -1,0 +1,57 @@
+/**
+ * @file   array_buffers.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022-2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines the ArrayBuffers class.
+ */
+
+#include "array_buffers.h"
+#include "utils/logger.h"
+
+namespace tiledb::vcf {
+using namespace tiledb;
+
+std::shared_ptr<ColumnBuffer> ArrayBuffers::at(const std::string& name) {
+  if (!contains(name)) {
+    throw std::runtime_error(
+        fmt::format("[ArrayBuffers] column '{}' does not exist", name));
+  }
+  return buffers_[name];
+}
+
+void ArrayBuffers::emplace(
+    const std::string& name, std::shared_ptr<ColumnBuffer> buffer) {
+  if (contains(name)) {
+    throw std::runtime_error(
+        fmt::format("[ArrayBuffers] column '{}' already exists", name));
+  }
+  names_.push_back(name);
+  buffers_.emplace(name, buffer);
+}
+
+}  // namespace tiledb::vcf

--- a/libtiledbvcf/src/stats/array_buffers.h
+++ b/libtiledbvcf/src/stats/array_buffers.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -30,19 +30,14 @@
  *   This declares the array buffers API
  */
 
-#ifndef ARRAY_BUFFERS_H
-#define ARRAY_BUFFERS_H
+#ifndef TILEDB_ARRAY_BUFFERS_H
+#define TILEDB_ARRAY_BUFFERS_H
 
-#include <stdexcept>  // for windows: error C2039: 'runtime_error': is not a member of 'std'
-
-#include <span>
 #include <tiledb/tiledb>
 
 #include "column_buffer.h"
-#include "utils/logger_public.h"
 
 namespace tiledb::vcf {
-
 using namespace tiledb;
 
 class ArrayBuffers {
@@ -58,10 +53,15 @@ class ArrayBuffers {
    * @param name Column name
    * @return std::shared_ptr<ColumnBuffer> Column buffer
    */
-  std::shared_ptr<ColumnBuffer> at(const std::string& name) {
-    if (!contains(name)) {
-      LOG_FATAL(fmt::format("[ArrayBuffers] column '{}' does not exist", name));
-    }
+  std::shared_ptr<ColumnBuffer> at(const std::string& name);
+
+  /**
+   * @brief Return the buffer with the given name.
+   *
+   * @param name Column name
+   * @return std::shared_ptr<ColumnBuffer> Column buffer
+   */
+  std::shared_ptr<ColumnBuffer> operator[](const std::string& name) {
     return buffers_[name];
   }
 
@@ -82,13 +82,7 @@ class ArrayBuffers {
    * @param name Column name
    * @param buffer Column buffer
    */
-  void emplace(const std::string& name, std::shared_ptr<ColumnBuffer> buffer) {
-    if (contains(name)) {
-      LOG_FATAL(fmt::format("[ArrayBuffers] column '{}' already exists", name));
-    }
-    names_.push_back(name);
-    buffers_.emplace(name, buffer);
-  }
+  void emplace(const std::string& name, std::shared_ptr<ColumnBuffer> buffer);
 
   /**
    * @brief Returns the ordered vector of names.
@@ -118,4 +112,4 @@ class ArrayBuffers {
 
 }  // namespace tiledb::vcf
 
-#endif
+#endif  // TILEDB_ARRAY_BUFFERS_H

--- a/libtiledbvcf/src/stats/sample_stats.cc
+++ b/libtiledbvcf/src/stats/sample_stats.cc
@@ -1,0 +1,374 @@
+/**
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "sample_stats.h"
+#include "array_buffers.h"
+#include "managed_query.h"
+#include "utils/utils.h"
+
+namespace tiledb::vcf {
+
+std::string SampleStats::get_uri_(const Group& group) {
+  try {
+    auto member = group.member(SAMPLE_STATS_ARRAY);
+    return member.uri();
+  } catch (const tiledb::TileDBError& ex) {
+    return "";
+  }
+}
+
+std::string SampleStats::get_uri_(const std::string& root_uri, bool relative) {
+  auto root = relative ? "" : root_uri;
+  return utils::uri_join(root, SAMPLE_STATS_ARRAY);
+}
+
+void SampleStats::create(
+    Context& ctx, const std::string& root_uri, int compression_level) {
+  // Create filter lists
+  FilterList int_fl(ctx);
+  FilterList float_fl(ctx);
+  FilterList ascii_fl(ctx);
+  FilterList dict_fl(ctx);
+  FilterList rle_fl(ctx);
+
+  // Use tile level filtering
+  int_fl.set_max_chunk_size(0);
+  float_fl.set_max_chunk_size(0);
+  ascii_fl.set_max_chunk_size(0);
+  dict_fl.set_max_chunk_size(0);
+  rle_fl.set_max_chunk_size(0);
+
+  // Create checksum and compression filters
+  Filter checksum(ctx, TILEDB_FILTER_CHECKSUM_SHA256);
+  Filter compression(ctx, TILEDB_FILTER_ZSTD);
+  compression.set_option(TILEDB_COMPRESSION_LEVEL, compression_level);
+
+  int_fl.add_filter({ctx, TILEDB_FILTER_DOUBLE_DELTA})
+      .add_filter({ctx, TILEDB_FILTER_BIT_WIDTH_REDUCTION})
+      .add_filter(compression)
+      .add_filter(checksum);
+  float_fl.add_filter(compression).add_filter(checksum);
+  ascii_fl.add_filter(compression).add_filter(checksum);
+  dict_fl.add_filter({ctx, TILEDB_FILTER_DICTIONARY})
+      .add_filter(compression)
+      .add_filter(checksum);
+  rle_fl.add_filter({ctx, TILEDB_FILTER_RLE})
+      .add_filter(compression)
+      .add_filter(checksum);
+
+  // Create schema
+  ArraySchema schema(ctx, TILEDB_SPARSE);
+  schema.set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
+  schema.set_allows_dups(true);
+  schema.set_offsets_filter_list(int_fl);
+
+  // Create dimensions
+  Domain domain(ctx);
+
+  auto d0 =
+      Dimension::create(ctx, "sample", TILEDB_STRING_ASCII, nullptr, nullptr);
+  d0.set_filter_list(dict_fl);
+
+  domain.add_dimensions(d0);
+  schema.set_domain(domain);
+
+  // Create attributes
+  auto add_attribute = [&schema](
+                           const std::string& name,
+                           tiledb_datatype_t type,
+                           FilterList& filter_list,
+                           bool is_var = false,
+                           bool is_nullable = false) {
+    auto attr = Attribute::create(schema.context(), name, type);
+    attr.set_cell_val_num(is_var ? TILEDB_VAR_NUM : 1);
+    attr.set_nullable(is_nullable);
+    attr.set_filter_list(filter_list);
+    schema.add_attribute(attr);
+  };
+
+  add_attribute("contig", TILEDB_STRING_ASCII, dict_fl, true);
+
+  std::vector<std::string> columns = {
+      "dp_sum",      "dp_sum2",  "dp_count",     "dp_min",    "dp_max",
+      "gq_sum",      "gq_sum2",  "gq_count",     "gq_min",    "gq_max",
+      "n_records",   "n_called", "n_not_called", "n_hom_ref", "n_het",
+      "n_singleton", "n_snp",    "n_indel",      "n_ins",     "n_del",
+      "n_ti",        "n_tv",     "n_overlap",    "n_multi"};
+
+  for (const auto& name : columns) {
+    if (name.starts_with("dp_") || name.starts_with("gq_")) {
+      // Add nullable attributes for DP and GQ fields, since they may be missing
+      add_attribute(name, TILEDB_UINT64, int_fl, false, true);
+    } else {
+      add_attribute(name, TILEDB_UINT64, int_fl);
+    }
+  }
+
+  // Check schema
+  try {
+    schema.check();
+  } catch (const tiledb::TileDBError& e) {
+    throw std::runtime_error(e.what());
+  }
+
+  // Create array
+  LOG_DEBUG("[SampleStats] create array");
+  auto uri = get_uri_(root_uri);
+  tiledb::Array::create(uri, schema);
+
+  // Add array to root group
+  // Group assets use full paths for tiledb cloud, relative paths otherwise
+  auto relative = !utils::starts_with(root_uri, "tiledb://");
+  auto array_uri = get_uri_(root_uri, relative);
+  LOG_DEBUG("Adding array '{}' to group '{}'", array_uri, root_uri);
+  Group root_group(ctx, root_uri, TILEDB_WRITE);
+  root_group.add_member(array_uri, relative, SAMPLE_STATS_ARRAY);
+}
+
+void SampleStats::init(std::shared_ptr<Context> ctx, const Group& group) {
+  auto uri = get_uri_(group);
+
+  if (uri.empty()) {
+    LOG_DEBUG("[SampleStats] Ingestion task disabled");
+    enabled_ = false;
+    return;
+  }
+
+  LOG_DEBUG("[SampleStats] Open array '{}'", uri);
+
+  // Open array
+  array_ = std::make_shared<Array>(*ctx, uri, TILEDB_WRITE);
+  enabled_ = true;
+}
+
+void SampleStats::process(
+    const bcf_hdr_t* hdr,
+    const std::string& sample,
+    const std::string& contig,
+    uint32_t pos,
+    bcf1_t* rec) {
+  if (contig_ != contig) {
+    contig_ = contig;
+  }
+
+  if (bcf_get_format_int32(hdr, rec, "DP", &dst_, &ndst_) > 0) {
+    auto dp = static_cast<uint64_t>(dst_[0]);
+    stats_[sample]["dp_sum"] += dp;
+    stats_[sample]["dp_sum2"] += dp * dp;
+    stats_[sample]["dp_count"] += 1;
+    if (!stats_[sample].contains("dp_min")) {
+      stats_[sample]["dp_min"] = std::numeric_limits<uint64_t>::max();
+    }
+    stats_[sample]["dp_min"] = std::min(stats_[sample]["dp_min"], dp);
+    stats_[sample]["dp_max"] = std::max(stats_[sample]["dp_max"], dp);
+  }
+
+  if (bcf_get_format_int32(hdr, rec, "GQ", &dst_, &ndst_) > 0) {
+    auto gq = static_cast<uint64_t>(dst_[0]);
+    stats_[sample]["gq_sum"] += gq;
+    stats_[sample]["gq_sum2"] += gq * gq;
+    stats_[sample]["gq_count"] += 1;
+    if (!stats_[sample].contains("gq_min")) {
+      stats_[sample]["gq_min"] = std::numeric_limits<uint64_t>::max();
+    }
+    stats_[sample]["gq_min"] = std::min(stats_[sample]["gq_min"], gq);
+    stats_[sample]["gq_max"] = std::max(stats_[sample]["gq_max"], gq);
+  }
+
+  auto is_transition = [](char a, char b) {
+    return (a == 'A' && b == 'G') || (a == 'G' && b == 'A') ||
+           (a == 'C' && b == 'T') || (a == 'T' && b == 'C');
+  };
+
+  // Compute stats based on the genotypes
+  bool is_ref = true;
+  bool is_hom = true;
+  bool is_missing = true;
+  std::unordered_map<int, int> ac;
+
+  int ngt = bcf_get_genotypes(hdr, rec, &dst_, &ndst_);
+  if (ngt > 0) {
+    int first_allele = bcf_gt_allele(dst_[0]);
+
+    for (int i = 0; i < ngt; i++) {
+      int allele = bcf_gt_allele(dst_[i]);
+      is_ref &= allele == 0;
+      is_hom &= allele == first_allele;
+      is_missing &= bcf_gt_is_missing(dst_[i]);
+      ac[allele] += allele > 0;
+    }
+  }
+
+  bool is_hom_ref = !is_missing && is_hom && is_ref;
+  bool is_het = !is_missing && !is_hom;
+  bool is_multi = rec->n_allele > 2;
+
+  // Count singletons, multi-allelic records can have multiple singletons
+  int n_singleton = 0;
+  for (const auto& [allele, count] : ac) {
+    n_singleton += count == 1;
+  }
+
+  // Get types of variants in the record
+  auto var_types = bcf_has_variant_types(
+      rec,
+      VCF_SNP | VCF_INDEL | VCF_INS | VCF_DEL | VCF_OVERLAP,
+      bcf_match_subset);
+
+  // Compute stats based on the alleles
+  int n_snp = 0;
+  int n_ti = 0;
+  int n_tv = 0;
+
+  if (var_types & VCF_SNP) {
+    n_snp++;
+
+    // Count tis and tvs for each SNP, possibly multi-allelic
+    for (int i = 1; i < rec->n_allele; i++) {
+      if (bcf_get_variant_type(rec, i) & VCF_SNP) {
+        bool is_ti = is_transition(rec->d.allele[0][0], rec->d.allele[i][0]);
+        n_ti += is_ti;
+        n_tv += !is_ti;
+      }
+    }
+  }
+
+  // For multi-allelic records, n_ins + n_del can be > n_indel
+  int n_indel = (var_types & VCF_INDEL) > 0;
+  int n_ins = (var_types & VCF_INS) > 0;
+  int n_del = (var_types & VCF_DEL) > 0;
+  int n_overlap = (var_types & VCF_OVERLAP) > 0;
+
+  stats_[sample]["n_records"] += 1;
+  stats_[sample]["n_called"] += !is_missing;
+  stats_[sample]["n_not_called"] += is_missing;
+  stats_[sample]["n_hom_ref"] += is_hom_ref;
+  stats_[sample]["n_het"] += is_het;
+  stats_[sample]["n_singleton"] += n_singleton;
+  stats_[sample]["n_snp"] += n_snp;
+  stats_[sample]["n_ti"] += n_ti;
+  stats_[sample]["n_tv"] += n_tv;
+  stats_[sample]["n_indel"] += n_indel;
+  stats_[sample]["n_ins"] += n_ins;
+  stats_[sample]["n_del"] += n_del;
+  stats_[sample]["n_overlap"] += n_overlap;
+  stats_[sample]["n_multi"] += is_multi;
+}
+
+void SampleStats::flush(bool finalize) {
+  if (!enabled_ || !finalize) {
+    return;
+  }
+
+  if (stats_.empty()) {
+    LOG_DEBUG("[SampleStats] No stats to flush");
+    return;
+  }
+
+  LOG_DEBUG("[SampleStats] Finalize stats '{}'", contig_);
+
+  ArrayBuffers buffers;
+
+  auto add_buffer_ = [&](const std::string& name) {
+    buffers.emplace(name, ColumnBuffer::create(array_, name));
+  };
+
+  // Add buffers for all dimensions
+  auto schema = array_->schema();
+  for (const auto& dim : schema.domain().dimensions()) {
+    add_buffer_(dim.name());
+  }
+
+  // Add buffers for all attributes
+  for (const auto& [name, attr] : schema.attributes()) {
+    add_buffer_(name);
+  }
+
+  bool found_dp = false;
+  bool found_gq = false;
+
+  for (const auto& [sample, stat] : stats_) {
+    buffers["sample"]->push_back(sample);
+    buffers["contig"]->push_back(contig_);
+
+    // Add stats to buffers
+    for (const auto& [field, value] : stat) {
+      buffers[field]->push_back(value);
+      found_dp |= field == "dp_sum";
+      found_gq |= field == "gq_sum";
+    }
+
+    // Add nulls for missing DP fields
+    if (!found_dp) {
+      buffers["dp_sum"]->push_null();
+      buffers["dp_sum2"]->push_null();
+      buffers["dp_count"]->push_null();
+      buffers["dp_min"]->push_null();
+      buffers["dp_max"]->push_null();
+    }
+
+    // Add nulls for missing GQ fields
+    if (!found_gq) {
+      buffers["gq_sum"]->push_null();
+      buffers["gq_sum2"]->push_null();
+      buffers["gq_count"]->push_null();
+      buffers["gq_min"]->push_null();
+      buffers["gq_max"]->push_null();
+    }
+  }
+
+  // Create managed query
+  ManagedQuery mq(array_, "sample_stats");
+
+  // Attach buffers to the query
+  for (const auto& name : buffers.names()) {
+    mq.set_column_data(name, buffers[name]);
+  }
+
+  // Submit the write query and finalize
+  mq.submit_write();
+  mq.finalize();
+
+  // Clear the stats
+  stats_.clear();
+}
+
+void SampleStats::close() {
+  if (!enabled_) {
+    return;
+  }
+
+  LOG_DEBUG("[SampleStats] Close array");
+
+  if (array_ != nullptr) {
+    array_->close();
+    array_ = nullptr;
+  }
+
+  enabled_ = false;
+}
+
+}  // namespace tiledb::vcf

--- a/libtiledbvcf/src/stats/sample_stats.h
+++ b/libtiledbvcf/src/stats/sample_stats.h
@@ -1,0 +1,156 @@
+/**
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TILEDB_VCF_SAMPLE_STATS_H
+#define TILEDB_VCF_SAMPLE_STATS_H
+
+#include <map>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <htslib/vcf.h>
+#include <tiledb/tiledb>
+#include <tiledb/tiledb_experimental>
+
+namespace tiledb::vcf {
+
+/**
+ * @brief The SampleStats class stores per-sample statistics in a TileDB array.
+ *
+ * The sample stats are similar to the stats calculated by `bcftools stats` and
+ * Hail's sample_qc.
+ *
+ * For TileDB-VCF v4, each writer worker calculates sample stats for the records
+ * it processes and stores the results in a fragment of the TileDB array. The
+ * stats can be queried and aggregated across all fragments to get the sample
+ * stats.
+ */
+class SampleStats {
+ public:
+  /**
+   * @brief Create a new sample stats array.
+   *
+   * @param ctx TileDB context
+   * @param root_uri URI of TileDB-VCF dataset
+   * @param compression_level zstd compression level
+   */
+  static void create(
+      Context& ctx, const std::string& root_uri, int compression_level = 9);
+
+  /**
+   * @brief Initialize the sample stats array. Disable the sample stats
+   * processing if the array does not exist.
+   *
+   * @param ctx TileDB context
+   * @param group TileDB-VCF group
+   */
+  static void init(std::shared_ptr<Context> ctx, const Group& group);
+
+  /**
+   * @brief Close the sample stats array.
+   */
+  static void close();
+
+  // Constructor
+  SampleStats() = default;
+
+  // Destructor
+  ~SampleStats() {
+    // Flush any remaining stats
+    flush(true);
+
+    if (dst_ != nullptr) {
+      hts_free(dst_);
+    }
+  }
+
+  // Copy and move constructors/assignments
+  SampleStats(const SampleStats&) = delete;
+  SampleStats& operator=(const SampleStats&) = delete;
+  SampleStats(SampleStats&&) = delete;
+  SampleStats& operator=(SampleStats&&) = delete;
+
+  /**
+   * @brief Add a record to the sample stats.
+   *
+   * @param hdr VCF header for the record
+   * @param sample VCF sample name
+   * @param contig Contig part of the record's locus
+   * @param pos Position part of the record's locus
+   * @param record VCF record
+   */
+  void process(
+      const bcf_hdr_t* hdr,
+      const std::string& sample,
+      const std::string& contig,
+      uint32_t pos,
+      bcf1_t* rec);
+
+  /**
+   * @brief Write buffered stats to the TileDB array and reset the buffers.
+   *
+   * If finalize is true, the query buffers are cleared and the query is
+   * finalized. Finalize should be called after all records have been
+   * processed for a contig or merged contig.
+   *
+   * @param finalize If true, finalize the query.
+   */
+  void flush(bool finalize = false);
+
+ private:
+  // Array URI basename
+  inline static const std::string SAMPLE_STATS_ARRAY = "sample_stats";
+
+  // TileDB array pointer
+  inline static std::shared_ptr<Array> array_ = nullptr;
+
+  // Enable flag, disabled when the array does not exist
+  inline static bool enabled_ = false;
+
+  // Reusable htslib buffer for bcf_get_* functions
+  int* dst_ = nullptr;
+
+  // Reusable htslib buffer size for bcf_get_* functions
+  int ndst_ = 0;
+
+  // Current contig
+  std::string contig_;
+
+  // Aggregate stats for each sample. map: sample -> (map: field -> count)
+  std::map<std::string, std::unordered_map<std::string, uint64_t>> stats_;
+
+  // Get the URI for the array from the root group
+  static std::string get_uri_(const Group& group);
+
+  // Get the URI for the array from the root URI
+  static std::string get_uri_(
+      const std::string& root_uri, bool relative = false);
+};
+
+}  // namespace tiledb::vcf
+
+#endif  // TILEDB_VCF_SAMPLE_STATS_H

--- a/libtiledbvcf/src/stats/variant_stats.cc
+++ b/libtiledbvcf/src/stats/variant_stats.cc
@@ -45,7 +45,7 @@ std::string VariantStats::get_uri(const Group& group) {
 
 void VariantStats::create(
     Context& ctx, const std::string& root_uri, tiledb_filter_type_t checksum) {
-  LOG_DEBUG("VariantStats: Create array");
+  LOG_DEBUG("[VariantStats] Create array");
 
   // Create filter lists
   FilterList rle_coord_filters(ctx);
@@ -131,13 +131,13 @@ void VariantStats::init(std::shared_ptr<Context> ctx, const Group& group) {
   auto uri = get_uri(group);
 
   if (uri.empty()) {
-    LOG_DEBUG("VariantStats: Ingestion task disabled");
+    LOG_DEBUG("[VariantStats] Ingestion task disabled");
     enabled_ = false;
     return;
   }
 
   std::lock_guard<std::mutex> lock(query_lock_);
-  LOG_DEBUG("VariantStats: Open array '{}'", uri);
+  LOG_DEBUG("[VariantStats] Open array '{}'", uri);
 
   // Open array
   array_ = std::make_unique<Array>(*ctx, uri, TILEDB_WRITE);
@@ -155,7 +155,7 @@ void VariantStats::finalize_query() {
   }
 
   LOG_DEBUG(
-      "VariantStats: Finalize query with {} records", contig_records_.load());
+      "[VariantStats] Finalize query with {} records", contig_records_.load());
   if (contig_records_ > 0) {
     if (utils::query_buffers_set(query_.get())) {
       LOG_FATAL("Cannot submit_and_finalize query with buffers set.");
@@ -179,7 +179,7 @@ void VariantStats::finalize_query() {
       samples.pop_back();
     }
     LOG_DEBUG(
-        "VariantStats: fragment_num = {} uri = {} samples = {}",
+        "[VariantStats] fragment_num = {} uri = {} samples = {}",
         frag_num,
         uri,
         samples);
@@ -199,7 +199,7 @@ void VariantStats::close() {
   }
 
   std::lock_guard<std::mutex> lock(query_lock_);
-  LOG_DEBUG("VariantStats: Close array");
+  LOG_DEBUG("[VariantStats] Close array");
 
   if (query_ != nullptr) {
     query_ = nullptr;
@@ -296,12 +296,12 @@ void VariantStats::flush(bool finalize) {
   int buffered_records = attr_buffers_[AC].size();
 
   if (contig_offsets_.data() == nullptr) {
-    LOG_DEBUG("VariantStats: flush called with no records written");
+    LOG_DEBUG("[VariantStats] flush called with no records written");
     return;
   }
 
   if (buffered_records == 0 && !finalize) {
-    LOG_DEBUG("VariantStats: flush called with 0 records ");
+    LOG_DEBUG("[VariantStats] flush called with 0 records ");
     return;
   }
 
@@ -310,7 +310,7 @@ void VariantStats::flush(bool finalize) {
 
   if (buffered_records) {
     LOG_DEBUG(
-        "VariantStats: flushing {} records from {}:{}-{}",
+        "[VariantStats] flushing {} records from {}:{}-{}",
         buffered_records,
         contig_offsets_.size() > 1 ?
             contig_buffer_.substr(0, contig_offsets_[1]) :
@@ -330,7 +330,7 @@ void VariantStats::flush(bool finalize) {
 
     auto st = query_->submit();
     if (st == Query::Status::FAILED) {
-      LOG_FATAL("VariantStats: error submitting TileDB write query");
+      LOG_FATAL("[VariantStats] error submitting TileDB write query");
     }
 
     // Insert sample names from this query into the set of fragment sample names
@@ -376,10 +376,10 @@ void VariantStats::process(
   // Check if locus has changed
   if (contig != contig_ || pos != pos_) {
     if (contig != contig_) {
-      LOG_DEBUG("VariantStats: new contig = {}", contig);
+      LOG_DEBUG("[VariantStats] new contig = {}", contig);
     } else if (pos < pos_) {
       LOG_ERROR(
-          "VariantStats: contig {} pos out of order {} < {}",
+          "[VariantStats] contig {} pos out of order {} < {}",
           contig,
           pos,
           pos_);
@@ -413,7 +413,7 @@ void VariantStats::process(
     }
     if (any_exceeds_nallele) {
       LOG_WARN(
-          "VariantStats: skipping invalid GT value: sample={} locus={}:{} "
+          "[VariantStats] skipping invalid GT value: sample={} locus={}:{} "
           "gt={}/{} n_allele={}",
           sample_name,
           contig,

--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -49,6 +49,7 @@ Writer::~Writer() {
   utils::free_htslib_tiledb_context();
   AlleleCount::close();
   VariantStats::close();
+  SampleStats::close();
 }
 
 void Writer::init(const std::string& uri, const std::string& config_str) {
@@ -135,6 +136,7 @@ void Writer::init(const IngestionParams& params) {
   Group group(*ctx_, params.uri, TILEDB_READ);
   AlleleCount::init(ctx_, group);
   VariantStats::init(ctx_, group);
+  SampleStats::init(ctx_, group);
 }
 
 void Writer::set_tiledb_config(const std::string& config_str) {
@@ -475,6 +477,7 @@ void Writer::ingest_samples() {
 
   AlleleCount::close();
   VariantStats::close();
+  SampleStats::close();
   array_->close();
 
   // Clean up

--- a/libtiledbvcf/src/write/writer_worker_v4.cc
+++ b/libtiledbvcf/src/write/writer_worker_v4.cc
@@ -259,6 +259,7 @@ bool WriterWorkerV4::resume() {
 
 void WriterWorkerV4::flush_ingestion_tasks(bool finalize) {
   ac_.flush(finalize);
+  ss_.flush(finalize);
   vs_.flush(finalize);
 }
 
@@ -304,6 +305,7 @@ bool WriterWorkerV4::buffer_record(const RecordHeapV4::Node& node) {
   // Ingestion tasks process only NodeType::Record
   if (node.type == RecordHeapV4::NodeType::Record) {
     ac_.process(hdr, sample_name, contig, pos, r);
+    ss_.process(hdr, sample_name, contig, pos, r);
     vs_.process(hdr, sample_name, contig, pos, r);
   }
 

--- a/libtiledbvcf/src/write/writer_worker_v4.h
+++ b/libtiledbvcf/src/write/writer_worker_v4.h
@@ -39,6 +39,7 @@
 #include "dataset/attribute_buffer_set.h"
 #include "dataset/tiledbvcfdataset.h"
 #include "stats/allele_count.h"
+#include "stats/sample_stats.h"
 #include "stats/variant_stats.h"
 #include "vcf/htslib_value.h"
 #include "vcf/vcf_utils.h"
@@ -146,6 +147,9 @@ class WriterWorkerV4 : public WriterWorker {
 
   // Variant stats ingestion task object
   VariantStats vs_;
+
+  // Sample stats ingestion task object
+  SampleStats ss_;
 
   /**
    * Inserts a record (non-anchor) into the heap if it fits


### PR DESCRIPTION
Write sample level statistics to a new `sample_stats` array during ingestion, which enables reporting sample level statistics for all samples without querying the entire dataset.

The stats reported are similar to `bcftools stats` and `hail.sample_qc`. For example:

![image](https://github.com/TileDB-Inc/TileDB-VCF/assets/10476709/a9c29afa-ab18-4b80-92d9-b99ef081de57)
