### PR TITLE
Update the Buffer class data() method to compute string view directly from offsets

### DIFF
--- a/libtiledbvcf/src/utils/buffer.cc
+++ b/libtiledbvcf/src/utils/buffer.cc
@@ -196,9 +196,12 @@ std::vector<std::string_view> Buffer::data() const {
   assert(!offsets_.empty());
   assert(data_);
 
+  uint64_t start, len;
   std::vector<std::string_view> vec(offset_nelts_);
   for (uint64_t i = 0; i < offset_nelts_; i++) {
-    vec[i] = value(i);
+    start = offsets_[i];
+    len = offsets_[i + 1] - start;
+    vec[i] = std::string_view(data_ + start, len);
   }
 
   return vec;


### PR DESCRIPTION
This is to improve deletion run-time performance.

Note that the `value(...)` method may be similarly updated, but there's an edge case where the last offset is missing. Fortunately the `value(...)` method's impact on deletion run-time performance is negligible so it will remain unchanged in this PR.