### PR TITLE
type return incorrectly inst an object

### DIFF
--- a/apis/python/src/tiledbvcf/allele_frequency.py
+++ b/apis/python/src/tiledbvcf/allele_frequency.py
@@ -1,7 +1,7 @@
 import pandas
 
 
-def read_allele_frequency(dataset_uri: str, region: str) -> pandas.DataFrame():
+def read_allele_frequency(dataset_uri: str, region: str) -> pandas.DataFrame:
     """
     Read variant status
 


### PR DESCRIPTION
The type hint for the return instantiates a dataframe rather than just hints. This doesn't really cause an issue, but does cause that dataframe to be created whenever importing `tiledbvcf` do to this module being imported in top-level `__init__.py`