### PR TITLE
Build TileDB-VCF-Py on Windows without conda

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,31 +18,27 @@ on:
       - 'ci/gha-win-env.yml'
       - 'libtiledbvcf/**'
   workflow_dispatch:
-defaults:
-  run:
-    shell: cmd /C CALL {0}
 jobs:
   build:
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
-      - name: Install conda env
-        uses: mamba-org/setup-micromamba@v1
         with:
-          environment-file: ci/gha-win-env.yml
-          cache-environment: true
-          init-shell: cmd.exe
-          condarc: |
-            channels:
-              - conda-forge
-              - tiledb
-            channel_priority: strict
-      - name: Build libtiledbvcf
-        run: cmd /C CALL ci\build-libtiledbvcf.bat
-      - name: libtiledbvcf version
-        run: tiledbvcf.exe version
-      - name: Build tiledbvcf-py
-        run: cmd /C CALL ci\build-tiledbvcf-py.bat
+          fetch-depth: 0 # fetch everything for python setuptools_scm
+      - name: Build and install libtiledbvcf
+        run: |
+          cmake -S libtiledbvcf -B libtiledbvcf\build
+          cmake --build libtiledbvcf\build -j2
+          cmake --build libtiledbvcf\build -j2 --target install-libtiledbvcf
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install tiledbvcf-py
+        run: |
+          set TileDB_DIR=.\libtiledbvcf\build\externals\install\lib\cmake\TileDB\
+          cd apis\python
+          python -m pip install -v .[test,dev]
       - name: tiledbvcf-py version
         run: python -c "import tiledbvcf; print(tiledbvcf.version)"
       - name: Test

--- a/libtiledbvcf/cmake/Modules/FindHTSlib.cmake
+++ b/libtiledbvcf/cmake/Modules/FindHTSlib.cmake
@@ -91,11 +91,11 @@ if (NOT HTSLIB_FOUND)
       message("CMD_EXE_PATH is ${CMD_EXE_PATH}")
       string(REPLACE "/" "\\\\" CMD_EXE_PATH_FWD_SLASH "${CMD_EXE_PATH}")
       message("CMD_EXE_PATH_FWD_SLASH is ${CMD_EXE_PATH_FWD_SLASH}")
-      
+
       ExternalProject_Add(ep_htslib
         PREFIX "externals"
         URL https://github.com/TileDB-Inc/m2w64-htslib-build/releases/download/1.20-0/m2w64-htslib-1.20-0.tar.gz
-        URL_HASH SHA1=da39a3ee5e6b4b0d3255bfef95601890afd80709
+        URL_HASH SHA1=6f3e208ccc0262f89dcdf344d96e40696a5db133
         UPDATE_COMMAND ""
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""


### PR DESCRIPTION
**Goal:** Run Windows CI job without using conda

**Motivation:** We haven't been able to build the TileDB-VCF conda binary for months due to problems linking to fmt/spdlog from conda-forge. Ideally these sort of conda-specific problems should be handled in the feedstock repo, not here. It wasn't a pressing concern until recently when @gspowley started work to migrate to numpy 2, which included updating pyarrow (https://github.com/TileDB-Inc/TileDB-VCF/pull/762#issuecomment-2316301233). Now the Windows CI build is failing due to similar fmt/spdlog linking errors.

**Status:** I can build libtiledbvcf and tiledbvcf-py on Windows without conda. However, I can't `import tiledbvcf` because it can't find the libtiledbvcf DLL (strangely, since it is installed in the Python package).

**More details:**

* Ideally, since we are using scikit-build-core, the build would be as straightforward as `python -m pip install -v apis\python[test,dev]`. However, this failed because the following wouldn't execute on Windows:

https://github.com/TileDB-Inc/TileDB-VCF/blob/b9fd4386a2bcfb07e7eb59c7b34ee736844786a3/apis/python/CMakeLists.txt#L55-L61

* The Python CMake expects TileDB to be in `apis/python/dist_links/libtiledbvcf/build/externals/install`. This caused me headaches when I tried building libtiledbvcf from the root of the directory. I tried a few different ways to build from the symlinked subdirectory `apis/python/dist_links/libtiledbvcf`, but symlinks are different on Windows, so I abandoned this

https://github.com/TileDB-Inc/TileDB-VCF/blob/b9fd4386a2bcfb07e7eb59c7b34ee736844786a3/apis/python/CMakeLists.txt#L104-L107

* I finally got everything to build by setting `TileDB_DIR=.\libtiledbvcf\build\externals\install\lib\cmake\TileDB\`, so that the Python CMake routine could fine TileDB

```
  *** Installing project into wheel...
  -- Installing: C:\Users\RUNNER~1\AppData\Local\Temp\tmpc7c23i0p\wheel\platlib/tiledbvcf/libtiledbvcf.cp311-win_amd64.pyd
  -- Installing: C:\Users\RUNNER~1\AppData\Local\Temp\tmpc7c23i0p\wheel\platlib/tiledbvcf/tiledb.lib
  -- Installing: C:\Users\RUNNER~1\AppData\Local\Temp\tmpc7c23i0p\wheel\platlib/tiledbvcf/tiledbvcf.lib
  -- Installing: C:\Users\RUNNER~1\AppData\Local\Temp\tmpc7c23i0p\wheel\platlib/tiledbvcf/hts-3.lib
  -- Installing: C:/Users/RUNNER~1/AppData/Local/Temp/tmpc7c23i0p/wheel/scripts/tiledbvcf.dll
  -- Installing: C:/Users/RUNNER~1/AppData/Local/Temp/tmpc7c23i0p/wheel/scripts/tiledbvcf.exe
  -- Installing: C:/Users/RUNNER~1/AppData/Local/Temp/tmpc7c23i0p/wheel/scripts/tiledbvcf4test.dll
```

* However, I can't run the tests because I can't even import tiledbvcf-py. Unclear what I can do about this. Maybe the problem is that only `tiledb.lib` is copied to the Python package and not `tiledb.dll`

```sh
python -c "import tiledbvcf; print(tiledbvcf.version)"
## Traceback (most recent call last):
##   File "<string>", line 1, in <module>
##   File "C:\hostedtoolcache\windows\Python\3.11.9\x64\Lib\site-packages\tiledbvcf\__init__.py", line 9, in <module>
##     import tiledbvcf.libtiledbvcf
## ImportError: DLL load failed while importing libtiledbvcf: The specified module could not be found.
```

https://github.com/TileDB-Inc/TileDB-VCF/blob/b9fd4386a2bcfb07e7eb59c7b34ee736844786a3/apis/python/src/tiledbvcf/__init__.py#L9

* Note that I fixed the htslib download by updating the sha, which I learned from the PR https://github.com/TileDB-Inc/TileDB-VCF/pull/763 from @dudoslav