### PR TITLE
Migrate macOS CI to macos-12 runner

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,9 +18,7 @@ env:
   MACOSX_DEPLOYMENT_TARGET: "11"
 jobs:
   libtiledbvcf:
-    # Stuck on macos-11 because of the htslib dependency. The htslib
-    # configuration step fails on macos-12 and macos-13
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
       - name: Configure libtiledbvcf
@@ -64,7 +62,7 @@ jobs:
           # USAGE: run-cli-tests.sh <build-dir> <inputs-dir>
           libtiledbvcf/test/run-cli-tests.sh libtiledbvcf/build libtiledbvcf/test/inputs
   python:
-    runs-on: macos-11
+    runs-on: macos-12
     needs: libtiledbvcf
     env:
       DYLD_LIBRARY_PATH: "${{ github.workspace }}/dist/lib"
@@ -100,7 +98,7 @@ jobs:
       - name: Confirm linking
         run: otool -L /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/tiledbvcf/libtiledbvcf.cpython-*-darwin.so
   java:
-    runs-on: macos-11
+    runs-on: macos-12
     needs: libtiledbvcf
     steps:
       - uses: actions/checkout@v4
@@ -116,7 +114,7 @@ jobs:
       - name: Test
         run: cd apis/java && ./gradlew test
   spark:
-    runs-on: macos-11
+    runs-on: macos-12
     needs: libtiledbvcf
     steps:
       - uses: actions/checkout@v4
@@ -134,7 +132,7 @@ jobs:
       - name: Check format
         run: cd apis/spark && ./gradlew checkFormat
   spark3:
-    runs-on: macos-11
+    runs-on: macos-12
     needs: libtiledbvcf
     steps:
       - uses: actions/checkout@v4
@@ -152,7 +150,7 @@ jobs:
       - name: Check format
         run: cd apis/spark3 && ./gradlew checkFormat
   python-standalone:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - name: Setup to build htslib from source
+        run: brew install autoconf automake
       - name: Configure libtiledbvcf
         run: |
           cmake -S libtiledbvcf -B $(pwd)/libtiledbvcf/build \

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -157,6 +157,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # fetch everything for python setuptools_scm
+      - name: Setup to build htslib from source
+        run: brew install autoconf automake
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Discovered in #734. macos-11 will be retired this Friday

> This is a scheduled macOS-11 brownout. The macOS-11 environment is deprecated and will be removed on June 28th, 2024.

The nightly runs on macos-12, so this should be possible

https://github.com/TileDB-Inc/TileDB-VCF/blob/7ff0bacababf61ffff6d94ba2f3e3d447557b20e/.github/workflows/nightly.yml#L25