### PR TITLE
Build with numpy 2

### DIFF
--- a/apis/python/conda-env.yml
+++ b/apis/python/conda-env.yml
@@ -2,7 +2,7 @@ name: tiledbvcf-py
 channels:
   - conda-forge
 dependencies:
-  - numpy<2
+  - numpy
   - python<3.12 # based on available tiledb-py wheels
   - pybind11
   - pyarrow>=14.0.2 # for pyarrow security fix

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 
-dependencies = ["pandas", "pyarrow", "pyarrow-hotfix", "numpy<2"]
+dependencies = ["pandas", "pyarrow", "pyarrow-hotfix", "numpy"]
 
 [project.optional-dependencies]
 test = ["dask[distributed]", "pytest", "tiledb"]

--- a/ci/gha-win-env.yml
+++ b/ci/gha-win-env.yml
@@ -11,7 +11,7 @@ dependencies:
   - tiledb=2.15
   - vs2019_win-64
   # build tiledbvcf-py
-  - numpy<2
+  - numpy
   - pandas<2.0
   - pyarrow=9.0
   - pyarrow-hotfix


### PR DESCRIPTION
Follow-up to #734 

What is preventing us from building TileDB-VCF with numpy 2? Help wanted