### PR TITLE
Add no_sign_request to s3 read test

### DIFF
--- a/apis/python/tests/test_tiledbvcf.py
+++ b/apis/python/tests/test_tiledbvcf.py
@@ -934,7 +934,12 @@ def test_sample_and_region_partitioned_read():
 def test_large_export_correctness():
     uri = "s3://tiledb-inc-demo-data/tiledbvcf-arrays/v4/vcf-samples-20"
 
-    ds = tiledbvcf.Dataset(uri)
+    tiledb_config = {
+        "vfs.s3.no_sign_request": True,
+        "vfs.s3.region": "us-east-1",
+    }
+
+    ds = tiledbvcf.Dataset(uri, tiledb_config=tiledb_config)
     df = ds.read(
         attrs=[
             "sample_name",

--- a/ci/gha-win-env.yml
+++ b/ci/gha-win-env.yml
@@ -7,7 +7,7 @@ dependencies:
   # build libtiledbvcf
   - cmake
   - git
-  - m2w64-htslib
+  - m2w64-htslib=1.19
   - tiledb=2.15
   - vs2019_win-64
   # build tiledbvcf-py

--- a/libtiledbvcf/cmake/Modules/FindHTSlib.cmake
+++ b/libtiledbvcf/cmake/Modules/FindHTSlib.cmake
@@ -95,7 +95,7 @@ if (NOT HTSLIB_FOUND)
       ExternalProject_Add(ep_htslib
         PREFIX "externals"
         URL https://github.com/TileDB-Inc/m2w64-htslib-build/releases/download/1.20-0/m2w64-htslib-1.20-0.tar.gz
-        URL_HASH SHA1=da39a3ee5e6b4b0d3255bfef95601890afd80709
+        URL_HASH SHA1=6f3e208ccc0262f89dcdf344d96e40696a5db133
         UPDATE_COMMAND ""
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""


### PR DESCRIPTION
Set `"vfs.s3.no_sign_request": True` in the `test_large_export_correctness` pytest, which reads public s3 data.