### PR TITLE
Migrate TileDB-Py to scikit-build-core and don't check for deprecations

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [macos-12, ubuntu-latest]
         branches:
-          - {libtiledb: release-2.24, tiledb-py: 0.30.1}
+          - {libtiledb: release-2.25, tiledb-py: 0.31.1}
           - {libtiledb: dev, tiledb-py: dev}
     env:
       MACOSX_DEPLOYMENT_TARGET: 10.15

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -75,18 +75,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-      - name: Install dependencies for tiledb-py build
-        run: |
-          python -m pip install --prefer-binary \
-            -r TileDB-VCF/ci/nightly/requirements.txt
-          pip list
       - name: Build tiledb-py from source
-        run: |
-          cd TileDB-Py/
-          python setup.py develop --tiledb=../install/
-          python -c "import tiledb; print('successful import')"
-          python -c "import tiledb; print(tiledb.libtiledb.version())"
-          python -c "import tiledb; print(tiledb.version())"
+        run: bash TileDB-VCF/ci/nightly/build-tiledb-py.sh
       - name: Build (and test) tiledbvcf-py
         run: bash TileDB-VCF/ci/nightly/build-tiledbvcf-py.sh
   issue:

--- a/ci/nightly/build-tiledb-py.sh
+++ b/ci/nightly/build-tiledb-py.sh
@@ -19,7 +19,7 @@ fi
 export TILEDB_PATH=$GITHUB_WORKSPACE/install/
 
 cd TileDB-Py/
-python -m pip install -Cskbuild.cmake.define.TILEDB_REMOVE_DEPRECATIONS=OFF -v .
+python -m pip install -Cskbuild.cmake.define.TILEDB_REMOVE_DEPRECATIONS=OFF -v . pyarrow==12
 
 # Can't run the import inside of the Git repo because Python automatically looks
 # for `./module/__init.py__`

--- a/ci/nightly/build-tiledb-py.sh
+++ b/ci/nightly/build-tiledb-py.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -ex
+
+# Build tiledb-py assuming source code directory is ./TileDB-Py/ and libtiledb
+# shared library installed in $GITHUB_WORKSPACE/install/
+
+OS=$(uname)
+echo "OS: $OS"
+if [[ $OS == Linux ]]
+then
+  export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/install/lib:${LD_LIBRARY_PATH-}
+  echo "LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
+elif [[ $OS == Darwin ]]
+then
+  export DYLD_LIBRARY_PATH=$GITHUB_WORKSPACE/install/lib:${DYLD_LIBRARY_PATH-}
+  echo "DYLD_LIBRARY_PATH: $DYLD_LIBRARY_PATH"
+fi
+
+export TILEDB_PATH=$GITHUB_WORKSPACE/install/
+
+cd TileDB-Py/
+python -m pip install -Cskbuild.cmake.define.TILEDB_REMOVE_DEPRECATIONS=OFF -v .
+
+python -c "import tiledb; print('successful import')"
+python -c "import tiledb; print(tiledb.libtiledb.version())"
+python -c "import tiledb; print(tiledb.version())"

--- a/ci/nightly/build-tiledb-py.sh
+++ b/ci/nightly/build-tiledb-py.sh
@@ -21,6 +21,9 @@ export TILEDB_PATH=$GITHUB_WORKSPACE/install/
 cd TileDB-Py/
 python -m pip install -Cskbuild.cmake.define.TILEDB_REMOVE_DEPRECATIONS=OFF -v .
 
+# Can't run the import inside of the Git repo because Python automatically looks
+# for `./module/__init.py__`
+cd ..
 python -c "import tiledb; print('successful import')"
 python -c "import tiledb; print(tiledb.libtiledb.version())"
 python -c "import tiledb; print(tiledb.version())"

--- a/ci/nightly/build-tiledbvcf-py.sh
+++ b/ci/nightly/build-tiledbvcf-py.sh
@@ -20,7 +20,7 @@ fi
 export LIBTILEDBVCF_PATH=$GITHUB_WORKSPACE/install/
 
 cd TileDB-VCF/apis/python
-python -m pip install .[test]
+python -m pip install .[test] pyarrow==12
 python -c "import tiledbvcf; print(tiledbvcf.version)"
 
 pytest

--- a/ci/nightly/requirements.txt
+++ b/ci/nightly/requirements.txt
@@ -1,9 +1,0 @@
-numpy<2
-pandas
-pyarrow==11
-pyarrow-hotfix
-pybind11
-setuptools
-setuptools_scm
-setuptools_scm_git_archive
-wheel


### PR DESCRIPTION
Fixes #747

The nightly builds are no longer failing due to the use of deprecated APIs. However, now it is failing to build dev TileDB-Py from source (https://github.com/TileDB-Inc/TileDB-VCF/issues/747#issuecomment-2273415744).

I updated the nightly workflow to build TileDB-Py with scikit-build-core and also to set `TILEDB_REMOVE_DEPRECATIONS=OFF`. However, despite this being essentially identical to my setup in my centralized nightlies, TileDB-Py can't find libtiledb at runtime (at least that is my assumption for the failed import test). The only difference is that my [centralized nightlies perform an editable install](https://github.com/jdblischak/centralized-tiledb-nightlies/blob/ec5ce1f3d9cd1d01f799a7d0f1faa76184d2d73d/.github/workflows/linux.yml#L127).

@dudoslav do you have any insight in how to fix this runtime error? I set both `TILEDB_PATH` and `LD_LIBRARY_PATH`. And the build finds libtiledb and sets the `RPATH`

```
  -- Found external TileDB core library
  -- Using libtiledb path: /home/runner/work/TileDB-VCF/TileDB-VCF/install//lib/cmake/TileDB
  -- Setting RPATH for targets "main" and "libtiledb" to /home/runner/work/TileDB-VCF/TileDB-VCF/install/lib
  -- Setting RPATH for target "cc" to /home/runner/work/TileDB-VCF/TileDB-VCF/install/lib
```

Here is an example [failed build](https://github.com/jdblischak/TileDB-VCF/actions/runs/10306576824) from my fork.