### PR TITLE
Hotfix: pin numpy < 2

### DIFF
--- a/apis/python/conda-env.yml
+++ b/apis/python/conda-env.yml
@@ -2,6 +2,7 @@ name: tiledbvcf-py
 channels:
   - conda-forge
 dependencies:
+  - numpy<2
   - python<3.12 # based on available tiledb-py wheels
   - pybind11
   - pyarrow>=14.0.2 # for pyarrow security fix

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 
-dependencies = ["pandas", "pyarrow", "pyarrow-hotfix"]
+dependencies = ["pandas", "pyarrow", "pyarrow-hotfix", "numpy<2"]
 
 [project.optional-dependencies]
 test = ["dask[distributed]", "pytest", "tiledb"]

--- a/ci/gha-win-env.yml
+++ b/ci/gha-win-env.yml
@@ -11,7 +11,7 @@ dependencies:
   - tiledb=2.15
   - vs2019_win-64
   # build tiledbvcf-py
-  - numpy
+  - numpy<2
   - pandas<2.0
   - pyarrow=9.0
   - pyarrow-hotfix

--- a/ci/nightly/requirements.txt
+++ b/ci/nightly/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy<2
 pandas
 pyarrow==11
 pyarrow-hotfix


### PR DESCRIPTION
Both the nightlies in this repo (#730) and my centralized nightlies (https://github.com/jdblischak/centralized-tiledb-nightlies/issues/12#issuecomment-2176240410) have been failing for a week due to the release of numpy 2. PRs #731 and #732 have the numpy<2 pin, but they are still undergoing review. To fix the nightly builds, I cherry-picked @awenocur's commit to pin numpy<2.