### PR TITLE
Clone main branch in nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,7 +25,7 @@ jobs:
         os: [macos-13, ubuntu-24.04]
         branches:
           - {libtiledb: release-2.26, tiledb-py: 0.32.0}
-          - {libtiledb: dev, tiledb-py: dev}
+          - {libtiledb: main, tiledb-py: main}
     env:
       MACOSX_DEPLOYMENT_TARGET: 10.15
     steps:

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -51,7 +51,7 @@ homepage = "https://tiledb.com"
 repository = "https://github.com/TileDB-Inc/TileDB-VCF"
 
 [build-system]
-requires = ["scikit-build-core", "pybind11[global]"]
+requires = ["scikit-build-core", "pybind11[global]", "setuptools-scm>=8.1.0"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]


### PR DESCRIPTION
Update the nightly since `libtiledb` and `tiledb-py` renamed the `dev` branch to `main`.

Also added the `"setuptools-scm>=8.1.0"` requirement based on recent issues with tiledb-vcf-feedstock.

Resolves #797.