### PR TITLE
Setuptools SCM version file

### DIFF
--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -66,4 +66,4 @@ editable.mode = "inplace"
 
 [tool.setuptools_scm]
 root = "../.."
-version_file = "src/tiledbvcf/version.py"
+write_to = "src/tiledbvcf/version.py"


### PR DESCRIPTION
I believe that the correct way to set version file is to use
`write_to`
instead of
`version_file`

https://scikit-build-core.readthedocs.io/en/stable/configuration.html#dynamic-metadata

* Note that I found this out when building with Conda recipe for Cloud-Images

![1719913747_grim](https://github.com/TileDB-Inc/TileDB-VCF/assets/5787996/1a514401-e14a-4d56-92e2-c103ccf13bfe)
