### PR TITLE
Read BED files stored as TileDB files

### DIFF
--- a/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.c
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.c
@@ -155,25 +155,6 @@ Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1set_1bed_1file(
 }
 
 JNIEXPORT jint JNICALL
-Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1set_1bed_1array(
-    JNIEnv* env, jclass self, jlong readerPtr, jstring uri) {
-  (void)self;
-  tiledb_vcf_reader_t* reader = (tiledb_vcf_reader_t*)readerPtr;
-  if (reader == 0) {
-    return TILEDB_VCF_ERR;
-  }
-
-  const char* c_uri = (*env)->GetStringUTFChars(env, uri, 0);
-  if (c_uri == NULL) {
-    return TILEDB_VCF_ERR;
-  }
-
-  int rc = tiledb_vcf_reader_set_bed_array(reader, c_uri);
-  (*env)->ReleaseStringUTFChars(env, uri, c_uri);
-  return rc;
-}
-
-JNIEXPORT jint JNICALL
 Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1set_1samples(
     JNIEnv* env, jclass self, jlong readerPtr, jstring samples) {
   (void)self;

--- a/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.h
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.h
@@ -54,15 +54,6 @@ Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1set_1bed_1file(
 
 /*
  * Class:     io_tiledb_libvcfnative_LibVCFNative
- * Method:    tiledb_vcf_reader_set_bed_array
- * Signature: (JLjava/lang/String;)I
- */
-JNIEXPORT jint JNICALL
-Java_io_tiledb_libvcfnative_LibVCFNative_tiledb_1vcf_1reader_1set_1bed_1array(
-    JNIEnv*, jclass, jlong, jstring);
-
-/*
- * Class:     io_tiledb_libvcfnative_LibVCFNative
  * Method:    tiledb_vcf_reader_set_samples
  * Signature: (JLjava/lang/String;)I
  */

--- a/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.java
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/LibVCFNative.java
@@ -38,8 +38,6 @@ public class LibVCFNative {
 
   public static final native int tiledb_vcf_reader_set_bed_file(long readerPtr, String uri);
 
-  public static final native int tiledb_vcf_reader_set_bed_array(long readerPtr, String uri);
-
   public static final native int tiledb_vcf_reader_set_samples(long readerPtr, String samplesCSV);
 
   public static final native int tiledb_vcf_reader_set_regions(long readerPtr, String regionsCSV);

--- a/apis/java/src/main/java/io/tiledb/libvcfnative/VCFReader.java
+++ b/apis/java/src/main/java/io/tiledb/libvcfnative/VCFReader.java
@@ -286,15 +286,6 @@ public class VCFReader implements AutoCloseable {
     return this;
   }
 
-  public VCFReader setBedArray(String uri) {
-    int rc = LibVCFNative.tiledb_vcf_reader_set_bed_array(readerPtr, uri);
-    if (rc != 0) {
-      String msg = getLastErrorMessage();
-      throw new RuntimeException("Error setting query bed array '" + uri + "': " + msg);
-    }
-    return this;
-  }
-
   public VCFReader setSortRegions(boolean sortRegions) {
     int rc = LibVCFNative.tiledb_vcf_reader_set_sort_regions(readerPtr, sortRegions);
     if (rc != 0) {

--- a/apis/java/src/test/java/io/tiledb/libvcfnative/VCFReaderTest.java
+++ b/apis/java/src/test/java/io/tiledb/libvcfnative/VCFReaderTest.java
@@ -73,7 +73,7 @@ public class VCFReaderTest {
    * @throws IOException
    */
   private VCFReader getVFCReader(
-      Optional<String[]> inputSamples, Optional<String> bedFile, Optional<String> bedArray)
+      Optional<String[]> inputSamples, Optional<String> bedFile)
       throws IOException {
     String samples[] = inputSamples.orElse(getSamples());
 
@@ -82,8 +82,6 @@ public class VCFReaderTest {
             constructUri("ingested_2samples"), samples, Optional.empty(), Optional.empty());
 
     if (bedFile.isPresent()) reader.setBedFile(bedFile.get());
-
-    if (bedArray.isPresent()) reader.setBedArray(bedArray.get());
 
     return reader;
   }
@@ -95,7 +93,7 @@ public class VCFReaderTest {
    */
   @Test
   public void testReadCompletes() throws IOException {
-    VCFReader reader = getVFCReader(Optional.empty(), Optional.empty(), Optional.empty());
+    VCFReader reader = getVFCReader(Optional.empty(), Optional.empty());
 
     int results = 0;
 
@@ -114,7 +112,7 @@ public class VCFReaderTest {
    */
   @Test
   public void testReaderValues() throws IOException {
-    VCFReader reader = getVFCReader(Optional.empty(), Optional.empty(), Optional.empty());
+    VCFReader reader = getVFCReader(Optional.empty(), Optional.empty());
 
     reader.setRanges("1:12100-13360,1:13500-17350".split(","));
 
@@ -287,7 +285,7 @@ public class VCFReaderTest {
     int[] partitionsToCheck = {1, 2, 5, 10, 50, 100};
 
     for (int numPartitions : partitionsToCheck) {
-      VCFReader reader = getVFCReader(Optional.empty(), Optional.empty(), Optional.empty());
+      VCFReader reader = getVFCReader(Optional.empty(), Optional.empty());
 
       int results = 0;
 
@@ -315,7 +313,7 @@ public class VCFReaderTest {
   public void testSingleSample() throws IOException {
     VCFReader reader =
         getVFCReader(
-            Optional.of(new String[] {getSamples()[0]}), Optional.empty(), Optional.empty());
+            Optional.of(new String[] {getSamples()[0]}), Optional.empty());
 
     int results = 0;
 
@@ -335,7 +333,7 @@ public class VCFReaderTest {
   @Test
   public void testBEDFile() throws IOException {
     VCFReader reader =
-        getVFCReader(Optional.empty(), Optional.of(constructBEDURI()), Optional.empty());
+        getVFCReader(Optional.empty(), Optional.of(constructBEDURI()));
 
     int results = 0;
 
@@ -356,7 +354,7 @@ public class VCFReaderTest {
   @Test
   public void testBEDArray() throws IOException {
     VCFReader reader =
-        getVFCReader(Optional.empty(), Optional.empty(), Optional.of(constructBEDArrayURI()));
+        getVFCReader(Optional.empty(), Optional.of(constructBEDArrayURI()));
 
     int results = 0;
 
@@ -377,7 +375,7 @@ public class VCFReaderTest {
   @Test
   public void testSetSingleBuffer() throws IOException {
     VCFReader reader =
-        getVFCReader(Optional.empty(), Optional.of(constructBEDURI()), Optional.empty());
+        getVFCReader(Optional.empty(), Optional.of(constructBEDURI()));
     ByteBuffer data = ByteBuffer.allocateDirect(1024);
     reader.setBuffer("sample_name", data);
 
@@ -395,7 +393,7 @@ public class VCFReaderTest {
   @Test
   public void testSetStatsEnabled() throws IOException {
     VCFReader reader =
-        getVFCReader(Optional.empty(), Optional.of(constructBEDURI()), Optional.empty());
+        getVFCReader(Optional.empty(), Optional.of(constructBEDURI()));
 
     reader.setStatsEnabled(true);
   }
@@ -403,7 +401,7 @@ public class VCFReaderTest {
   @Test
   public void testGetStatsEnabled() throws IOException {
     VCFReader reader =
-        getVFCReader(Optional.empty(), Optional.of(constructBEDURI()), Optional.empty());
+        getVFCReader(Optional.empty(), Optional.of(constructBEDURI()));
 
     Assert.assertFalse(reader.getStatsEnabled());
     reader.setStatsEnabled(true);
@@ -415,7 +413,7 @@ public class VCFReaderTest {
   @Test
   public void testStats() throws IOException {
     VCFReader reader =
-        getVFCReader(Optional.empty(), Optional.of(constructBEDURI()), Optional.empty());
+        getVFCReader(Optional.empty(), Optional.of(constructBEDURI()));
     reader.setStatsEnabled(true);
     Assert.assertNotNull(reader.stats());
   }
@@ -429,7 +427,7 @@ public class VCFReaderTest {
   public void testAttributes() throws IOException {
     VCFReader reader =
         getVFCReader(
-            Optional.of(new String[] {getSamples()[0]}), Optional.empty(), Optional.empty());
+            Optional.of(new String[] {getSamples()[0]}), Optional.empty());
 
     Assert.assertTrue(reader.attributes.size() > 0);
     Assert.assertTrue(reader.fmtAttributes.size() > 0);

--- a/apis/java/src/test/java/io/tiledb/libvcfnative/VCFReaderTest.java
+++ b/apis/java/src/test/java/io/tiledb/libvcfnative/VCFReaderTest.java
@@ -72,8 +72,7 @@ public class VCFReaderTest {
    * @return The VCFReader instance
    * @throws IOException
    */
-  private VCFReader getVFCReader(
-      Optional<String[]> inputSamples, Optional<String> bedFile)
+  private VCFReader getVFCReader(Optional<String[]> inputSamples, Optional<String> bedFile)
       throws IOException {
     String samples[] = inputSamples.orElse(getSamples());
 
@@ -311,9 +310,7 @@ public class VCFReaderTest {
    */
   @Test
   public void testSingleSample() throws IOException {
-    VCFReader reader =
-        getVFCReader(
-            Optional.of(new String[] {getSamples()[0]}), Optional.empty());
+    VCFReader reader = getVFCReader(Optional.of(new String[] {getSamples()[0]}), Optional.empty());
 
     int results = 0;
 
@@ -332,8 +329,7 @@ public class VCFReaderTest {
    */
   @Test
   public void testBEDFile() throws IOException {
-    VCFReader reader =
-        getVFCReader(Optional.empty(), Optional.of(constructBEDURI()));
+    VCFReader reader = getVFCReader(Optional.empty(), Optional.of(constructBEDURI()));
 
     int results = 0;
 
@@ -353,8 +349,7 @@ public class VCFReaderTest {
    */
   @Test
   public void testBEDArray() throws IOException {
-    VCFReader reader =
-        getVFCReader(Optional.empty(), Optional.of(constructBEDArrayURI()));
+    VCFReader reader = getVFCReader(Optional.empty(), Optional.of(constructBEDArrayURI()));
 
     int results = 0;
 
@@ -374,8 +369,7 @@ public class VCFReaderTest {
    */
   @Test
   public void testSetSingleBuffer() throws IOException {
-    VCFReader reader =
-        getVFCReader(Optional.empty(), Optional.of(constructBEDURI()));
+    VCFReader reader = getVFCReader(Optional.empty(), Optional.of(constructBEDURI()));
     ByteBuffer data = ByteBuffer.allocateDirect(1024);
     reader.setBuffer("sample_name", data);
 
@@ -392,16 +386,14 @@ public class VCFReaderTest {
 
   @Test
   public void testSetStatsEnabled() throws IOException {
-    VCFReader reader =
-        getVFCReader(Optional.empty(), Optional.of(constructBEDURI()));
+    VCFReader reader = getVFCReader(Optional.empty(), Optional.of(constructBEDURI()));
 
     reader.setStatsEnabled(true);
   }
 
   @Test
   public void testGetStatsEnabled() throws IOException {
-    VCFReader reader =
-        getVFCReader(Optional.empty(), Optional.of(constructBEDURI()));
+    VCFReader reader = getVFCReader(Optional.empty(), Optional.of(constructBEDURI()));
 
     Assert.assertFalse(reader.getStatsEnabled());
     reader.setStatsEnabled(true);
@@ -412,8 +404,7 @@ public class VCFReaderTest {
 
   @Test
   public void testStats() throws IOException {
-    VCFReader reader =
-        getVFCReader(Optional.empty(), Optional.of(constructBEDURI()));
+    VCFReader reader = getVFCReader(Optional.empty(), Optional.of(constructBEDURI()));
     reader.setStatsEnabled(true);
     Assert.assertNotNull(reader.stats());
   }
@@ -425,9 +416,7 @@ public class VCFReaderTest {
    */
   @Test
   public void testAttributes() throws IOException {
-    VCFReader reader =
-        getVFCReader(
-            Optional.of(new String[] {getSamples()[0]}), Optional.empty());
+    VCFReader reader = getVFCReader(Optional.of(new String[] {getSamples()[0]}), Optional.empty());
 
     Assert.assertTrue(reader.attributes.size() > 0);
     Assert.assertTrue(reader.fmtAttributes.size() > 0);

--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -24,7 +24,6 @@ PYBIND11_MODULE(libtiledbvcf, m) {
       .def("set_samples_file", &Reader::set_samples_file)
       .def("set_regions", &Reader::set_regions)
       .def("set_bed_file", &Reader::set_bed_file)
-      .def("set_bed_array", &Reader::set_bed_array)
       .def("set_sort_regions", &Reader::set_sort_regions)
       .def("set_region_partition", &Reader::set_region_partition)
       .def("set_sample_partition", &Reader::set_sample_partition)

--- a/apis/python/src/tiledbvcf/binding/reader.cc
+++ b/apis/python/src/tiledbvcf/binding/reader.cc
@@ -108,11 +108,6 @@ void Reader::set_bed_file(const std::string& uri) {
   check_error(reader, tiledb_vcf_reader_set_bed_file(reader, uri.c_str()));
 }
 
-void Reader::set_bed_array(const std::string& uri) {
-  auto reader = ptr.get();
-  check_error(reader, tiledb_vcf_reader_set_bed_array(reader, uri.c_str()));
-}
-
 void Reader::set_region_partition(int32_t partition, int32_t num_partitions) {
   auto reader = ptr.get();
   check_error(

--- a/apis/python/src/tiledbvcf/binding/reader.h
+++ b/apis/python/src/tiledbvcf/binding/reader.h
@@ -67,9 +67,6 @@ class Reader {
   /** Sets a URI of a BED file containing regions to include in the read. */
   void set_bed_file(const std::string& uri);
 
-  /** Sets a URI of a BED array containing regions to include in the read. */
-  void set_bed_array(const std::string& uri);
-
   /** Sets the region partition of this reader. */
   void set_region_partition(int32_t partition, int32_t num_partitions);
 

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -210,7 +210,6 @@ class Dataset(object):
         regions: (str, List[str]) = None,
         samples_file: str = None,
         bed_file: str = None,
-        bed_array: str = None,
         skip_check_samples: bool = False,
         set_af_filter: str = "",
         scan_all_samples: bool = False,
@@ -236,8 +235,6 @@ class Dataset(object):
             URI of file containing sample names to be read, one per line.
         bed_file
             URI of a BED file of genomic regions to be read.
-        bed_array
-            URI of a BED array of genomic regions to be read.
         skip_check_samples
             Skip checking if the samples in `samples_file` exist in the dataset.
         set_af_filter
@@ -275,9 +272,6 @@ class Dataset(object):
 
         if bed_file is not None:
             self.reader.set_bed_file(bed_file)
-
-        if bed_array is not None:
-            self.reader.set_bed_array(bed_array)
 
         return self.continue_read_arrow()
 
@@ -322,7 +316,6 @@ class Dataset(object):
         regions: (str, List[str]) = None,
         samples_file: str = None,
         bed_file: str = None,
-        bed_array: str = None,
         skip_check_samples: bool = False,
         set_af_filter: str = "",
         scan_all_samples: bool = False,
@@ -350,8 +343,6 @@ class Dataset(object):
             URI of file containing sample names to be read, one per line.
         bed_file
             URI of a BED file of genomic regions to be read.
-        bed_array
-            URI of a BED array of genomic regions to be read.
         skip_check_samples
             Skip checking if the samples in `samples_file` exist in the dataset.
         set_af_filter
@@ -388,9 +379,6 @@ class Dataset(object):
         if bed_file is not None:
             self.reader.set_bed_file(bed_file)
 
-        if bed_array is not None:
-            self.reader.set_bed_array(bed_array)
-
         return self.continue_read()
 
     def export(
@@ -399,7 +387,6 @@ class Dataset(object):
         regions: (str, List[str]) = None,
         samples_file: str = None,
         bed_file: str = None,
-        bed_array: str = None,
         skip_check_samples: bool = False,
         enable_progress_estimation: bool = False,
         merge: bool = False,
@@ -420,8 +407,6 @@ class Dataset(object):
             URI of file containing sample names to be read, one per line.
         bed_file
             URI of a BED file of genomic regions to be read.
-        bed_array
-            URI of a BED array of genomic regions to be read.
         skip_check_samples
             Skip checking if the samples in `samples_file` exist in the dataset.
         set_af_filter
@@ -466,9 +451,6 @@ class Dataset(object):
 
         if bed_file is not None:
             self.reader.set_bed_file(bed_file)
-
-        if bed_array is not None:
-            self.reader.set_bed_array(bed_array)
 
         self.reader.read()
         if not self.read_completed():

--- a/libtiledbvcf/src/c_api/tiledbvcf.cc
+++ b/libtiledbvcf/src/c_api/tiledbvcf.cc
@@ -228,17 +228,6 @@ int32_t tiledb_vcf_reader_set_bed_file(
   return TILEDB_VCF_OK;
 }
 
-int32_t tiledb_vcf_reader_set_bed_array(
-    tiledb_vcf_reader_t* reader, const char* uri) {
-  if (sanity_check(reader) == TILEDB_VCF_ERR || uri == nullptr)
-    return TILEDB_VCF_ERR;
-
-  if (SAVE_ERROR_CATCH(reader, reader->reader_->set_bed_array(uri)))
-    return TILEDB_VCF_ERR;
-
-  return TILEDB_VCF_OK;
-}
-
 int32_t tiledb_vcf_reader_set_samples(
     tiledb_vcf_reader_t* reader, const char* samples) {
   if (sanity_check(reader) == TILEDB_VCF_ERR || samples == nullptr)

--- a/libtiledbvcf/src/c_api/tiledbvcf.h
+++ b/libtiledbvcf/src/c_api/tiledbvcf.h
@@ -183,16 +183,6 @@ TILEDBVCF_EXPORT int32_t
 tiledb_vcf_reader_set_bed_file(tiledb_vcf_reader_t* reader, const char* uri);
 
 /**
- * Sets the URI of a BED array containing regions to be read.
- *
- * @param reader VCF reader object
- * @param uri URI of BED array
- * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
- */
-TILEDBVCF_EXPORT int32_t
-tiledb_vcf_reader_set_bed_array(tiledb_vcf_reader_t* reader, const char* uri);
-
-/**
  * Given a CSV string of sample names, sets the samples to be read.
  *
  * If you specify both a CSV samples list and a samples file, samples from both

--- a/libtiledbvcf/src/cli/tiledbvcf.cc
+++ b/libtiledbvcf/src/cli/tiledbvcf.cc
@@ -762,11 +762,6 @@ void add_export(CLI::App& app) {
          args->regions_file_uri,
          "File containing regions (BED format)")
       ->excludes("--regions");
-  cmd->add_option(
-         "-A,--bed-array",
-         args->bed_array_uri,
-         "URI of TileDB BED array containing regions to export")
-      ->excludes("--regions");
   cmd->add_flag(
       "--sorted",
       args->sort_regions,

--- a/libtiledbvcf/src/read/reader.h
+++ b/libtiledbvcf/src/read/reader.h
@@ -93,7 +93,6 @@ struct ExportParams {
   std::string log_file;
   std::string samples_file_uri;
   std::string regions_file_uri;
-  std::string bed_array_uri;
   std::vector<std::string> sample_names;
   std::vector<std::string> regions;
   std::string output_dir;
@@ -214,9 +213,6 @@ class Reader {
 
   /** Sets the BED file URI parameter. */
   void set_bed_file(const std::string& uri);
-
-  /** Sets the BED array URI parameter. */
-  void set_bed_array(const std::string& uri);
 
   /** Sets the region partitioning. */
   void set_region_partition(uint64_t partition_idx, uint64_t num_partitions);

--- a/libtiledbvcf/src/utils/utils.cc
+++ b/libtiledbvcf/src/utils/utils.cc
@@ -30,8 +30,10 @@
 #include <unistd.h>
 #endif
 #include <cerrno>
+#include <filesystem>
 #include <fstream>
 #include <mutex>
+#include <random>
 
 #include "htslib_plugin/hfile_tiledb_vfs.h"
 #include "utils/logger_public.h"
@@ -628,6 +630,15 @@ bool query_buffers_set(tiledb::Query* query) {
     }
   }
   return false;
+}
+
+std::string temp_filename(const std::string& extension) {
+  std::random_device rd;
+  std::stringstream filename;
+  filename << "vcf_tmp_" << rd() << extension;
+  std::filesystem::path path =
+      std::filesystem::temp_directory_path() / filename.str();
+  return path.string();
 }
 
 }  // namespace utils

--- a/libtiledbvcf/src/utils/utils.h
+++ b/libtiledbvcf/src/utils/utils.h
@@ -513,6 +513,13 @@ bool contains(std::vector<T>& vec, T& item) {
  */
 bool query_buffers_set(tiledb::Query* query);
 
+/**
+ * @brief Return a random temporary file name
+ *
+ * @return std::string full path to temporary file
+ */
+std::string temp_filename(const std::string& extension = "");
+
 }  // namespace utils
 }  // namespace vcf
 }  // namespace tiledb

--- a/libtiledbvcf/src/vcf/region.cc
+++ b/libtiledbvcf/src/vcf/region.cc
@@ -181,10 +181,9 @@ void Region::read_bed_array(
       auto chromStart = mq.data<uint64_t>(column_alias[START])[i];
       auto chromEnd = mq.data<uint64_t>(column_alias[END])[i];
 
-      // Each region in the BED array is 0-indexed and inclusive
-      // [0-start, end] which is the same format as the Region struct, so no
-      // modification is required.
-      result.emplace_back(chrom, chromStart, chromEnd, line++);
+      // BED files contain 0-indexed, half-open regions. Convert to a
+      // 0-based, inclusive Region object.
+      result.emplace_back(chrom, chromStart, chromEnd - 1, line++);
     }
   }
 }

--- a/libtiledbvcf/test/src/unit-c-api-reader.cc
+++ b/libtiledbvcf/test/src/unit-c-api-reader.cc
@@ -614,37 +614,9 @@ TEST_CASE("C API: Reader set BED file", "[capi][reader]") {
 
   REQUIRE(tiledb_vcf_reader_init(reader, dataset_uri.c_str()) == TILEDB_VCF_OK);
 
-  REQUIRE(
-      tiledb_vcf_reader_set_bed_file(reader, "file:///does/not/exist.bed") ==
-      TILEDB_VCF_ERR);
-
   auto bed_uri = TILEDB_VCF_TEST_INPUT_DIR + std::string("/simple.bed");
   REQUIRE(
       tiledb_vcf_reader_set_bed_file(reader, bed_uri.c_str()) == TILEDB_VCF_OK);
-
-  tiledb_vcf_reader_free(&reader);
-}
-
-TEST_CASE("C API: Reader set BED array", "[capi][reader]") {
-  tiledb_vcf_reader_t* reader = nullptr;
-  REQUIRE(tiledb_vcf_reader_alloc(&reader) == TILEDB_VCF_OK);
-
-  std::string dataset_uri;
-  dataset_uri = INPUT_ARRAYS_DIR_V4 + "/ingested_2samples";
-
-  REQUIRE(tiledb_vcf_reader_init(reader, dataset_uri.c_str()) == TILEDB_VCF_OK);
-
-  REQUIRE(
-      tiledb_vcf_reader_set_bed_array(reader, "file:///does/not/exist.bed") ==
-      TILEDB_VCF_ERR);
-
-  // This check is making sure we can set the bed URI without an error,
-  // it doesn't matter if the URI is a BED array. Since we don't have a BED
-  // array in the test data, we use the data array.
-  auto bed_uri = dataset_uri + "/data";
-  REQUIRE(
-      tiledb_vcf_reader_set_bed_array(reader, bed_uri.c_str()) ==
-      TILEDB_VCF_OK);
 
   tiledb_vcf_reader_free(&reader);
 }


### PR DESCRIPTION
Read BED files stored in a TileDB filestore. This enables reading BED files registered on TileDB Cloud, which supports complex object store credentials.

The read API is simplified by unifying the parameter used to pass in a BED file, BED file registered on TileDB Cloud, or a BED array. The separate BED array parameter is removed.
