### PR TITLE
Run CI on Ubuntu 24 (GCC 13)

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -17,7 +17,7 @@ stages:
       strategy:
         matrix:
           linux:
-            imageName: 'ubuntu-22.04'
+            imageName: 'ubuntu-24.04'
             python.version: '3.x'
             CXX: g++
             BUILD_PYTHON_API: ON
@@ -39,7 +39,7 @@ stages:
     jobs:
       - job: Build
         pool:
-          vmImage: 'ubuntu-22.04'
+          vmImage: 'ubuntu-24.04'
         strategy:
           matrix:
             cli:
@@ -62,7 +62,7 @@ stages:
         strategy:
           matrix:
             linux:
-              imageName: 'ubuntu-22.04'
+              imageName: 'ubuntu-24.04'
               python.version: '3.x'
               CXX: g++
               BUILD_PYTHON_API: ON
@@ -92,7 +92,7 @@ stages:
         strategy:
           matrix:
             ubuntu_18:
-              imageName: 'ubuntu-22.04'
+              imageName: 'ubuntu-24.04'
         pool:
           vmImage: $(imageName)
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, ubuntu-latest]
+        os: [macos-13, ubuntu-24.04]
         branches:
           - {libtiledb: release-2.26, tiledb-py: 0.32.0}
           - {libtiledb: dev, tiledb-py: dev}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -68,7 +68,7 @@ jobs:
           otool -L install/lib/libtiledbvcf.dylib
       - name: Install bcftools (for tests) (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt install bcftools
+        run: sudo apt-get install --yes bcftools
       - name: Install bcftools (for tests) (macOS)
         if: runner.os == 'macOS'
         run: brew install bcftools

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,6 +48,9 @@ jobs:
           fetch-depth: 0 # fetch everything for python setuptools_scm
       - name: Build libtiledb
         run: bash TileDB-VCF/ci/nightly/build-libtiledb.sh
+      - name: Setup to build htslib from source (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get install --yes automake autoconf libbz2-dev liblzma-dev
       - name: Setup to build htslib from source (macOS)
         if: runner.os == 'macOS'
         run: brew install autoconf automake

--- a/ci/azure-linux_mac.yml
+++ b/ci/azure-linux_mac.yml
@@ -39,7 +39,7 @@ steps:
 
       # Install autoconf/automake (required for htslib)
       if [[ "$AGENT_OS" == "Linux" ]]; then
-          sudo apt update && sudo apt install -y automake autoconf libbz2-dev
+          sudo apt-get update && sudo apt-get install -y automake autoconf libbz2-dev liblzma-dev
       fi
 
       # Install bcftools (only required for running the CLI tests)

--- a/ci/azure-linux_mac.yml
+++ b/ci/azure-linux_mac.yml
@@ -36,6 +36,12 @@ steps:
 
   - bash: |
       set -e pipefail
+
+      # Install autoconf/automake (required for htslib)
+      if [[ "$AGENT_OS" == "Linux" ]]; then
+          sudo apt update && sudo apt install -y automake autoconf libbz2-dev
+      fi
+
       # Install bcftools (only required for running the CLI tests)
       version=1.20
       if [[ "$AGENT_OS" == "Linux" ]]; then
@@ -49,11 +55,6 @@ steps:
           popd
       else
           brew install bcftools automake
-      fi
-
-      # Install autoconf/automake (required for htslib)
-      if [[ "$AGENT_OS" == "Linux" ]]; then
-          sudo apt update && sudo apt install -y automake autoconf
       fi
 
       # Install some extra dependencies to speed up the core TileDB build

--- a/ci/azure-linux_mac.yml
+++ b/ci/azure-linux_mac.yml
@@ -37,7 +37,7 @@ steps:
   - bash: |
       set -e pipefail
 
-      # Install autoconf/automake (required for htslib)
+      # Install htslib dependencies
       if [[ "$AGENT_OS" == "Linux" ]]; then
           sudo apt-get update && sudo apt-get install -y automake autoconf libbz2-dev liblzma-dev
       fi

--- a/ci/azure-linux_mac.yml
+++ b/ci/azure-linux_mac.yml
@@ -23,7 +23,7 @@ steps:
       set -e pipefail
       sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421
       sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main'
-      sudo apt install -y clang-format-15
+      sudo apt-get install -y clang-format-15
       src=$BUILD_REPOSITORY_LOCALPATH/libtiledbvcf
       cd $BUILD_REPOSITORY_LOCALPATH
       ci/run-clang-format.sh $src clang-format-15 0 \
@@ -59,7 +59,7 @@ steps:
 
       # Install some extra dependencies to speed up the core TileDB build
       if [[ "$AGENT_OS" == "Linux" ]]; then
-          sudo apt install -y libssl-dev libbz2-dev liblz4-dev libtbb-dev libcurl4-openssl-dev zlib1g-dev
+          sudo apt-get install -y libssl-dev libbz2-dev liblz4-dev libtbb-dev libcurl4-openssl-dev zlib1g-dev
       fi
     displayName: 'Install dependencies'
 

--- a/ci/native_libs-linux_osx.yml
+++ b/ci/native_libs-linux_osx.yml
@@ -18,12 +18,12 @@ steps:
 
         # Install autoconf/automake (required for htslib)
         if [[ "$AGENT_OS" == "Linux" ]]; then
-            sudo apt update && sudo apt install -y automake autoconf
+            sudo apt-get update && sudo apt-get install -y automake autoconf
         fi
 
         # Install some extra dependencies to speed up the core TileDB build
         if [[ "$AGENT_OS" == "Linux" ]]; then
-            sudo apt install -y libssl-dev libbz2-dev liblz4-dev libtbb-dev libcurl4-openssl-dev zlib1g-dev
+            sudo apt-get install -y libssl-dev libbz2-dev liblz4-dev libtbb-dev libcurl4-openssl-dev zlib1g-dev
         fi
       displayName: 'Install dependencies'
 

--- a/ci/native_libs-linux_osx.yml
+++ b/ci/native_libs-linux_osx.yml
@@ -1,6 +1,12 @@
 steps:
     - bash: |
         set -e pipefail
+
+        # Install htslib dependencies
+        if [[ "$AGENT_OS" == "Linux" ]]; then
+            sudo apt-get update && sudo apt-get install -y automake autoconf libbz2-dev liblzma-dev
+        fi
+
         # Install bcftools (only required for running the CLI tests)
         version=1.16
         if [[ "$AGENT_OS" == "Linux" ]]; then
@@ -14,11 +20,6 @@ steps:
             popd
         else
             brew install bcftools automake
-        fi
-
-        # Install autoconf/automake (required for htslib)
-        if [[ "$AGENT_OS" == "Linux" ]]; then
-            sudo apt-get update && sudo apt-get install -y automake autoconf
         fi
 
         # Install some extra dependencies to speed up the core TileDB build


### PR DESCRIPTION
This PR has multiple motivations:

* `ubuntu-latest` will be Ubuntu 24 on [Dec 5th](https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/)
* The [centralized-tiledb-nightlies](https://github.com/TileDB-Inc/centralized-tiledb-nightlies) repo has migrated to Ubuntu 24 in order to update GCC from 11 to 13 to accommodate the recent transition of TileDB-SOMA to C++20 (https://github.com/TileDB-Inc/centralized-tiledb-nightlies/pull/27, https://github.com/single-cell-data/TileDB-SOMA/issues/3154). libtiledbvcf cannot be compiled with GCC 13, and when it is built with GCC 11, it fails to link against libtiledb that was built with GCC 13 (https://github.com/TileDB-Inc/centralized-tiledb-nightlies/issues/28)