### PR TITLE
Bump nightly build release branch to 2.28

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [macos-13, ubuntu-24.04]
         branches:
-          - {libtiledb: release-2.27, tiledb-py: 0.33.3}
+          - {libtiledb: release-2.28, tiledb-py: 0.34.0}
           - {libtiledb: main, tiledb-py: main}
     env:
       MACOSX_DEPLOYMENT_TARGET: 10.15


### PR DESCRIPTION
Building TileDB core from the branch `release-2.28` should fix the bzip2 download errors due to the flaky URL (https://github.com/TileDB-Inc/TileDB-VCF/issues/808#issuecomment-2794250839)