### PR TITLE
Bump nightly release branch to 2.21

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [macos-12, ubuntu-latest]
         branches:
-          - {libtiledb: release-2.21, tiledb-py: release-0.27.1}
+          - {libtiledb: release-2.21, tiledb-py: 0.27.1}
           - {libtiledb: dev, tiledb-py: dev}
     env:
       MACOSX_DEPLOYMENT_TARGET: 10.15

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [macos-12, ubuntu-latest]
         branches:
-          - {libtiledb: release-2.20, tiledb-py: release-0.26.1}
+          - {libtiledb: release-2.21, tiledb-py: release-0.27.1}
           - {libtiledb: dev, tiledb-py: dev}
     env:
       MACOSX_DEPLOYMENT_TARGET: 10.15


### PR DESCRIPTION
The recent fix for CMake 3.29.1 was backported to [`release-2.21`](https://github.com/TileDB-Inc/TileDB/tree/release-2.21) (https://github.com/TileDB-Inc/TileDB/pull/4864)

Closes #694 