### PR TITLE
Reduced redundant strlen(...) calls in data() method of Buffer class

### DIFF
--- a/libtiledbvcf/src/utils/buffer.cc
+++ b/libtiledbvcf/src/utils/buffer.cc
@@ -196,9 +196,17 @@ std::vector<std::string_view> Buffer::data() const {
   assert(!offsets_.empty());
   assert(data_);
 
+  uint64_t len, start, end = 0;
   std::vector<std::string_view> vec(offset_nelts_);
   for (uint64_t i = 0; i < offset_nelts_; i++) {
-    vec[i] = value(i);
+    start = offsets_[i];
+    if (start >= end) {
+      len = std::strlen(data_ + start);
+      end = start + len;
+    } else {
+      len = end - start;
+    }
+    vec[i] = std::string_view(data_ + start, len);
   }
 
   return vec;


### PR DESCRIPTION
Specifically, the data() method may call strlen(...) on multiple suffixes of the same data. These suffixes are iterated from longest to shortest, meaning their common endpoint can be derived from the first strlen(...) call and used to compute subsequent lengths in O(1) time.