### PR TITLE
Open vcf_header and data arrays in parallel

### DIFF
--- a/libtiledbvcf/src/enums/attr_datatype.h
+++ b/libtiledbvcf/src/enums/attr_datatype.h
@@ -30,6 +30,7 @@
 #ifndef TILEDB_VCF_ATTR_DATATYPE_H
 #define TILEDB_VCF_ATTR_DATATYPE_H
 
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 


### PR DESCRIPTION
Reduce the time to open a VCF dataset by opening the `vcf_header` and `data` arrays in parallel.

[sc-44880]
