### PR TITLE
Add Dataset delete to the Python API

### DIFF
--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -1,3 +1,5 @@
+import os
+import shutil
 import warnings
 from collections import namedtuple
 from typing import List
@@ -1037,6 +1039,39 @@ class Dataset(object):
         from . import dask_functions
 
         return dask_functions.read_dask(self, *args, **kwargs)
+
+    @staticmethod
+    def delete(uri: str, *, config: dict = None) -> None:
+        """
+        Delete the dataset.
+
+        Parameters
+        ----------
+        uri
+            URI of the dataset.
+        config
+            TileDB configuration.
+        """
+
+        if os.path.exists(uri):
+            shutil.rmtree(uri)
+        elif uri.startswith("tiledb://"):
+            try:
+                import tiledb.cloud
+            except Exception:
+                raise Exception(
+                    "Deleting this dataset requires the tiledb.cloud package"
+                )
+            tiledb.cloud.asset.delete(uri, recursive=True)
+        else:
+            try:
+                import tiledb
+            except Exception:
+                raise Exception("Deleting this dataset requires the tiledb package")
+
+            with tiledb.scope_ctx(config):
+                with tiledb.Group(uri, "m") as g:
+                    g.delete(recursive=True)
 
 
 class TileDBVCFDataset(Dataset):

--- a/apis/python/tests/test_tiledbvcf.py
+++ b/apis/python/tests/test_tiledbvcf.py
@@ -2085,3 +2085,19 @@ def test_context_manager():
     ds2.close()
     with pytest.raises(Exception):
         assert ds2.count() == expected_count2
+
+
+def test_delete_dataset(tmp_path):
+    uri = os.path.join(tmp_path, "delete_dataset")
+
+    with tiledbvcf.Dataset(uri, mode="w") as ds:
+        ds.create_dataset()
+
+    # Check that the dataset exists
+    assert tiledb.object_type(uri)
+
+    # Delete the dataset
+    tiledbvcf.Dataset.delete(uri)
+
+    # Check that the dataset does not exist
+    assert not tiledb.object_type(uri)


### PR DESCRIPTION
Add `Dataset.delete` to the Python API, which deletes TileDB-VCF datasets stored on the local file system, remote object store, or registered on TileDB Cloud.

For example:
```python
ds_uri = ...
tiledbvcf.Dataset.delete(ds_uri)
```
