### PR TITLE
Add Dataset close and context manager support to the Python API

### DIFF
--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -131,6 +131,20 @@ class Dataset(object):
         else:
             raise Exception("Unsupported dataset mode {}".format(mode))
 
+    def close(self):
+        """Close the dataset and release resources."""
+        if self.mode == "r":
+            del self.reader
+        elif self.mode == "w":
+            del self.writer
+        self.mode = "closed"
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
     def _set_read_cfg(self, cfg):
         if cfg is None:
             return

--- a/apis/python/tests/test_tiledbvcf.py
+++ b/apis/python/tests/test_tiledbvcf.py
@@ -2053,3 +2053,29 @@ def test_info_end(tmp_path):
 
     # Check the results
     _check_dfs(df, expected_end)
+
+
+def test_context_manager():
+    ds1_uri = os.path.join(TESTS_INPUT_DIR, "arrays/v4/ingested_2samples")
+    ds2_uri = os.path.join(TESTS_INPUT_DIR, "arrays/v4/small.tdb")
+
+    # Test the context manager
+    with tiledbvcf.Dataset(ds1_uri) as ds:
+        assert ds.count() == 14
+
+    with tiledbvcf.Dataset(ds2_uri) as ds:
+        assert ds.count() == 6
+
+    # Open the datasets outside the context manager
+    ds1 = tiledbvcf.Dataset(ds1_uri)
+    assert ds1.count() == 14
+
+    ds2 = tiledbvcf.Dataset(ds2_uri)
+    assert ds2.count() == 6
+
+    # Check that an exception is raised when trying to access a closed dataset
+    ds1.close()
+    with pytest.raises(Exception):
+        assert ds1.count() == 14
+
+    assert ds2.count() == 6

--- a/apis/python/tests/test_tiledbvcf.py
+++ b/apis/python/tests/test_tiledbvcf.py
@@ -2056,26 +2056,32 @@ def test_info_end(tmp_path):
 
 
 def test_context_manager():
-    ds1_uri = os.path.join(TESTS_INPUT_DIR, "arrays", "v4", "ingested_2samples")
-    ds2_uri = os.path.join(TESTS_INPUT_DIR, "arrays", "v4", "small.tdb")
+    ds1_uri = os.path.join(TESTS_INPUT_DIR, "arrays/v4/ingested_2samples")
+    expected_count1 = 14
+    ds2_uri = os.path.join(TESTS_INPUT_DIR, "arrays/v3/synth-array")
+    expected_count2 = 19565
 
     # Test the context manager
     with tiledbvcf.Dataset(ds1_uri) as ds:
-        assert ds.count() == 14
+        assert ds.count() == expected_count1
 
     with tiledbvcf.Dataset(ds2_uri) as ds:
-        assert ds.count() == 6
+        assert ds.count() == expected_count2
 
     # Open the datasets outside the context manager
     ds1 = tiledbvcf.Dataset(ds1_uri)
-    assert ds1.count() == 14
+    assert ds1.count() == expected_count1
 
     ds2 = tiledbvcf.Dataset(ds2_uri)
-    assert ds2.count() == 6
+    assert ds2.count() == expected_count2
 
     # Check that an exception is raised when trying to access a closed dataset
     ds1.close()
     with pytest.raises(Exception):
-        assert ds1.count() == 14
+        assert ds1.count() == expected_count1
 
-    assert ds2.count() == 6
+    assert ds2.count() == expected_count2
+
+    ds2.close()
+    with pytest.raises(Exception):
+        assert ds2.count() == expected_count2

--- a/apis/python/tests/test_tiledbvcf.py
+++ b/apis/python/tests/test_tiledbvcf.py
@@ -2056,8 +2056,8 @@ def test_info_end(tmp_path):
 
 
 def test_context_manager():
-    ds1_uri = os.path.join(TESTS_INPUT_DIR, "arrays/v4/ingested_2samples")
-    ds2_uri = os.path.join(TESTS_INPUT_DIR, "arrays/v4/small.tdb")
+    ds1_uri = os.path.join(TESTS_INPUT_DIR, "arrays", "v4", "ingested_2samples")
+    ds2_uri = os.path.join(TESTS_INPUT_DIR, "arrays", "v4", "small.tdb")
 
     # Test the context manager
     with tiledbvcf.Dataset(ds1_uri) as ds:


### PR DESCRIPTION
Add context manager support to the Python `Dataset` class.

```python
import tiledbvcf

ds_uri = "..."

with tiledbvcf.Dataset(ds_uri) as ds:
    num_records = ds.count()
```

For code that doesn't use the context manager, a separate `close` method is available.
```python
import tiledbvcf

ds_uri = "..."

ds = tiledbvcf.Dataset(ds_uri)
num_records = ds.count()
ds.close()
```