### PR TITLE
Set java/spark version from git tag

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -111,6 +111,7 @@ stages:
               unset SYSTEM
               set +e
               ci/collect-nativelibs.sh
+            displayName: 'Collect Native Libraries'
 
           - task: ArchiveFiles@2
             inputs:

--- a/apis/java/build.gradle
+++ b/apis/java/build.gradle
@@ -6,8 +6,17 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '4.0.3'
 }
 
+ext.getVersionName = { ->
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'describe', '--tags'
+        standardOutput = stdout
+    }
+    return stdout.toString().trim()
+}
+
 group 'io.tiledb'
-version '0.31.0'
+version getVersionName()
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -39,6 +48,9 @@ dependencies {
 test {
     testLogging {
         showStandardStreams = true
+    }
+    doLast {
+        println "\nTileDB-VCF version: ${project.version}"
     }
 }
 

--- a/apis/java/build.gradle
+++ b/apis/java/build.gradle
@@ -8,11 +8,22 @@ plugins {
 
 ext.getVersionName = { ->
     def stdout = new ByteArrayOutputStream()
-    exec {
-        commandLine 'git', 'describe', '--tags'
-        standardOutput = stdout
+    try {
+        // Try to get the version from git
+        exec {
+            commandLine 'git', 'describe', '--tags'
+            standardOutput = stdout
+        }
+        return stdout.toString().trim()
+    } catch (Exception e1) {
+        try {
+            // Try to get the version from a file
+            return file("../../version.txt").text.trim()
+        } catch (Exception e2) {
+            // Version is unknown
+            return "unknown"
+        }
     }
-    return stdout.toString().trim()
 }
 
 group 'io.tiledb'

--- a/apis/spark/build.gradle
+++ b/apis/spark/build.gradle
@@ -6,8 +6,17 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '4.0.3'
 }
 
+ext.getVersionName = { ->
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'describe', '--tags'
+        standardOutput = stdout
+    }
+    return stdout.toString().trim()
+}
+
 group 'io.tiledb'
-version '0.31.0'
+version getVersionName()
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -50,6 +59,9 @@ test {
     testLogging {
         showStandardStreams = true
     }
+    doLast {
+        println "\nTileDB-VCF version: ${project.version}"
+    }    
 }
 
 shadowJar {

--- a/apis/spark/build.gradle
+++ b/apis/spark/build.gradle
@@ -8,11 +8,22 @@ plugins {
 
 ext.getVersionName = { ->
     def stdout = new ByteArrayOutputStream()
-    exec {
-        commandLine 'git', 'describe', '--tags'
-        standardOutput = stdout
+    try {
+        // Try to get the version from git
+        exec {
+            commandLine 'git', 'describe', '--tags'
+            standardOutput = stdout
+        }
+        return stdout.toString().trim()
+    } catch (Exception e1) {
+        try {
+            // Try to get the version from a file
+            return file("../../version.txt").text.trim()
+        } catch (Exception e2) {
+            // Version is unknown
+            return "unknown"
+        }
     }
-    return stdout.toString().trim()
 }
 
 group 'io.tiledb'

--- a/apis/spark3/build.gradle
+++ b/apis/spark3/build.gradle
@@ -6,8 +6,17 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '4.0.3'
 }
 
+ext.getVersionName = { ->
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'describe', '--tags'
+        standardOutput = stdout
+    }
+    return stdout.toString().trim()
+}
+
 group 'io.tiledb'
-version '0.31.0'
+version getVersionName()
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -50,6 +59,9 @@ test {
     testLogging {
         showStandardStreams = true
     }
+    doLast {
+        println "\nTileDB-VCF version: ${project.version}"
+    }    
 }
 
 shadowJar {

--- a/apis/spark3/build.gradle
+++ b/apis/spark3/build.gradle
@@ -8,11 +8,22 @@ plugins {
 
 ext.getVersionName = { ->
     def stdout = new ByteArrayOutputStream()
-    exec {
-        commandLine 'git', 'describe', '--tags'
-        standardOutput = stdout
+    try {
+        // Try to get the version from git
+        exec {
+            commandLine 'git', 'describe', '--tags'
+            standardOutput = stdout
+        }
+        return stdout.toString().trim()
+    } catch (Exception e1) {
+        try {
+            // Try to get the version from a file
+            return file("../../version.txt").text.trim()
+        } catch (Exception e2) {
+            // Version is unknown
+            return "unknown"
+        }
     }
-    return stdout.toString().trim()
 }
 
 group 'io.tiledb'

--- a/ci/native_libs-linux_osx.yml
+++ b/ci/native_libs-linux_osx.yml
@@ -92,6 +92,10 @@ steps:
       env: { sourceVersion: $(Build.SourceVersion) }
       displayName: Git Hash 7-digit
 
+    - bash: |
+        git describe --tags > $BUILD_REPOSITORY_LOCALPATH/version.txt
+      displayName: 'Capture version'
+
     - task: ArchiveFiles@2
       inputs:
         rootFolderOrFile: '$(Build.BinariesDirectory)'


### PR DESCRIPTION
The goal of this PR is to remove the manual step of bumping the Java/Spark version for every release.

The `build.gradle` files try to read the version from a git tag or a `version.txt` file in the root of the repo, which is added to the build artifacts during the `BuildNativeLibs` CI task.