### PR TITLE
Retry vcf_open in VCF read header function

### DIFF
--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -165,6 +165,9 @@ std::vector<std::string> TileDBVCFDataset::get_vcf_attributes(std::string uri) {
 
   // Read VCF header into string for parsing
   bcf_hdr_t* hdr = VCFUtils::hdr_read_header(uri);
+  if (hdr == nullptr) {
+    throw std::runtime_error("Error reading VCF header from: " + uri);
+  }
   std::string hdrstr = VCFUtils::hdr_to_string(hdr);
   const char* p = hdrstr.c_str();
 

--- a/libtiledbvcf/src/vcf/vcf_utils.cc
+++ b/libtiledbvcf/src/vcf/vcf_utils.cc
@@ -62,6 +62,12 @@ uint32_t VCFUtils::get_end_pos(
 
 bcf_hdr_t* VCFUtils::hdr_read_header(const std::string& path) {
   auto fh = vcf_open(path.c_str(), "r");
+
+  int retries = 3;
+  while (!fh && retries--) {
+    fh = vcf_open(path.c_str(), "r");
+  }
+
   if (!fh)
     return nullptr;
   auto hdr = bcf_hdr_read(fh);


### PR DESCRIPTION
Retry `vcf_open` in `VCFUtils::hdr_read_header` to handle intermittent read issues.