### PR TITLE
Add Hail-like AC, AN, and AF computation to variant stats V3

### DIFF
--- a/apis/python/tests/test_tiledbvcf.py
+++ b/apis/python/tests/test_tiledbvcf.py
@@ -1254,12 +1254,15 @@ def test_ingest_with_stats_v3(tmp_path):
         attrs=["contig", "pos_start", "id", "qual", "info_TILEDB_IAF", "sample_name"],
         scan_all_samples=True,
     )
-    assert data_frame[
-        (data_frame["sample_name"] == "second") & (data_frame["pos_start"] == 4)
-    ]["info_TILEDB_IAF"].iloc[0][0] == pytest.approx(0.9583333)
+    assert (
+        data_frame[
+            (data_frame["sample_name"] == "second") & (data_frame["pos_start"] == 4)
+        ]["info_TILEDB_IAF"].iloc[0][0]
+        == 15.0
+    )
     ds = tiledbvcf.Dataset(uri=os.path.join(tmp_path, "stats_test"), mode="r")
     df = ds.read_variant_stats("chr1:1-10000")
-    assert df.shape == (12, 5)
+    assert df.shape == (11, 5)
     df = tiledbvcf.allele_frequency.read_allele_frequency(
         os.path.join(tmp_path, "stats_test"), "chr1:1-10000"
     )
@@ -1267,9 +1270,8 @@ def test_ingest_with_stats_v3(tmp_path):
     df["an_check"] = (df.ac / df.af).round(0).astype("int32")
     assert df.an_check.equals(df.an)
     df = ds.read_variant_stats("chr1:1-10000")
-    assert df.shape == (12, 5)
+    assert df.shape == (11, 5)
     df = df.to_pandas()
-    assert sum(sum((df[df["alleles"] == "nr"] == (9, "nr", 4, 4, 1.0)).values)) == 5
     df = ds.read_allele_count("chr1:1-10000")
     assert df.shape == (7, 6)
     df = df.to_pandas()

--- a/apis/python/tests/test_tiledbvcf.py
+++ b/apis/python/tests/test_tiledbvcf.py
@@ -1258,7 +1258,7 @@ def test_ingest_with_stats_v3(tmp_path):
         data_frame[
             (data_frame["sample_name"] == "second") & (data_frame["pos_start"] == 4)
         ]["info_TILEDB_IAF"].iloc[0][0]
-        == 15.0
+        == 0.9375
     )
     ds = tiledbvcf.Dataset(uri=os.path.join(tmp_path, "stats_test"), mode="r")
     df = ds.read_variant_stats("chr1:1-10000")

--- a/apis/python/tests/test_tiledbvcf.py
+++ b/apis/python/tests/test_tiledbvcf.py
@@ -1241,7 +1241,7 @@ def test_ingest_with_stats_v3(tmp_path):
         attrs=["contig", "pos_start", "id", "qual", "info_TILEDB_IAF", "sample_name"],
         set_af_filter="<0.2",
     )
-    assert data_frame.shape == (3, 8)
+    assert data_frame.shape == (1, 8)
     assert data_frame.query("sample_name == 'second'")["qual"].iloc[0] == pytest.approx(
         343.73
     )
@@ -1254,12 +1254,9 @@ def test_ingest_with_stats_v3(tmp_path):
         attrs=["contig", "pos_start", "id", "qual", "info_TILEDB_IAF", "sample_name"],
         scan_all_samples=True,
     )
-    assert (
-        data_frame[
-            (data_frame["sample_name"] == "second") & (data_frame["pos_start"] == 4)
-        ]["info_TILEDB_IAF"].iloc[0][0]
-        == 0.9375
-    )
+    assert data_frame[
+        (data_frame["sample_name"] == "second") & (data_frame["pos_start"] == 4)
+    ]["info_TILEDB_IAF"].iloc[0][0] == pytest.approx(0.9583333)
     ds = tiledbvcf.Dataset(uri=os.path.join(tmp_path, "stats_test"), mode="r")
     df = ds.read_variant_stats("chr1:1-10000")
     assert df.shape == (12, 5)

--- a/apis/python/tests/test_tiledbvcf.py
+++ b/apis/python/tests/test_tiledbvcf.py
@@ -1262,7 +1262,7 @@ def test_ingest_with_stats_v3(tmp_path):
     )
     ds = tiledbvcf.Dataset(uri=os.path.join(tmp_path, "stats_test"), mode="r")
     df = ds.read_variant_stats("chr1:1-10000")
-    assert df.shape == (11, 5)
+    assert df.shape == (13, 5)
     df = tiledbvcf.allele_frequency.read_allele_frequency(
         os.path.join(tmp_path, "stats_test"), "chr1:1-10000"
     )
@@ -1270,7 +1270,7 @@ def test_ingest_with_stats_v3(tmp_path):
     df["an_check"] = (df.ac / df.af).round(0).astype("int32")
     assert df.an_check.equals(df.an)
     df = ds.read_variant_stats("chr1:1-10000")
-    assert df.shape == (11, 5)
+    assert df.shape == (13, 5)
     df = df.to_pandas()
     df = ds.read_allele_count("chr1:1-10000")
     assert df.shape == (7, 6)
@@ -1342,7 +1342,7 @@ def test_ingest_with_stats_v2(tmp_path):
     )
     ds = tiledbvcf.Dataset(uri=os.path.join(tmp_path, "stats_test"), mode="r")
     df = ds.read_variant_stats("chr1:1-10000")
-    assert df.shape == (12, 5)
+    assert df.shape == (13, 5)
     df = tiledbvcf.allele_frequency.read_allele_frequency(
         os.path.join(tmp_path, "stats_test"), "chr1:1-10000"
     )
@@ -1350,7 +1350,7 @@ def test_ingest_with_stats_v2(tmp_path):
     df["an_check"] = (df.ac / df.af).round(0).astype("int32")
     assert df.an_check.equals(df.an)
     df = ds.read_variant_stats("chr1:1-10000")
-    assert df.shape == (12, 5)
+    assert df.shape == (13, 5)
     df = df.to_pandas()
     df = ds.read_allele_count("chr1:1-10000")
     assert df.shape == (7, 6)

--- a/libtiledbvcf/src/CMakeLists.txt
+++ b/libtiledbvcf/src/CMakeLists.txt
@@ -68,6 +68,7 @@ set(TILEDB_VCF_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/utils/bitmap.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/utils/buffer.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/utils/logger.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/utils/normalize.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/utils/sample_utils.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/utils/utils.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/vcf/bed_file.cc

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -768,8 +768,8 @@ void TileDBVCFDataset::load_field_type_maps_v4(
         // TODO: do something better than promoting this pointer type;
         // perhaps the header should be duplicated and later modified
         const_cast<bcf_hdr_t*>(hdr),
-        "##INFO=<ID=TILEDB_IAF,Number=R,Type=Float,Description=\"Internal "
-        "Allele Frequency, computed over dataset by TileDB\">");
+        "##INFO=<ID=TILEDB_IAF,Number=R,Type=Float,Description="
+        "\"Internal Allele Frequency, computed over dataset by TileDB\">");
     if (header_appended < 0) {
       throw std::runtime_error(
           "Error appending to header for internal allele frequency.");
@@ -779,8 +779,8 @@ void TileDBVCFDataset::load_field_type_maps_v4(
             // perhaps the header should be duplicated and later modified
             const_cast<bcf_hdr_t*>(hdr),
             "##INFO=<ID=TILEDB_IAC,Number=R,Type=Integer,Description="
-            "\"Internal "
-            "Allele Count, computed over dataset by TileDB\">") < 0) {
+            "\"Internal Allele Count, computed over dataset by TileDB\">") <
+        0) {
       throw std::runtime_error(
           "Error appending to header for internal allele count.");
     }
@@ -789,8 +789,8 @@ void TileDBVCFDataset::load_field_type_maps_v4(
             // perhaps the header should be duplicated and later modified
             const_cast<bcf_hdr_t*>(hdr),
             "##INFO=<ID=TILEDB_IAN,Number=R,Type=Integer,Description="
-            "\"Internal "
-            "Allele Number, computed over dataset by TileDB\">") < 0) {
+            "\"Internal Allele Number, computed over dataset by TileDB\">") <
+        0) {
       throw std::runtime_error(
           "Error appending to header for internal allele number.");
     }

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -764,12 +764,13 @@ void TileDBVCFDataset::load_field_type_maps_v4(
   }
 
   if (add_iaf) {
-    if (bcf_hdr_append(
-            // TODO: do something better than promoting this pointer type;
-            // perhaps the header should be duplicated and later modified
-            const_cast<bcf_hdr_t*>(hdr),
-            "##INFO=<ID=TILEDB_IAF,Number=R,Type=Float,Description=\"Internal "
-            "Allele Frequency, computed over dataset by TileDB\">") < 0) {
+    int header_appended = bcf_hdr_append(
+        // TODO: do something better than promoting this pointer type;
+        // perhaps the header should be duplicated and later modified
+        const_cast<bcf_hdr_t*>(hdr),
+        "##INFO=<ID=TILEDB_IAF,Number=R,Type=Float,Description=\"Internal "
+        "Allele Frequency, computed over dataset by TileDB\">");
+    if (header_appended < 0) {
       throw std::runtime_error(
           "Error appending to header for internal allele frequency.");
     }

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -773,6 +773,26 @@ void TileDBVCFDataset::load_field_type_maps_v4(
       throw std::runtime_error(
           "Error appending to header for internal allele frequency.");
     }
+    if (bcf_hdr_append(
+            // TODO: do something better than promoting this pointer type;
+            // perhaps the header should be duplicated and later modified
+            const_cast<bcf_hdr_t*>(hdr),
+            "##INFO=<ID=TILEDB_IAC,Number=R,Type=Integer,Description="
+            "\"Internal "
+            "Allele Count, computed over dataset by TileDB\">") < 0) {
+      throw std::runtime_error(
+          "Error appending to header for internal allele count.");
+    }
+    if (bcf_hdr_append(
+            // TODO: do something better than promoting this pointer type;
+            // perhaps the header should be duplicated and later modified
+            const_cast<bcf_hdr_t*>(hdr),
+            "##INFO=<ID=TILEDB_IAN,Number=R,Type=Integer,Description="
+            "\"Internal "
+            "Allele Number, computed over dataset by TileDB\">") < 0) {
+      throw std::runtime_error(
+          "Error appending to header for internal allele number.");
+    }
     info_iaf_field_type_added_ = true;
     if (bcf_hdr_sync(const_cast<bcf_hdr_t*>(hdr)) < 0) {
       throw std::runtime_error("Error syncing header after adding IAF record.");
@@ -949,8 +969,8 @@ void TileDBVCFDataset::delete_samples(
       throw std::runtime_error("Sample not found in dataset: " + sample);
     }
 
-    // If a stats array exists, read the data with the delete exporter, which
-    // adds negative counts to the stats arrays
+    // If a stats array exists, read the data with the delete exporter,
+    // which adds negative counts to the stats arrays
     if (stats_array_exists) {
       ExportParams args;
       args.tiledb_config = tiledb_config;
@@ -1132,7 +1152,8 @@ std::unordered_map<uint32_t, SafeBCFHdr> TileDBVCFDataset::fetch_vcf_headers_v4(
     // first sample.
     if (first_sample && num_rows == 0) {
       LOG_DEBUG(
-          "[fetch_vcf_headers_v4] the first sample was deleted, resubmitting");
+          "[fetch_vcf_headers_v4] the first sample was deleted, "
+          "resubmitting");
       mq = std::make_unique<ManagedQuery>(
           vcf_header_array_, "fetch_vcf_headers_v4");
       mq->select_columns({"sample", "header"});
@@ -2002,7 +2023,8 @@ const char* TileDBVCFDataset::materialized_attribute_name(
 
 bool TileDBVCFDataset::is_attribute_materialized(
     const std::string& attr) const {
-  if (attr == "info_TILEDB_IAF") {
+  if (attr == "info_TILEDB_IAF" || attr == "info_TILEDB_IAC" ||
+      attr == "info_TILEDB_IAN") {
     return true;
   }
 

--- a/libtiledbvcf/src/read/in_memory_exporter.cc
+++ b/libtiledbvcf/src/read/in_memory_exporter.cc
@@ -985,8 +985,7 @@ bool InMemoryExporter::copy_info_fmt_value(
   auto& ac_values = curr_query_results_->ac_values;
   auto& an_values = curr_query_results_->an_values;
   if ((is_iaf || is_iac || is_ian) && !af_values.empty()) {
-    if (af_values.size() != ac_values.size() ||
-        af_values.size() != an_values.size()) {
+    if (af_values.size() != ac_values.size()) {
       throw std::runtime_error(
           "inconsistent cardinality of IAC/IAN/IAF vectors in query results");
     }

--- a/libtiledbvcf/src/read/in_memory_exporter.cc
+++ b/libtiledbvcf/src/read/in_memory_exporter.cc
@@ -595,7 +595,8 @@ bool InMemoryExporter::fixed_len_attr(const std::string& attr) {
       "fmt_PS",
       "fmt_PQ",
       "fmt_MQ",
-      "fmt_MIN_DP"};
+      "fmt_MIN_DP",
+      "info_TILEDB_IAN"};
   return fixed_len.count(attr) > 0;
 }
 
@@ -983,7 +984,7 @@ bool InMemoryExporter::copy_info_fmt_value(
   uint64_t nbytes = 0, nelts = 0;
   auto& af_values = curr_query_results_->af_values;
   auto& ac_values = curr_query_results_->ac_values;
-  auto& an_values = curr_query_results_->an_values;
+  uint32_t an_value = curr_query_results_->an_value;
   if ((is_iaf || is_iac || is_ian) && !af_values.empty()) {
     if (af_values.size() != ac_values.size()) {
       throw std::runtime_error(
@@ -1000,9 +1001,9 @@ bool InMemoryExporter::copy_info_fmt_value(
         nelts = ac_values.size();
         nbytes = nelts * sizeof(decltype(ac_values.at(0)));
       } else {
-        src = an_values.data();
-        nelts = an_values.size();
-        nbytes = nelts * sizeof(decltype(an_values.at(0)));
+        src = &an_value;
+        nelts = 1;
+        nbytes = nelts * sizeof(decltype(an_value));
       }
     }
   } else {

--- a/libtiledbvcf/src/read/read_query_results.h
+++ b/libtiledbvcf/src/read/read_query_results.h
@@ -88,6 +88,8 @@ struct ReadQueryResults {
 
   /** TileDB Internal Allele Frequency values*/
   std::vector<float> af_values;
+  std::vector<uint32_t> ac_values;
+  std::vector<uint32_t> an_values;
 
  private:
   /** Pointer to buffer set holding the actual data. */

--- a/libtiledbvcf/src/read/read_query_results.h
+++ b/libtiledbvcf/src/read/read_query_results.h
@@ -89,7 +89,7 @@ struct ReadQueryResults {
   /** TileDB Internal Allele Frequency values*/
   std::vector<float> af_values;
   std::vector<uint32_t> ac_values;
-  std::vector<uint32_t> an_values;
+  uint32_t an_value;
 
  private:
   /** Pointer to buffer set holding the actual data. */

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -1376,6 +1376,8 @@ bool Reader::process_query_results_v4() {
       }
 
       read_state_.query_results.af_values.clear();
+      read_state_.query_results.ac_values.clear();
+      read_state_.query_results.an_values.clear();
       int allele_index = 0;
       bool is_ref = true;
       for (auto&& allele : alleles) {
@@ -1403,6 +1405,8 @@ bool Reader::process_query_results_v4() {
         //  - build vector of AFs matching the order of the VCF record
         //  - all allele AF values are required, so do not exit this loop early
         read_state_.query_results.af_values.push_back(af);
+        read_state_.query_results.ac_values.push_back(ac);
+        read_state_.query_results.an_values.push_back(an);
 
         LOG_TRACE("  pass = {}", pass);
         is_ref = false;

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -1379,7 +1379,7 @@ bool Reader::process_query_results_v4() {
       int allele_index = 0;
       bool is_ref = true;
       for (auto&& allele : alleles) {
-        auto [allele_passes, af] = af_filter_->pass(
+        auto [allele_passes, af, ac, an] = af_filter_->pass(
             real_start,
             is_ref ? "ref" : alleles[0] + "," + allele,
             params_.scan_all_samples,

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -183,6 +183,10 @@ void Reader::init_af_filter() {
     Group group(*ctx_, dataset_->root_uri(), TILEDB_READ);
     af_filter_ = std::make_unique<VariantStatsReader>(ctx_, group);
     af_filter_->set_condition(params_.af_filter);
+    // TODO: enable sorting only if needed for GVCF IAF feature
+    if (af_filter_->array_version() > 2) {
+      params_.sort_real_start_pos = true;
+    }
   }
 }
 

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -1380,8 +1380,9 @@ bool Reader::process_query_results_v4() {
       read_state_.query_results.an_values.clear();
       int allele_index = 0;
       bool is_ref = true;
+      uint32_t an = 0;
       for (auto&& allele : alleles) {
-        auto [allele_passes, af, ac, an] = af_filter_->pass(
+        auto [allele_passes, af, ac, allele_an] = af_filter_->pass(
             real_start,
             is_ref ? "ref" : alleles[0] + "," + allele,
             params_.scan_all_samples,
@@ -1406,11 +1407,12 @@ bool Reader::process_query_results_v4() {
         //  - all allele AF values are required, so do not exit this loop early
         read_state_.query_results.af_values.push_back(af);
         read_state_.query_results.ac_values.push_back(ac);
-        read_state_.query_results.an_values.push_back(an);
+        an = allele_an;
 
         LOG_TRACE("  pass = {}", pass);
         is_ref = false;
       }
+      read_state_.query_results.an_values.push_back(an);
 
       // If all alleles do not pass the af filter, continue
       if (!pass) {

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -952,7 +952,7 @@ void Reader::prepare_variant_stats() {
         "Error preparing variant stats: there should be exactly one region "
         "specified");
   }
-  af_filter_->add_region(params_.regions[0]);
+  af_filter_->add_region(params_.regions[0], true);
   af_filter_->compute_af();
 }
 

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -1377,7 +1377,7 @@ bool Reader::process_query_results_v4() {
 
       read_state_.query_results.af_values.clear();
       read_state_.query_results.ac_values.clear();
-      read_state_.query_results.an_values.clear();
+      read_state_.query_results.an_value = 0;
       int allele_index = 0;
       bool is_ref = true;
       uint32_t an = 0;
@@ -1412,7 +1412,7 @@ bool Reader::process_query_results_v4() {
         LOG_TRACE("  pass = {}", pass);
         is_ref = false;
       }
-      read_state_.query_results.an_values.push_back(an);
+      read_state_.query_results.an_value = an;
 
       // If all alleles do not pass the af filter, continue
       if (!pass) {

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -1382,13 +1382,15 @@ bool Reader::process_query_results_v4() {
       int allele_index = 0;
       bool is_ref = true;
       uint32_t an = 0;
-      if (af_filter_->array_version() > 2) {
-        normalize(alleles);
-      }
       for (auto&& allele : alleles) {
+        std::string normalized_ref = alleles[0];
+        std::string normalized_allele = allele;
+        if (af_filter_->array_version() > 2) {
+          normalize(normalized_ref, normalized_allele);
+        }
         auto [allele_passes, af, ac, allele_an] = af_filter_->pass(
             real_start,
-            is_ref ? "ref" : alleles[0] + "," + allele,
+            is_ref ? "ref" : normalized_ref + "," + normalized_allele,
             params_.scan_all_samples,
             num_samples);
 

--- a/libtiledbvcf/src/read/reader.cc
+++ b/libtiledbvcf/src/read/reader.cc
@@ -41,6 +41,7 @@
 #include "read/reader.h"
 #include "read/tsv_exporter.h"
 #include "utils/logger_public.h"
+#include "utils/normalize.h"
 #include "utils/utils.h"
 
 namespace tiledb {
@@ -1381,6 +1382,9 @@ bool Reader::process_query_results_v4() {
       int allele_index = 0;
       bool is_ref = true;
       uint32_t an = 0;
+      if (af_filter_->array_version() > 2) {
+        normalize(alleles);
+      }
       for (auto&& allele : alleles) {
         auto [allele_passes, af, ac, allele_an] = af_filter_->pass(
             real_start,

--- a/libtiledbvcf/src/stats/variant_stats.cc
+++ b/libtiledbvcf/src/stats/variant_stats.cc
@@ -383,7 +383,7 @@ void VariantStats::flush(bool finalize) {
   // Update results for the last locus before flushing
   update_results();
 
-  int buffered_records = ac_buffer.size();
+  int buffered_records = ac_buffer_.size();
 
   if (contig_offsets_.data() == nullptr) {
     LOG_DEBUG("[VariantStats] flush called with no records written");
@@ -418,12 +418,12 @@ void VariantStats::flush(bool finalize) {
           .set_offsets_buffer(COLUMN_STR[SAMPLE], sample_offsets_);
     }
 
-    query_->set_data_buffer("ac", ac_buffer);
-    query_->set_data_buffer("an", an_buffer);
-    query_->set_data_buffer("n_hom", n_hom_buffer);
+    query_->set_data_buffer("ac", ac_buffer_);
+    query_->set_data_buffer("an", an_buffer_);
+    query_->set_data_buffer("n_hom", n_hom_buffer_);
     if (array_version_ >= 3) {
-      query_->set_data_buffer("max_length", max_length_buffer);
-      query_->set_data_buffer("end", end_buffer);
+      query_->set_data_buffer("max_length", max_length_buffer_);
+      query_->set_data_buffer("end", end_buffer_);
     }
 
     auto st = query_->submit();
@@ -443,12 +443,12 @@ void VariantStats::flush(bool finalize) {
     sample_offsets_.clear();
     allele_buffer_.clear();
     allele_offsets_.clear();
-    ac_buffer.clear();
-    an_buffer.clear();
-    n_hom_buffer.clear();
+    ac_buffer_.clear();
+    an_buffer_.clear();
+    n_hom_buffer_.clear();
     if (array_version_ >= 3) {
-      max_length_buffer.clear();
-      end_buffer.clear();
+      max_length_buffer_.clear();
+      end_buffer_.clear();
     }
   }
 
@@ -466,12 +466,12 @@ void VariantStats::flush(bool finalize) {
           .set_offsets_buffer(COLUMN_STR[SAMPLE], sample_offsets_);
     }
 
-    query_->set_data_buffer("ac", ac_buffer);
-    query_->set_data_buffer("an", an_buffer);
-    query_->set_data_buffer("n_hom", n_hom_buffer);
+    query_->set_data_buffer("ac", ac_buffer_);
+    query_->set_data_buffer("an", an_buffer_);
+    query_->set_data_buffer("n_hom", n_hom_buffer_);
     if (array_version_ >= 3) {
-      query_->set_data_buffer("max_length", max_length_buffer);
-      query_->set_data_buffer("end", end_buffer);
+      query_->set_data_buffer("max_length", max_length_buffer_);
+      query_->set_data_buffer("end", end_buffer_);
     }
     finalize_query();
   }
@@ -509,7 +509,8 @@ inline void VariantStats::process_v3(
   HtslibValueMem val;
   int32_t end_pos = VCFUtils::get_end_pos(hdr, rec, &val);
   // Check if locus has changed
-  if (contig != contig_ || pos != pos_ || sample_name != sample_) {
+  if (contig != contig_ || pos != pos_ || sample_name != sample_ ||
+      end_pos != end_) {
     if (contig != contig_) {
       LOG_DEBUG("[VariantStats] new contig = {}", contig);
     } else if (pos < pos_) {
@@ -666,7 +667,8 @@ inline void VariantStats::process_v2(
   HtslibValueMem val;
   int32_t end_pos = VCFUtils::get_end_pos(hdr, rec, &val);
   // Check if locus has changed
-  if (contig != contig_ || pos != pos_ || sample_name != sample_) {
+  if (contig != contig_ || pos != pos_ || sample_name != sample_ ||
+      end_pos != end_) {
     if (contig != contig_) {
       LOG_DEBUG("[VariantStats] new contig = {}", contig);
     } else if (pos < pos_) {
@@ -806,20 +808,70 @@ std::string VariantStats::get_uri(const std::string& root_uri, bool relative) {
 void VariantStats::update_results() {
   if (values_.size() > 0) {
     for (auto& [allele, value] : values_) {
-      contig_offsets_.push_back(contig_buffer_.size());
-      contig_buffer_ += contig_;
-      pos_buffer_.push_back(pos_);
-      sample_offsets_.push_back(sample_buffer_.size());
-      sample_buffer_ += sample_;
-      allele_offsets_.push_back(allele_buffer_.size());
-      allele_buffer_ += allele;
-      ac_buffer.push_back(value.ac);
-      an_buffer.push_back(value.an);
-      n_hom_buffer.push_back(value.n_hom);
+      auto contig_offsets_point = contig_offsets_.end();
+      auto contig_buffer_point = contig_buffer_.end();
+      auto pos_buffer_point = pos_buffer_.end();
+      auto sample_offsets_point = sample_offsets_.end();
+      auto sample_buffer_point = sample_buffer_.end();
+      auto allele_offsets_point = allele_offsets_.end();
+      auto allele_buffer_point = allele_buffer_.end();
+      auto ac_buffer_point = ac_buffer_.end();
+      auto an_buffer_point = an_buffer_.end();
+      auto n_hom_buffer_point = n_hom_buffer_.end();
+      auto end_buffer_point = end_buffer_.end();
       if (array_version_ >= 3) {
-        max_length_buffer.push_back(value.max_length);
-        end_buffer.push_back(value.end);
+        // check that we don't underrun the end buffer
+        if (end_buffer_.size() > 0)
+        // while the end coord is too low to be appended to the end, go backward
+        // until it fits in order
+        {
+          while (end_buffer_point - 1 > end_buffer_.begin() &&
+                 value.end < *(end_buffer_point - 1) &&
+                 *(pos_buffer_point - 1) == pos_ &&
+                 !strncmp(
+                     sample_buffer_.data() + *(sample_offsets_point - 1),
+                     sample_.data(),
+                     std::min(
+                         (sample_buffer_.size() - *sample_offsets_point - 1),
+                         sample_.size()))) {
+            // decrement iterators by one cell
+            contig_offsets_point--;
+            contig_buffer_point =
+                contig_buffer_.begin() + *contig_offsets_point;
+            *contig_offsets_point += contig_.length();
+            pos_buffer_point--;
+            sample_offsets_point--;
+            sample_buffer_point =
+                sample_buffer_.begin() + *sample_offsets_point;
+            *sample_offsets_point += sample_.length();
+            allele_offsets_point--;
+            allele_buffer_point =
+                allele_buffer_.begin() + *allele_offsets_point;
+            *allele_offsets_point += allele.length();
+            ac_buffer_point--;
+            an_buffer_point--;
+            n_hom_buffer_point--;
+            end_buffer_point--;
+          }
+        }
+        max_length_buffer_.push_back(value.max_length);
+        end_buffer_.insert(end_buffer_point, value.end);
       }
+      contig_offsets_.insert(
+          contig_offsets_point, contig_buffer_point - contig_buffer_.begin());
+      contig_buffer_.insert(
+          contig_buffer_point, contig_.begin(), contig_.end());
+      pos_buffer_.insert(pos_buffer_point, pos_);
+      sample_offsets_.insert(
+          sample_offsets_point, sample_buffer_point - sample_buffer_.begin());
+      sample_buffer_.insert(
+          sample_buffer_point, sample_.begin(), sample_.end());
+      allele_offsets_.insert(
+          allele_offsets_point, allele_buffer_point - allele_buffer_.begin());
+      allele_buffer_.insert(allele_buffer_point, allele.begin(), allele.end());
+      ac_buffer_.insert(ac_buffer_point, value.ac);
+      an_buffer_.insert(an_buffer_point, value.an);
+      n_hom_buffer_.insert(n_hom_buffer_point, value.n_hom);
     }
     values_.clear();
   }

--- a/libtiledbvcf/src/stats/variant_stats.cc
+++ b/libtiledbvcf/src/stats/variant_stats.cc
@@ -507,7 +507,7 @@ inline void VariantStats::process_v3(
   }
 
   HtslibValueMem val;
-  int32_t end_pos = VCFUtils::get_end_pos(hdr, rec, &val);
+  uint32_t end_pos = VCFUtils::get_end_pos(hdr, rec, &val);
   // Check if locus has changed
   if (contig != contig_ || pos != pos_ || sample_name != sample_ ||
       end_pos != end_) {
@@ -665,7 +665,7 @@ inline void VariantStats::process_v2(
   }
 
   HtslibValueMem val;
-  int32_t end_pos = VCFUtils::get_end_pos(hdr, rec, &val);
+  uint32_t end_pos = VCFUtils::get_end_pos(hdr, rec, &val);
   // Check if locus has changed
   if (contig != contig_ || pos != pos_ || sample_name != sample_ ||
       end_pos != end_) {

--- a/libtiledbvcf/src/stats/variant_stats.cc
+++ b/libtiledbvcf/src/stats/variant_stats.cc
@@ -634,12 +634,12 @@ inline void VariantStats::process_v3(
       if (gt[i] == 0) {
         values_[ref_key].ac += count_delta_;
         values_[ref_key].an = ngt * count_delta_;
-        values_[ref_key].end = end_;
+        values_[ref_key].end = end_pos;
         values_[ref_key].max_length = max_length_;
       } else {
         values_[alt].ac += count_delta_;
         values_[alt].an = ngt * count_delta_;
-        values_[alt].end = end_;
+        values_[alt].end = end_pos;
         values_[alt].max_length = max_length_;
       }
 
@@ -776,12 +776,12 @@ inline void VariantStats::process_v2(
       if (gt[i] == 0) {
         values_["ref"].ac += count_delta_;
         values_["ref"].an = ngt * count_delta_;
-        values_["ref"].end = end_;
+        values_["ref"].end = end_pos;
         values_["ref"].max_length = max_length_;
       } else {
         values_[alt].ac += count_delta_;
         values_[alt].an = ngt * count_delta_;
-        values_[alt].end = end_;
+        values_[alt].end = end_pos;
         values_[alt].max_length = max_length_;
       }
 

--- a/libtiledbvcf/src/stats/variant_stats.cc
+++ b/libtiledbvcf/src/stats/variant_stats.cc
@@ -28,6 +28,7 @@
 #include <algorithm>
 #include <stdexcept>
 #include "utils/logger_public.h"
+#include "utils/normalize.h"
 #include "utils/utils.h"
 #include "vcf/htslib_value.h"
 #include "vcf/vcf_utils.h"
@@ -604,7 +605,7 @@ inline void VariantStats::process_v3(
       }
     }
     normalized_alleles.push_back({ref, true});
-    // TODO: normalize here; normalized_alleles isn't complete until this is
+    normalize(normalized_alleles);
     normalized_alleles.pop_back();
     // done
   }

--- a/libtiledbvcf/src/stats/variant_stats.cc
+++ b/libtiledbvcf/src/stats/variant_stats.cc
@@ -25,6 +25,7 @@
  */
 
 #include "variant_stats.h"
+#include <algorithm>
 #include <stdexcept>
 #include "utils/logger_public.h"
 #include "utils/utils.h"
@@ -831,8 +832,8 @@ void VariantStats::update_results() {
                  !strncmp(
                      sample_buffer_.data() + *(sample_offsets_point - 1),
                      sample_.data(),
-                     std::min(
-                         (sample_buffer_.size() - *sample_offsets_point - 1),
+                     std::min<uint32_t>(
+                         (sample_buffer_.size() - *sample_offsets_point),
                          sample_.size()))) {
             // decrement iterators by one cell
             contig_offsets_point--;

--- a/libtiledbvcf/src/stats/variant_stats.h
+++ b/libtiledbvcf/src/stats/variant_stats.h
@@ -375,7 +375,7 @@ class VariantStats {
    * @param alt Alternate allele
    * @return std::string ALT string
    */
-  std::string alt_string(std::string ref, std::string alt);
+  std::string alt_string_v3(char* ref, char* alt);
 };
 
 }  // namespace tiledb::vcf

--- a/libtiledbvcf/src/stats/variant_stats.h
+++ b/libtiledbvcf/src/stats/variant_stats.h
@@ -300,11 +300,11 @@ class VariantStats {
   // Buffer for allele offsets
   std::vector<uint64_t> allele_offsets_;
 
-  std::vector<int32_t> ac_buffer;
-  std::vector<int32_t> an_buffer;
-  std::vector<int32_t> n_hom_buffer;
-  std::vector<uint32_t> max_length_buffer;
-  std::vector<uint32_t> end_buffer;
+  std::vector<int32_t> ac_buffer_;
+  std::vector<int32_t> an_buffer_;
+  std::vector<int32_t> n_hom_buffer_;
+  std::vector<uint32_t> max_length_buffer_;
+  std::vector<uint32_t> end_buffer_;
 
   // Reusable htslib buffer for bcf_get_* functions
   int* dst_ = nullptr;

--- a/libtiledbvcf/src/stats/variant_stats.h
+++ b/libtiledbvcf/src/stats/variant_stats.h
@@ -367,6 +367,15 @@ class VariantStats {
    * @return std::string ALT string
    */
   std::string alt_string(char* ref, char* alt);
+
+  /**
+   * @brief Create an ALT string from the reference and alternate alleles.
+   *
+   * @param ref Reference allele
+   * @param alt Alternate allele
+   * @return std::string ALT string
+   */
+  std::string alt_string(std::string ref, std::string alt);
 };
 
 }  // namespace tiledb::vcf

--- a/libtiledbvcf/src/stats/variant_stats_reader.cc
+++ b/libtiledbvcf/src/stats/variant_stats_reader.cc
@@ -184,6 +184,15 @@ VariantStatsReader::VariantStatsReader(
   auto uri = VariantStats::get_uri(group);
   LOG_DEBUG("[VariantStatsReader] Opening array {}", uri);
   array_ = std::make_shared<Array>(*ctx, uri, TILEDB_READ);
+  const void* alt_max = 0;
+    tiledb_datatype_t alt_max_datatype = TILEDB_ANY;
+    uint32_t alt_max_num = 0;
+    array_->get_metadata(
+        "max_length", &alt_max_datatype, &alt_max_num, &alt_max);
+    if (alt_max)
+      if (alt_max_datatype == TILEDB_INT32 && alt_max_num == 1) {
+          af_map_.max_length = *((int32_t*)alt_max);
+      }
   const void* variant_stats_version_read;
   uint32_t& variant_stats_version = af_map_.array_version;
   tiledb_datatype_t version_datatype;

--- a/libtiledbvcf/src/stats/variant_stats_reader.cc
+++ b/libtiledbvcf/src/stats/variant_stats_reader.cc
@@ -278,7 +278,7 @@ void VariantStatsReader::compute_af_worker_() {
 
   // Setup the query
   ManagedQuery mq(array_, "variant_stats", TILEDB_UNORDERED);
-  mq.select_columns({"pos", "allele", "ac"});
+  mq.select_columns({"pos", "sample", "allele", "ac", "an", "end"});
   mq.select_point<std::string>("contig", regions_.front().seq_name);
   for (auto& region : regions_) {
     LOG_DEBUG("[VariantStatsReader] compute_af for region={}", region.to_str());

--- a/libtiledbvcf/src/stats/variant_stats_reader.cc
+++ b/libtiledbvcf/src/stats/variant_stats_reader.cc
@@ -178,14 +178,14 @@ std::tuple<float, uint32_t, uint32_t> AFMap::af_v3(
   // We don't know that allele was called in this sample. Ask nicely for the
   // allele count.
   auto next_allele = pos_map.second.find(allele);
+  bool is_ref_block = allele == "ref";
 
   // First multiply by 1.0 to force a float type, then look up AC from the
   // above iterator. Substitute 0 for the AC value if it is absent in pos_map.
   // Divide by AN (pos_map.first) to get AF.
   if (next_allele == pos_map.second.end()) {
-    return {0, 0, pos_map.first + an_sum_};
+    return {0, is_ref_block ? ac_sum_ : 0, pos_map.first + an_sum_};
   }
-  bool is_ref_block = next_allele->first == "ref";
   return {
       1.0 * (next_allele->second + (is_ref_block ? ac_sum_ : 0)) /
           (pos_map.first + an_sum_),
@@ -214,13 +214,14 @@ std::tuple<float, uint32_t, uint32_t> AFMap::af_v3(
   decltype(pos_map.second)::const_iterator next_allele =
       pos_map.second.find(allele);
 
+  bool is_ref_block = allele == "ref";
+
   // First multiply by 1.0 to force a float type, then look up AC from the
   // above iterator. Substitute 0 for the AC value if it is absent in pos_map.
   // Divide by AN (pos_map.first) to get AF.
   if (next_allele == pos_map.second.end()) {
-    return {0, 0, num_samples / 2 + an_sum_};
+    return {0, is_ref_block ? ac_sum_ : 0, num_samples / 2 + an_sum_};
   }
-  bool is_ref_block = next_allele->first == "ref";
   return {
       next_allele->second +
           (is_ref_block ? ac_sum_ : 0) / (num_samples * 2 + an_sum_),

--- a/libtiledbvcf/src/stats/variant_stats_reader.cc
+++ b/libtiledbvcf/src/stats/variant_stats_reader.cc
@@ -270,7 +270,9 @@ std::tuple<bool, float, uint32_t, uint32_t> VariantStatsReader::pass(
     const std::string& allele,
     bool scan_all_samples,
     size_t num_samples) {
-  af_map_.advance_to_ref_block(pos);
+  if (array_version() > 2) {
+    af_map_.advance_to_ref_block(pos);
+  }
   if (!allele.compare("<NON_REF>")) {
     // TODO: replace placeholder return values if necessary
     return {false, 0.0, 0, 0};

--- a/libtiledbvcf/src/stats/variant_stats_reader.cc
+++ b/libtiledbvcf/src/stats/variant_stats_reader.cc
@@ -26,6 +26,7 @@
 
 #include <algorithm>
 #include <regex>
+#include <stdexcept>
 
 #include "variant_stats_reader.h"
 
@@ -70,6 +71,15 @@ bool AFMap::RefBlockComp::operator()(
 }
 
 inline void AFMap::advance_to_ref_block(uint32_t pos) {
+  if (pos + 1 == active_pos_) {
+    return;
+  }
+  if (pos + 1 < active_pos_) {
+    throw std::runtime_error(
+        "[VariantStatsReader] ref block computation performed on incompletely "
+        "sorted positions");
+  }
+  active_pos_++;
   // ref blocks entering scope
   while (selected_ref_block_ != ref_block_cache_.end() &&
          selected_ref_block_->start <= pos) {
@@ -80,8 +90,8 @@ inline void AFMap::advance_to_ref_block(uint32_t pos) {
   // ref blocks exiting scope
   while (selected_ref_block_end_ != ref_block_by_end_.end() &&
          (**selected_ref_block_end_).end < pos) {
-    ac_sum_ -= selected_ref_block_->ac;
-    an_sum_ -= selected_ref_block_->an;
+    ac_sum_ -= (**selected_ref_block_end_).ac;
+    an_sum_ -= (**selected_ref_block_end_).an;
     selected_ref_block_end_++;
   }
 }

--- a/libtiledbvcf/src/stats/variant_stats_reader.cc
+++ b/libtiledbvcf/src/stats/variant_stats_reader.cc
@@ -178,18 +178,18 @@ std::tuple<float, uint32_t, uint32_t> AFMap::af_v3(
   // We don't know that allele was called in this sample. Ask nicely for the
   // allele count.
   auto next_allele = pos_map.second.find(allele);
-  bool is_ref_block = allele == "ref";
+  bool is_ref = allele == "ref";
 
   // First multiply by 1.0 to force a float type, then look up AC from the
   // above iterator. Substitute 0 for the AC value if it is absent in pos_map.
   // Divide by AN (pos_map.first) to get AF.
   if (next_allele == pos_map.second.end()) {
-    return {0, is_ref_block ? ac_sum_ : 0, pos_map.first + an_sum_};
+    return {0, is_ref ? ac_sum_ : 0, pos_map.first + an_sum_};
   }
   return {
-      1.0 * (next_allele->second + (is_ref_block ? ac_sum_ : 0)) /
+      1.0 * (next_allele->second + (is_ref ? ac_sum_ : 0)) /
           (pos_map.first + an_sum_),
-      next_allele->second + (is_ref_block ? ac_sum_ : 0),
+      next_allele->second + (is_ref ? ac_sum_ : 0),
       (pos_map.first + an_sum_)};
 }
 
@@ -214,18 +214,18 @@ std::tuple<float, uint32_t, uint32_t> AFMap::af_v3(
   decltype(pos_map.second)::const_iterator next_allele =
       pos_map.second.find(allele);
 
-  bool is_ref_block = allele == "ref";
+  bool is_ref = allele == "ref";
 
   // First multiply by 1.0 to force a float type, then look up AC from the
   // above iterator. Substitute 0 for the AC value if it is absent in pos_map.
   // Divide by AN (pos_map.first) to get AF.
   if (next_allele == pos_map.second.end()) {
-    return {0, is_ref_block ? ac_sum_ : 0, num_samples / 2 + an_sum_};
+    return {0, is_ref ? ac_sum_ : 0, num_samples / 2 + an_sum_};
   }
   return {
       next_allele->second +
-          (is_ref_block ? ac_sum_ : 0) / (num_samples * 2 + an_sum_),
-      next_allele->second + (is_ref_block ? ac_sum_ : 0),
+          (is_ref ? ac_sum_ : 0) / (num_samples * 2 + an_sum_),
+      next_allele->second + (is_ref ? ac_sum_ : 0),
       num_samples * 2 + an_sum_};
 }
 

--- a/libtiledbvcf/src/stats/variant_stats_reader.cc
+++ b/libtiledbvcf/src/stats/variant_stats_reader.cc
@@ -145,8 +145,7 @@ std::tuple<float, uint32_t, uint32_t> AFMap::af(
 
   // We don't know that allele was called in this sample. Ask nicely for the
   // allele count.
-  decltype(pos_map.second)::const_iterator next_allele =
-      pos_map.second.find(allele);
+  auto next_allele = pos_map.second.find(allele);
 
   // First multiply by 1.0 to force a float type, then look up AC from the
   // above iterator. Substitute 0 for the AC value if it is absent in pos_map.
@@ -327,10 +326,11 @@ VariantStatsReader::VariantStatsReader(
   tiledb_datatype_t alt_max_datatype = TILEDB_ANY;
   uint32_t alt_max_num = 0;
   array_->get_metadata("max_length", &alt_max_datatype, &alt_max_num, &alt_max);
-  if (alt_max)
+  if (alt_max) {
     if (alt_max_datatype == TILEDB_INT32 && alt_max_num == 1) {
       max_length_ = *((int32_t*)alt_max);
     }
+  }
   const void* variant_stats_version_read;
   uint32_t& variant_stats_version = af_map_.array_version;
   tiledb_datatype_t version_datatype;

--- a/libtiledbvcf/src/stats/variant_stats_reader.cc
+++ b/libtiledbvcf/src/stats/variant_stats_reader.cc
@@ -96,6 +96,138 @@ inline void AFMap::advance_to_ref_block(uint32_t pos) {
   }
 }
 
+std::tuple<float, uint32_t, uint32_t> AFMap::af(
+    uint32_t pos, const std::string& allele) {
+  // calculate af = ac / an
+  std::unordered_map<
+      uint32_t,
+      std::pair<int, std::unordered_map<std::string, int>>>::const_iterator
+      pos_map_iterator = ac_map_.find(pos);
+
+  // Return -1.0 if the allele was not called
+  if (pos_map_iterator == ac_map_.end()) {
+    return {-1.0, 0, 0};
+  }
+
+  const auto pos_map = pos_map_iterator->second;
+
+  // We don't know that allele was called in this sample. Ask nicely for the
+  // allele count.
+  auto next_allele = pos_map.second.find(allele);
+
+  // First multiply by 1.0 to force a float type, then look up AC from the
+  // above iterator. Substitute 0 for the AC value if it is absent in pos_map.
+  // Divide by AN (pos_map.first) to get AF.
+  if (next_allele == pos_map.second.end()) {
+    return {0, 0, pos_map.first};
+  }
+  return {
+      1.0 * next_allele->second / pos_map.first,
+      next_allele->second,
+      pos_map.first};
+}
+
+std::tuple<float, uint32_t, uint32_t> AFMap::af(
+    uint32_t pos, const std::string& allele, size_t num_samples) {
+  // calculate af = ac / an
+  std::unordered_map<
+      uint32_t,
+      std::pair<int, std::unordered_map<std::string, int>>>::const_iterator
+      pos_map_iterator = ac_map_.find(pos);
+
+  // Return -1.0 if the allele was not called
+  if (pos_map_iterator == ac_map_.end()) {
+    return {-1.0, 0, 0};
+  }
+
+  const std::pair<int, std::unordered_map<std::string, int>>& pos_map =
+      pos_map_iterator->second;
+
+  // We don't know that allele was called in this sample. Ask nicely for the
+  // allele count.
+  decltype(pos_map.second)::const_iterator next_allele =
+      pos_map.second.find(allele);
+
+  // First multiply by 1.0 to force a float type, then look up AC from the
+  // above iterator. Substitute 0 for the AC value if it is absent in pos_map.
+  // Divide by AN (pos_map.first) to get AF.
+  if (next_allele == pos_map.second.end()) {
+    return {0, 0, num_samples * 2};
+  }
+  return {
+      1.0 * next_allele->second / num_samples / 2,
+      next_allele->second,
+      num_samples * 2};
+}
+
+std::tuple<float, uint32_t, uint32_t> AFMap::af_v3(
+    uint32_t pos, const std::string& allele) {
+  // calculate af = ac / an
+  std::unordered_map<
+      uint32_t,
+      std::pair<int, std::unordered_map<std::string, int>>>::const_iterator
+      pos_map_iterator = ac_map_.find(pos);
+
+  // Return -1.0 if the allele was not called
+  if (pos_map_iterator == ac_map_.end()) {
+    return {-1.0, 0, 0};
+  }
+
+  const auto pos_map = pos_map_iterator->second;
+
+  // We don't know that allele was called in this sample. Ask nicely for the
+  // allele count.
+  auto next_allele = pos_map.second.find(allele);
+
+  // First multiply by 1.0 to force a float type, then look up AC from the
+  // above iterator. Substitute 0 for the AC value if it is absent in pos_map.
+  // Divide by AN (pos_map.first) to get AF.
+  if (next_allele == pos_map.second.end()) {
+    return {0, 0, pos_map.first + an_sum_};
+  }
+  bool is_ref_block = next_allele->first == "ref";
+  return {
+      1.0 * (next_allele->second + (is_ref_block ? ac_sum_ : 0)) /
+          (pos_map.first + an_sum_),
+      next_allele->second + (is_ref_block ? ac_sum_ : 0),
+      (pos_map.first + an_sum_)};
+}
+
+std::tuple<float, uint32_t, uint32_t> AFMap::af_v3(
+    uint32_t pos, const std::string& allele, size_t num_samples) {
+  // calculate af = ac / an
+  std::unordered_map<
+      uint32_t,
+      std::pair<int, std::unordered_map<std::string, int>>>::const_iterator
+      pos_map_iterator = ac_map_.find(pos);
+
+  // Return -1.0 if the allele was not called
+  if (pos_map_iterator == ac_map_.end()) {
+    return {-1.0, 0, 0};
+  }
+
+  const std::pair<int, std::unordered_map<std::string, int>>& pos_map =
+      pos_map_iterator->second;
+
+  // We don't know that allele was called in this sample. Ask nicely for the
+  // allele count.
+  decltype(pos_map.second)::const_iterator next_allele =
+      pos_map.second.find(allele);
+
+  // First multiply by 1.0 to force a float type, then look up AC from the
+  // above iterator. Substitute 0 for the AC value if it is absent in pos_map.
+  // Divide by AN (pos_map.first) to get AF.
+  if (next_allele == pos_map.second.end()) {
+    return {0, 0, num_samples / 2 + an_sum_};
+  }
+  bool is_ref_block = next_allele->first == "ref";
+  return {
+      next_allele->second +
+          (is_ref_block ? ac_sum_ : 0) / (num_samples * 2 + an_sum_),
+      next_allele->second + (is_ref_block ? ac_sum_ : 0),
+      num_samples * 2 + an_sum_};
+}
+
 void AFMap::finalize_ref_block_cache() {
   std::sort(ref_block_cache_.begin(), ref_block_cache_.end(), RefBlockComp());
   ref_block_by_end_.clear();

--- a/libtiledbvcf/src/stats/variant_stats_reader.cc
+++ b/libtiledbvcf/src/stats/variant_stats_reader.cc
@@ -47,10 +47,10 @@ inline int pos_comparator(const void* a, const void* b) {
 
 bool AFMap::RefBlockComp::operator()(
     const RefBlock& a, const RefBlock& b) const {
-  if (a.start > b.start) {
+  if (a.start < b.start) {
     return true;
   } else {
-    if (a.end > b.end) {
+    if (a.start == b.start && a.end < b.end) {
       return true;
     }
   }
@@ -59,10 +59,10 @@ bool AFMap::RefBlockComp::operator()(
 
 bool AFMap::RefBlockComp::operator()(
     const RefBlock* a, const RefBlock* b) const {
-  if (a->end > b->end) {
+  if (a->end < b->end) {
     return true;
   } else {
-    if (a->start > b->start) {
+    if (a->end == b->end && a->start < b->start) {
       return true;
     }
   }
@@ -89,6 +89,7 @@ inline void AFMap::advance_to_ref_block(uint32_t pos) {
 void AFMap::finalize_ref_block_cache() {
   std::sort(ref_block_cache_.begin(), ref_block_cache_.end(), RefBlockComp());
   selected_ref_block_ = ref_block_cache_.begin();
+  ref_block_by_end_.clear();
   for (RefBlock& selected_block : ref_block_cache_) {
     ref_block_by_end_.push_back(&selected_block);
   }
@@ -212,6 +213,7 @@ void VariantStatsReader::compute_af() {
   } else {
     compute_af_worker_();
   }
+  af_map_.finalize_ref_block_cache();
 }
 
 void VariantStatsReader::set_condition(std::string condition) {
@@ -224,7 +226,6 @@ void VariantStatsReader::wait() {
       TRY_CATCH_THROW(compute_future_.wait());
     }
   }
-  af_map_.finalize_ref_block_cache();
 }
 
 std::pair<bool, float> VariantStatsReader::pass(

--- a/libtiledbvcf/src/stats/variant_stats_reader.cc
+++ b/libtiledbvcf/src/stats/variant_stats_reader.cc
@@ -184,7 +184,10 @@ std::tuple<float, uint32_t, uint32_t> AFMap::af_v3(
   // above iterator. Substitute 0 for the AC value if it is absent in pos_map.
   // Divide by AN (pos_map.first) to get AF.
   if (next_allele == pos_map.second.end()) {
-    return {0, is_ref ? ac_sum_ : 0, pos_map.first + an_sum_};
+    return {
+        is_ref ? 1.0 * ac_sum_ / (pos_map.first + an_sum_) : 0,
+        is_ref ? ac_sum_ : 0,
+        pos_map.first + an_sum_};
   }
   return {
       1.0 * (next_allele->second + (is_ref ? ac_sum_ : 0)) /
@@ -220,11 +223,14 @@ std::tuple<float, uint32_t, uint32_t> AFMap::af_v3(
   // above iterator. Substitute 0 for the AC value if it is absent in pos_map.
   // Divide by AN (pos_map.first) to get AF.
   if (next_allele == pos_map.second.end()) {
-    return {0, is_ref ? ac_sum_ : 0, num_samples / 2 + an_sum_};
+    return {
+        is_ref ? 1.0 * ac_sum_ / (num_samples * 2 + an_sum_) : 0,
+        is_ref ? ac_sum_ : 0,
+        num_samples / 2 + an_sum_};
   }
   return {
-      next_allele->second +
-          (is_ref ? ac_sum_ : 0) / (num_samples * 2 + an_sum_),
+      1.0 * (next_allele->second + (is_ref ? ac_sum_ : 0)) /
+          (num_samples * 2 + an_sum_),
       next_allele->second + (is_ref ? ac_sum_ : 0),
       num_samples * 2 + an_sum_};
 }

--- a/libtiledbvcf/src/stats/variant_stats_reader.h
+++ b/libtiledbvcf/src/stats/variant_stats_reader.h
@@ -317,6 +317,9 @@ class AFMap {
 
   uint32_t array_version = 2;
 
+  /** maximum length to extend variant stats query */
+  int32_t max_length = 0;
+
  private:
   struct RefBlock {
     uint32_t start;
@@ -351,8 +354,13 @@ class AFMap {
       std::pair<int, std::unordered_map<std::string, int>>>
       ac_map_;
 
+  /** track running sum of AC when computing IAF for GVCF */
   uint64_t ac_sum_ = 0;
+
+  /** track running sum of AN when computing IAF for GVCF */
   uint64_t an_sum_ = 0;
+
+  /** track position when computing IAF for GVCF */
   uint64_t active_pos_ = 0;
 
   /** ref block, selected from ref_block_cache_, that demarcates the beginning

--- a/libtiledbvcf/src/stats/variant_stats_reader.h
+++ b/libtiledbvcf/src/stats/variant_stats_reader.h
@@ -227,12 +227,11 @@ class AFMap {
     if (next_allele == pos_map.second.end()) {
       return {0, 0, pos_map.first + an_sum_};
     }
+    bool is_ref_block = next_allele->first == "ref";
     return {
-        1.0 *
-            (next_allele->second +
-             (next_allele->first == "ref" ? ac_sum_ : 0)) /
+        1.0 * (next_allele->second + (is_ref_block ? ac_sum_ : 0)) /
             (pos_map.first + an_sum_),
-        next_allele->second + (next_allele->first == "ref" ? ac_sum_ : 0),
+        next_allele->second + (is_ref_block ? ac_sum_ : 0),
         (pos_map.first + an_sum_)};
   }
 
@@ -272,10 +271,11 @@ class AFMap {
     if (next_allele == pos_map.second.end()) {
       return {0, 0, num_samples / 2 + an_sum_};
     }
+    bool is_ref_block = next_allele->first == "ref";
     return {
-        next_allele->second + (next_allele->first == "ref" ? ac_sum_ : 0) /
-                                  (num_samples * 2 + an_sum_),
-        next_allele->second + (next_allele->first == "ref" ? ac_sum_ : 0),
+        next_allele->second +
+            (is_ref_block ? ac_sum_ : 0) / (num_samples * 2 + an_sum_),
+        next_allele->second + (is_ref_block ? ac_sum_ : 0),
         num_samples * 2 + an_sum_};
   }
 

--- a/libtiledbvcf/src/stats/variant_stats_reader.h
+++ b/libtiledbvcf/src/stats/variant_stats_reader.h
@@ -291,6 +291,10 @@ class AFMap {
    */
   void clear() {
     ac_map_.clear();
+    ref_block_cache_.clear();
+    ac_sum_ = 0;
+    an_sum_ = 0;
+    active_pos_ = 0;
   }
 
   /**
@@ -349,6 +353,7 @@ class AFMap {
 
   uint64_t ac_sum_ = 0;
   uint64_t an_sum_ = 0;
+  uint64_t active_pos_ = 0;
 
   /** ref block, selected from ref_block_cache_, that demarcates the beginning
    * of the overlap  with the current position */

--- a/libtiledbvcf/src/stats/variant_stats_reader.h
+++ b/libtiledbvcf/src/stats/variant_stats_reader.h
@@ -235,8 +235,11 @@ class AFMap {
       return {0, 0, pos_map.first + an_sum_};
     }
     return {
-        1.0 * (next_allele->second + ac_sum_) / (pos_map.first + an_sum_),
-        (next_allele->second + ac_sum_),
+        1.0 *
+            (next_allele->second +
+             (next_allele->first == "ref" ? ac_sum_ : 0)) /
+            (pos_map.first + an_sum_),
+        next_allele->second + (next_allele->first == "ref" ? ac_sum_ : 0),
         (pos_map.first + an_sum_)};
   }
 
@@ -277,8 +280,9 @@ class AFMap {
       return {0, 0, num_samples / 2 + an_sum_};
     }
     return {
-        1.0 * (next_allele->second + ac_sum_) / (num_samples * 2 + an_sum_),
-        next_allele->second + ac_sum_,
+        next_allele->second + (next_allele->first == "ref" ? ac_sum_ : 0) /
+                                  (num_samples * 2 + an_sum_),
+        next_allele->second + (next_allele->first == "ref" ? ac_sum_ : 0),
         num_samples * 2 + an_sum_};
   }
 

--- a/libtiledbvcf/src/stats/variant_stats_reader.h
+++ b/libtiledbvcf/src/stats/variant_stats_reader.h
@@ -90,11 +90,10 @@ class AFMap {
             ac_map_[pos].second[allele],
             ac_map_[pos].first);
       }
-    }
-
-    if (should_tally) {
-      allele_aggregate_size_ += allele.length();
-      allele_cardinality_++;
+      if (should_tally) {
+        allele_aggregate_size_ += allele.length();
+        allele_cardinality_++;
+      }
     }
   }
 

--- a/libtiledbvcf/src/stats/variant_stats_reader.h
+++ b/libtiledbvcf/src/stats/variant_stats_reader.h
@@ -58,14 +58,13 @@ class AFMap {
       int ac,
       int an = 0,
       uint32_t end = 0) {
-    // Should this insertion be tallied for contributing to transport (Arrow)
-    // buffer size?
-
     // add encountered ref block to the cache
     if (array_version >= 3 && allele == "nr") {
       ref_block_cache_.push_back({pos, end, ac, an});
     } else {
       if (pos >= min_pos) {
+        // Should this insertion be tallied for contributing to transport
+        // (Arrow)  buffer size?
         bool should_tally =
             !ac_map_.contains(pos) || !ac_map_[pos].second.contains(allele);
         // add ac to the an for this position

--- a/libtiledbvcf/src/stats/variant_stats_reader.h
+++ b/libtiledbvcf/src/stats/variant_stats_reader.h
@@ -122,36 +122,8 @@ class AFMap {
    * @param allele Allele value
    * @return float Allele Frequency
    */
-  std::tuple<float, uint32_t, uint32_t> af(
-      uint32_t pos, const std::string& allele) {
-    // calculate af = ac / an
-    std::unordered_map<
-        uint32_t,
-        std::pair<int, std::unordered_map<std::string, int>>>::const_iterator
-        pos_map_iterator = ac_map_.find(pos);
-
-    // Return -1.0 if the allele was not called
-    if (pos_map_iterator == ac_map_.end()) {
-      return {-1.0, 0, 0};
-    }
-
-    const auto pos_map = pos_map_iterator->second;
-
-    // We don't know that allele was called in this sample. Ask nicely for the
-    // allele count.
-    auto next_allele = pos_map.second.find(allele);
-
-    // First multiply by 1.0 to force a float type, then look up AC from the
-    // above iterator. Substitute 0 for the AC value if it is absent in pos_map.
-    // Divide by AN (pos_map.first) to get AF.
-    if (next_allele == pos_map.second.end()) {
-      return {0, 0, pos_map.first};
-    }
-    return {
-        1.0 * next_allele->second / pos_map.first,
-        next_allele->second,
-        pos_map.first};
-  }
+  inline std::tuple<float, uint32_t, uint32_t> af(
+      uint32_t pos, const std::string& allele);
 
   /**
    * @brief Compute the Allele Frequency for an allele at the given position,
@@ -162,38 +134,8 @@ class AFMap {
    * @param num_samples Number of samples in the entire dataset
    * @return float Allele Frequency
    */
-  std::tuple<float, uint32_t, uint32_t> af(
-      uint32_t pos, const std::string& allele, size_t num_samples) {
-    // calculate af = ac / an
-    std::unordered_map<
-        uint32_t,
-        std::pair<int, std::unordered_map<std::string, int>>>::const_iterator
-        pos_map_iterator = ac_map_.find(pos);
-
-    // Return -1.0 if the allele was not called
-    if (pos_map_iterator == ac_map_.end()) {
-      return {-1.0, 0, 0};
-    }
-
-    const std::pair<int, std::unordered_map<std::string, int>>& pos_map =
-        pos_map_iterator->second;
-
-    // We don't know that allele was called in this sample. Ask nicely for the
-    // allele count.
-    decltype(pos_map.second)::const_iterator next_allele =
-        pos_map.second.find(allele);
-
-    // First multiply by 1.0 to force a float type, then look up AC from the
-    // above iterator. Substitute 0 for the AC value if it is absent in pos_map.
-    // Divide by AN (pos_map.first) to get AF.
-    if (next_allele == pos_map.second.end()) {
-      return {0, 0, num_samples * 2};
-    }
-    return {
-        1.0 * next_allele->second / num_samples / 2,
-        next_allele->second,
-        num_samples * 2};
-  }
+  inline std::tuple<float, uint32_t, uint32_t> af(
+      uint32_t pos, const std::string& allele, size_t num_samples);
 
   /**
    * @brief Compute the Allele Frequency for an allele at the given position.
@@ -202,38 +144,8 @@ class AFMap {
    * @param allele Allele value
    * @return float Allele Frequency
    */
-  std::tuple<float, uint32_t, uint32_t> af_v3(
-      uint32_t pos, const std::string& allele) {
-    // calculate af = ac / an
-    std::unordered_map<
-        uint32_t,
-        std::pair<int, std::unordered_map<std::string, int>>>::const_iterator
-        pos_map_iterator = ac_map_.find(pos);
-
-    // Return -1.0 if the allele was not called
-    if (pos_map_iterator == ac_map_.end()) {
-      return {-1.0, 0, 0};
-    }
-
-    const auto pos_map = pos_map_iterator->second;
-
-    // We don't know that allele was called in this sample. Ask nicely for the
-    // allele count.
-    auto next_allele = pos_map.second.find(allele);
-
-    // First multiply by 1.0 to force a float type, then look up AC from the
-    // above iterator. Substitute 0 for the AC value if it is absent in pos_map.
-    // Divide by AN (pos_map.first) to get AF.
-    if (next_allele == pos_map.second.end()) {
-      return {0, 0, pos_map.first + an_sum_};
-    }
-    bool is_ref_block = next_allele->first == "ref";
-    return {
-        1.0 * (next_allele->second + (is_ref_block ? ac_sum_ : 0)) /
-            (pos_map.first + an_sum_),
-        next_allele->second + (is_ref_block ? ac_sum_ : 0),
-        (pos_map.first + an_sum_)};
-  }
+  inline std::tuple<float, uint32_t, uint32_t> af_v3(
+      uint32_t pos, const std::string& allele);
 
   /**
    * @brief Compute the Allele Frequency for an allele at the given position,
@@ -244,40 +156,8 @@ class AFMap {
    * @param num_samples Number of samples in the entire dataset
    * @return float Allele Frequency
    */
-  std::tuple<float, uint32_t, uint32_t> af_v3(
-      uint32_t pos, const std::string& allele, size_t num_samples) {
-    // calculate af = ac / an
-    std::unordered_map<
-        uint32_t,
-        std::pair<int, std::unordered_map<std::string, int>>>::const_iterator
-        pos_map_iterator = ac_map_.find(pos);
-
-    // Return -1.0 if the allele was not called
-    if (pos_map_iterator == ac_map_.end()) {
-      return {-1.0, 0, 0};
-    }
-
-    const std::pair<int, std::unordered_map<std::string, int>>& pos_map =
-        pos_map_iterator->second;
-
-    // We don't know that allele was called in this sample. Ask nicely for the
-    // allele count.
-    decltype(pos_map.second)::const_iterator next_allele =
-        pos_map.second.find(allele);
-
-    // First multiply by 1.0 to force a float type, then look up AC from the
-    // above iterator. Substitute 0 for the AC value if it is absent in pos_map.
-    // Divide by AN (pos_map.first) to get AF.
-    if (next_allele == pos_map.second.end()) {
-      return {0, 0, num_samples / 2 + an_sum_};
-    }
-    bool is_ref_block = next_allele->first == "ref";
-    return {
-        next_allele->second +
-            (is_ref_block ? ac_sum_ : 0) / (num_samples * 2 + an_sum_),
-        next_allele->second + (is_ref_block ? ac_sum_ : 0),
-        num_samples * 2 + an_sum_};
-  }
+  inline std::tuple<float, uint32_t, uint32_t> af_v3(
+      uint32_t pos, const std::string& allele, size_t num_samples);
 
   /**
    * @brief Clear the map.

--- a/libtiledbvcf/src/utils/normalize.cc
+++ b/libtiledbvcf/src/utils/normalize.cc
@@ -1,0 +1,87 @@
+/**
+ * @file   normalize.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines class Logger, declared in logger.h, and the public logging
+ * functions, declared in logger_public.h.
+ */
+
+#include <utils/normalize.h>
+
+static inline std::string& get_allele(std::pair<std::string, bool>& allele) {
+  return allele.first;
+}
+
+static inline std::string& get_allele(std::string& allele) {
+  return allele;
+}
+
+static inline std::string& ref_allele(
+    std::vector<std::pair<std::string, bool>>& alleles) {
+  return alleles.back().first;
+}
+
+static inline std::string& ref_allele(std::vector<std::string>& alleles) {
+  return alleles[0];
+}
+
+namespace tiledb::vcf {
+template <typename T>
+void normalize(std::vector<T>& alleles) {
+  if (alleles.size() == 0) {
+    return;
+  }
+  size_t min_length = UINT64_MAX;
+  bool done = false;
+  for (T& allele_wrapper : alleles) {
+    min_length = std::min(min_length, get_allele(allele_wrapper).length());
+  }
+  size_t i = 1;
+  while (!done && i < min_length) {
+    for (T& allele_wrapper : alleles) {
+      std::string& allele = get_allele(allele_wrapper);
+      if (allele[allele.length() - i] !=
+          ref_allele(alleles)[ref_allele(alleles).length() - i]) {
+        done = true;
+        break;
+      }
+    }
+    if (!done) {
+      i++;
+    }
+  }
+  i--;
+  for (T& allele_wrapper : alleles) {
+    std::string& allele = get_allele(allele_wrapper);
+    allele.resize(allele.size() - i);
+  }
+}
+
+template void normalize(std::vector<std::string>&);
+template void normalize(std::vector<std::pair<std::string, bool>>&);
+}  // namespace tiledb::vcf

--- a/libtiledbvcf/src/utils/normalize.cc
+++ b/libtiledbvcf/src/utils/normalize.cc
@@ -33,49 +33,17 @@
 
 #include <utils/normalize.h>
 
-static inline std::string& get_allele(std::pair<std::string, bool>& allele) {
-  return allele.first;
-}
-
-static inline std::string& get_allele(std::string& allele) {
-  return allele;
-}
-
-static inline std::string& ref_allele(
-    std::vector<std::pair<std::string, bool>>& alleles) {
-  return alleles.back().first;
-}
-
-static inline std::string& ref_allele(std::vector<std::string>& alleles) {
-  return alleles[0];
-}
-
-template <typename T>
-static inline bool is_ref(std::string& allele, std::vector<T>& alleles) {
-  return &allele == &ref_allele(alleles);
-}
-
 namespace tiledb::vcf {
-template <typename T>
-void normalize(std::vector<T>& alleles) {
-  if (alleles.size() == 0) {
-    return;
+void normalize(std::string& ref, std::string& alt) {
+  size_t min_length = UINT64_MAX;
+  min_length = std::min(min_length, alt.length());
+  size_t i = 1;
+  if (alt[alt.length() - i] == ref[ref.length() - i]) {
+    i++;
   }
-  for (T& allele_wrapper : alleles) {
-    size_t min_length = UINT64_MAX;
-    min_length = std::min(min_length, get_allele(allele_wrapper).length());
-    size_t i = 1;
-    std::string& allele = get_allele(allele_wrapper);
-    std::string& ref = ref_allele(alleles);
-    if (!is_ref(allele, alleles) &&
-        allele[allele.length() - i] == ref[ref.length() - i]) {
-      i++;
-    }
-    i--;
-    allele.resize(allele.size() - i);
-  }
+  i--;
+  alt.resize(alt.size() - i);
+  ref.resize(ref.size() - i);
 }
 
-template void normalize(std::vector<std::string>&);
-template void normalize(std::vector<std::pair<std::string, bool>>&);
 }  // namespace tiledb::vcf

--- a/libtiledbvcf/src/utils/normalize.cc
+++ b/libtiledbvcf/src/utils/normalize.cc
@@ -50,34 +50,28 @@ static inline std::string& ref_allele(std::vector<std::string>& alleles) {
   return alleles[0];
 }
 
+template <typename T>
+static inline bool is_ref(std::string& allele, std::vector<T>& alleles) {
+  return &allele == &ref_allele(alleles);
+}
+
 namespace tiledb::vcf {
 template <typename T>
 void normalize(std::vector<T>& alleles) {
   if (alleles.size() == 0) {
     return;
   }
-  size_t min_length = UINT64_MAX;
-  bool done = false;
   for (T& allele_wrapper : alleles) {
+    size_t min_length = UINT64_MAX;
     min_length = std::min(min_length, get_allele(allele_wrapper).length());
-  }
-  size_t i = 1;
-  while (!done && i < min_length) {
-    for (T& allele_wrapper : alleles) {
-      std::string& allele = get_allele(allele_wrapper);
-      if (allele[allele.length() - i] !=
-          ref_allele(alleles)[ref_allele(alleles).length() - i]) {
-        done = true;
-        break;
-      }
-    }
-    if (!done) {
+    size_t i = 1;
+    std::string& allele = get_allele(allele_wrapper);
+    std::string& ref = ref_allele(alleles);
+    if (!is_ref(allele, alleles) &&
+        allele[allele.length() - i] == ref[ref.length() - i]) {
       i++;
     }
-  }
-  i--;
-  for (T& allele_wrapper : alleles) {
-    std::string& allele = get_allele(allele_wrapper);
+    i--;
     allele.resize(allele.size() - i);
   }
 }

--- a/libtiledbvcf/src/utils/normalize.h
+++ b/libtiledbvcf/src/utils/normalize.h
@@ -1,0 +1,44 @@
+/**
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2018 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TILEDB_VCF_NORMALIZE_H
+#define TILEDB_VCF_NORMALIZE_H
+
+#include <stdint.h>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace tiledb {
+namespace vcf {
+
+template <typename T>
+void normalize(std::vector<T>& alleles);
+
+}  // namespace vcf
+}  // namespace tiledb
+
+#endif  // TILEDB_VCF_NORMALIZE_H

--- a/libtiledbvcf/src/utils/normalize.h
+++ b/libtiledbvcf/src/utils/normalize.h
@@ -35,8 +35,7 @@
 namespace tiledb {
 namespace vcf {
 
-template <typename T>
-void normalize(std::vector<T>& alleles);
+void normalize(std::string& ref, std::string& alt);
 
 }  // namespace vcf
 }  // namespace tiledb

--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -849,7 +849,9 @@ std::pair<uint64_t, uint64_t> Writer::ingest_samples_v4(
                                 params.avg_vcf_record_size;
 
   LOG_DEBUG("Output buffer records = {}", output_buffer_records);
-  assert(output_buffer_records > 0 && output_buffer_records < UINT32_MAX);
+  assert(
+      output_buffer_records > 0 &&
+      output_buffer_records < static_cast<float>(UINT32_MAX));
 
   if (params.use_legacy_thread_task_size) {
     LOG_INFO(

--- a/libtiledbvcf/test/inputs/stats/first.vcf
+++ b/libtiledbvcf/test/inputs/stats/first.vcf
@@ -11,10 +11,11 @@
 ##contig=<ID=chrX>
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	first
 chr1	1	.	T	C,<NON_REF>	829.77	.	ExcessHet=3.0103	GT	0/1
+chr1	1	.	C	<NON_REF>	.	PASS	END=3	GT:AD	0/0:20,8
 chr1	2	.	G	GTTTA,T,<NON_REF>	1042.73	.	ExcessHet=4.8532	GT	0/1
 chr1	3	.	C	A,G	10.032	.	ExcessHet=2.0134	GT	2/2
 chr1	4	.	G	GTTTA,<NON_REF>	1042.73	.	ExcessHet=4.8532	GT	0/0
-chr1	10	.	C	<NON_REF>	.	PASS	END=65	GT:AD	0/0:20,8
+chr1	5	.	C	T	1042.73	.	ExcessHet=4.8532	GT	0/1/0
 chr2	1	.	G	GTTTA	1042.73	.	ExcessHet=4.8532	GT	./1
 chr2	1	.	G	GTTTA	1042.73	.	ExcessHet=4.8532	GT	1/.
 chr2	3	.	G	GTTTA	1042.73	.	ExcessHet=4.8532	GT	1/1

--- a/libtiledbvcf/test/inputs/stats/second.vcf
+++ b/libtiledbvcf/test/inputs/stats/second.vcf
@@ -9,7 +9,7 @@
 ##contig=<ID=chr1>
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	second
 chr1	1	.	T	C,<NON_REF>	829.77	.	ExcessHet=3.0103	GT	0/1
+chr1	2	.	C	<NON_REF>	.	PASS	END=3	GT:AD	0/0:65,4
 chr1	2	.	G	GTTTA,T,<NON_REF>	343.73	.	ExcessHet=2.8532	GT	0/1
 chr1	3	.	C	A,G	10.032	.	ExcessHet=8.34	GT	2/2
 chr1	4	.	G	GTTTA,<NON_REF>	343.73	.	ExcessHet=2.8532	GT	0/1
-chr1	10	.	C	<NON_REF>	.	PASS	END=60	GT:AD	0/0:65,4

--- a/libtiledbvcf/test/run-cli-tests.sh
+++ b/libtiledbvcf/test/run-cli-tests.sh
@@ -494,7 +494,7 @@ mkdir -p ${upload_dir}/outputs
 $tilevcf create -u ${upload_dir}/pre_test3 --enable-variant-stats --enable-allele-count --log-level trace --variant-stats-version 3
 $tilevcf store -u ${upload_dir}/pre_test3 --log-level trace ${upload_dir}/stats/*.vcf.gz
 $tilevcf export -u ${upload_dir}/pre_test3 -d ${upload_dir}/outputs -Ov --af-filter '< 0.2' --log-level trace
-test -e ${upload_dir}/outputs/first.vcf || exit 1
+test ! -e ${upload_dir}/outputs/first.vcf || exit 1
 test -e ${upload_dir}/outputs/second.vcf || exit 1
 test ! -e ${upload_dir}/outputs/third.vcf || exit 1
 test ! -e ${upload_dir}/outputs/fourth.vcf || exit 1
@@ -503,7 +503,7 @@ test ! -e ${upload_dir}/outputs/sixth.vcf || exit 1
 test ! -e ${upload_dir}/outputs/seventh.vcf || exit 1
 test ! -e ${upload_dir}/outputs/eighth.vcf || exit 1
 
-[ $(bcftools view -H ${upload_dir}/outputs/second.vcf  | wc -l) == "2" ] || exit 1
+[ $(bcftools view -H ${upload_dir}/outputs/second.vcf  | wc -l) == "1" ] || exit 1
 
 rm -rf ${upload_dir}/outputs
 


### PR DESCRIPTION
Take ref blocks into account when computing AF, and make two new fields: `info_TILEDB_IAC` and `info_TILEDB_IAN` available to data frames.