### PR TITLE
Update APT in nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,7 +50,9 @@ jobs:
         run: bash TileDB-VCF/ci/nightly/build-libtiledb.sh
       - name: Setup to build htslib from source (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get install --yes automake autoconf libbz2-dev liblzma-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes automake autoconf libbz2-dev liblzma-dev
       - name: Setup to build htslib from source (macOS)
         if: runner.os == 'macOS'
         run: brew install autoconf automake


### PR DESCRIPTION
Closes #805 

Run `apt-get update` to get the latest security patch for liblzma-dev