### PR TITLE
Handle legacy stats arrays

### DIFF
--- a/libtiledbvcf/src/stats/variant_stats.cc
+++ b/libtiledbvcf/src/stats/variant_stats.cc
@@ -38,6 +38,9 @@ namespace tiledb::vcf {
 int32_t VariantStats::max_length_ = 0;
 
 uint32_t VariantStats::array_version_ = VariantStats::VARIANT_STATS_MIN_VERSION;
+
+bool VariantStats::an_present_ = false;
+
 //===================================================================
 //= public static functions
 //===================================================================
@@ -212,6 +215,10 @@ void VariantStats::init(std::shared_ptr<Context> ctx, const Group& group) {
       array_version_ < VARIANT_STATS_MIN_VERSION)
     throw std::runtime_error(
         "encountered variant stats array version out of range while writing");
+
+  // Check for presence of "an" attribute
+  auto schema = fetch_version.schema();
+  an_present_ = schema.has_attribute("an");
 
   // Open array
   array_ = std::make_unique<Array>(*ctx, uri, TILEDB_WRITE);
@@ -421,7 +428,9 @@ void VariantStats::flush(bool finalize) {
     }
 
     query_->set_data_buffer("ac", ac_buffer_);
-    query_->set_data_buffer("an", an_buffer_);
+    if (an_present_) {
+      query_->set_data_buffer("an", an_buffer_);
+    }
     query_->set_data_buffer("n_hom", n_hom_buffer_);
     if (array_version_ >= 3) {
       query_->set_data_buffer("max_length", max_length_buffer_);
@@ -469,7 +478,9 @@ void VariantStats::flush(bool finalize) {
     }
 
     query_->set_data_buffer("ac", ac_buffer_);
-    query_->set_data_buffer("an", an_buffer_);
+    if (an_present_) {
+      query_->set_data_buffer("an", an_buffer_);
+    }
     query_->set_data_buffer("n_hom", n_hom_buffer_);
     if (array_version_ >= 3) {
       query_->set_data_buffer("max_length", max_length_buffer_);

--- a/libtiledbvcf/src/stats/variant_stats.h
+++ b/libtiledbvcf/src/stats/variant_stats.h
@@ -241,14 +241,19 @@ class VariantStats {
   // Sample names included in the fragment
   inline static std::set<std::string> fragment_sample_names_;
 
+  // maximum allele length encountered
+  static int32_t max_length_;
+
+  // Array version
+  static uint32_t array_version_;
+
+  // Flag to indicate if AN is present in the schema, needed to handle
+  // the case where AN could be missing in a version 2 schema
+  static bool an_present_;
+
   //===================================================================
   //= private non-static
   //===================================================================
-
-  // maximum allele length ecountered
-  static int32_t max_length_;
-
-  static uint32_t array_version_;
 
   // Count delta is +1 in ingest mode, -1 in delete mode
   int count_delta_ = 1;


### PR DESCRIPTION
The computation of variant statistics was improved in [0.33.0](https://github.com/TileDB-Inc/TileDB-VCF/releases/tag/0.33.0). This PR handles writing to the `sample_stats` and `variant_stats` arrays created before version 0.33.0.