### PR TITLE
Deletion memory usage

### DIFF
--- a/libtiledbvcf/src/cli/tiledbvcf.cc
+++ b/libtiledbvcf/src/cli/tiledbvcf.cc
@@ -117,8 +117,21 @@ void do_delete(const DeleteParams& args, const CLI::App& cmd) {
   tiledb::Config cfg;
   utils::set_tiledb_config(args.tiledb_config, &cfg);
 
+  // Instantiate the dataset with the same memory budget as the reader
+  cfg["sm.mem.total_budget"] = args.memory_budget_mb << 20;
   TileDBVCFDataset dataset(cfg);
-  dataset.delete_samples(args.uri, args.sample_names, args.tiledb_config);
+
+  // Delete with explicit export params to configure memory
+  ExportParams params;
+  params.format = ExportFormat::Delete;
+  params.export_to_disk = true;
+  params.uri = args.uri;
+  params.tiledb_config = args.tiledb_config;
+  params.memory_budget_mb = args.memory_budget_mb;
+  params.memory_budget_breakdown.buffers_percentage = args.buffers_percentage;
+  params.memory_budget_breakdown.tile_cache_percentage
+    = args.tile_cache_percentage;
+  dataset.delete_samples(args.sample_names, params);
   LOG_TRACE("Finished delete command.");
 }
 
@@ -691,7 +704,24 @@ void add_delete(CLI::App& app) {
          args->sample_names,
          "CSV list of sample names to delete")
       ->delimiter(',');
+
+  cmd->option_defaults()->group("TileDB options");
   add_tiledb_options(cmd, args->tiledb_config);
+  cmd->add_option(
+      "-b,--mem-budget-mb",
+      args->memory_budget_mb,
+      "The memory budget (MB) used when submitting TileDB "
+      "queries.");
+  cmd->add_option(
+      "--mem-budget-buffer-percentage",
+      args->buffers_percentage,
+      "The percentage of the memory budget to use for TileDB "
+      "query buffers.");
+  cmd->add_option(
+      "--mem-budget-tile-cache-percentage",
+      args->tile_cache_percentage,
+      "The percentage of the memory budget to use for TileDB tile "
+      "cache.");
   add_logging_options(cmd, args->log_level, args->log_file);
 
   // register function to implement this command

--- a/libtiledbvcf/src/cli/tiledbvcf.cc
+++ b/libtiledbvcf/src/cli/tiledbvcf.cc
@@ -129,8 +129,8 @@ void do_delete(const DeleteParams& args, const CLI::App& cmd) {
   params.tiledb_config = args.tiledb_config;
   params.memory_budget_mb = args.memory_budget_mb;
   params.memory_budget_breakdown.buffers_percentage = args.buffers_percentage;
-  params.memory_budget_breakdown.tile_cache_percentage
-    = args.tile_cache_percentage;
+  params.memory_budget_breakdown.tile_cache_percentage =
+      args.tile_cache_percentage;
   dataset.delete_samples(args.sample_names, params);
   LOG_TRACE("Finished delete command.");
 }
@@ -409,9 +409,10 @@ void add_logging_options(
          [](const std::string& value) { LOG_SET_LEVEL(value); },
          "Log message level")
       ->default_str("fatal")
-      ->check(CLI::IsMember(
-          {"fatal", "error", "warn", "info", "debug", "trace"},
-          CLI::ignore_case));
+      ->check(
+          CLI::IsMember(
+              {"fatal", "error", "warn", "info", "debug", "trace"},
+              CLI::ignore_case));
   cmd->add_option_function<std::string>(
       "--log-file",
       [](const std::string& value) { LOG_SET_FILE(value); },

--- a/libtiledbvcf/src/cli/tiledbvcf.cc
+++ b/libtiledbvcf/src/cli/tiledbvcf.cc
@@ -409,10 +409,9 @@ void add_logging_options(
          [](const std::string& value) { LOG_SET_LEVEL(value); },
          "Log message level")
       ->default_str("fatal")
-      ->check(
-          CLI::IsMember(
-              {"fatal", "error", "warn", "info", "debug", "trace"},
-              CLI::ignore_case));
+      ->check(CLI::IsMember(
+          {"fatal", "error", "warn", "info", "debug", "trace"},
+          CLI::ignore_case));
   cmd->add_option_function<std::string>(
       "--log-file",
       [](const std::string& value) { LOG_SET_FILE(value); },

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -981,7 +981,7 @@ void TileDBVCFDataset::delete_samples(
       ExportParams args;
       args.tiledb_config = tiledb_config;
       args.uri = uri;
-      args.sample_names = sample_names;
+      args.sample_names = {sample};
       args.format = ExportFormat::Delete;
       args.export_to_disk = true;
 

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -949,8 +949,7 @@ void TileDBVCFDataset::delete_samples(
 }
 
 void TileDBVCFDataset::delete_samples(
-    const std::vector<std::string>& sample_names,
-    const ExportParams& params) {
+    const std::vector<std::string>& sample_names, const ExportParams& params) {
   assert(params.format == ExportFormat::Delete);
   assert(params.export_to_disk);
 

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -940,9 +940,23 @@ void TileDBVCFDataset::delete_samples(
     const std::string& uri,
     const std::vector<std::string>& sample_names,
     const std::vector<std::string>& tiledb_config) {
+  ExportParams params;
+  params.format = ExportFormat::Delete;
+  params.export_to_disk = true;
+  params.uri = uri;
+  params.tiledb_config = tiledb_config;
+  delete_samples(sample_names, params);
+}
+
+void TileDBVCFDataset::delete_samples(
+    const std::vector<std::string>& sample_names,
+    const ExportParams& params) {
+  assert(params.format == ExportFormat::Delete);
+  assert(params.export_to_disk);
+
   // Open dataset in read mode, required before calling `sample_exists`.
   if (!open_) {
-    open(uri, tiledb_config);
+    open(params.uri, params.tiledb_config);
   }
 
   // Define a function that deletes a sample from an array
@@ -978,16 +992,10 @@ void TileDBVCFDataset::delete_samples(
     // If a stats array exists, read the data with the delete exporter,
     // which adds negative counts to the stats arrays
     if (stats_array_exists) {
-      ExportParams args;
-      args.tiledb_config = tiledb_config;
-      args.uri = uri;
-      args.sample_names = {sample};
-      args.format = ExportFormat::Delete;
-      args.export_to_disk = true;
-
       Reader reader;
-      reader.set_all_params(args);
-      reader.open_dataset(uri);
+      reader.set_all_params(params);
+      reader.set_samples(sample);
+      reader.open_dataset(params.uri);
       reader.read();
     }
 

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -346,8 +346,7 @@ class TileDBVCFDataset {
    * @param params The read parameters to use, including TileDB config values
    */
   void delete_samples(
-      const std::vector<std::string>& sample_names,
-      const ExportParams& params);
+      const std::vector<std::string>& sample_names, const ExportParams& params);
 
   /**
    * @brief Delete samples from the dataset. This removes samples from the

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -47,6 +47,9 @@
 namespace tiledb {
 namespace vcf {
 
+// Forward declare export params
+struct ExportParams;
+
 /* ********************************* */
 /*       AUXILIARY DATATYPES         */
 /* ********************************* */
@@ -105,6 +108,11 @@ struct DeleteParams {
   std::string log_file;
   std::vector<std::string> sample_names;
   std::vector<std::string> tiledb_config;
+
+  // Memory/performance params:
+  uint64_t memory_budget_mb = 2 * 1024;
+  float buffers_percentage = 25;
+  float tile_cache_percentage = 10;
 };
 
 struct UtilsParams {
@@ -332,7 +340,18 @@ class TileDBVCFDataset {
 
   /**
    * @brief Delete samples from the dataset. This removes samples from the
-   * data, vcf_header, and stats arrays.
+   * data, vcf_header, and stats arrays using the given read parameters.
+   *
+   * @param sample_names Sample names to delete
+   * @param params The read parameters to use, including TileDB config values
+   */
+  void delete_samples(
+      const std::vector<std::string>& sample_names,
+      const ExportParams& params);
+
+  /**
+   * @brief Delete samples from the dataset. This removes samples from the
+   * data, vcf_header, and stats arrays using the default export parameters.
    *
    * @param uri TileDB-VCF dataset URI
    * @param sample_names Sample names to delete

--- a/libtiledbvcf/test/run-cli-tests.sh
+++ b/libtiledbvcf/test/run-cli-tests.sh
@@ -27,6 +27,7 @@ function clean_up {
            ingested_capacity HG01762.vcf HG00280.vcf tmp.bed tmp1.vcf tmp2.vcf \
            region-map.txt pfx.tsv \
            export_test G1.bcf \
+           deletion_test \
            create_test \
            combine-test \
            tmp
@@ -419,6 +420,23 @@ $tilevcf create -u export_test
 $tilevcf store -u export_test ${input_dir}/random_synthetic/G1.bcf
 $tilevcf export -u export_test -Ob -s G1
 diff -u <(bcftools view -H G1.bcf | sort -k1,1 -k2,2n) <(bcftools view -H ${input_dir}/random_synthetic/G1.bcf | sort -k1,1 -k2,2n) || exit 1
+
+# check deletion
+$tilevcf create -u deletion_test || exit 1
+for i in {1..10}; do
+  $tilevcf store -u deletion_test ${input_dir}/random_synthetic/G$i.bcf || exit 1
+done
+$tilevcf delete -u deletion_test -s G1,G2,G3,G4,G5,G6,G7,G8,G9
+diff -u <($tilevcf list -u deletion_test) <(
+cat <<EOF
+G10
+EOF
+) || exit 1
+$tilevcf delete -u deletion_test -s G10
+diff -u <($tilevcf list -u deletion_test) <(
+cat <<EOF
+EOF
+) || exit 1
 
 # check create from vcf
 $tilevcf create -u create_test -v ${input_dir}/small3.bcf || exit 1

--- a/libtiledbvcf/test/src/unit-vcf-delete.cc
+++ b/libtiledbvcf/test/src/unit-vcf-delete.cc
@@ -176,10 +176,6 @@ TEST_CASE("TileDB-VCF: Test delete stats", "[tiledbvcf][delete]") {
 TEST_CASE("TileDB-VCF: Test multi sample delete", "[tiledbvcf][delete]") {
   // LOG_CONFIG("debug");
 
-  auto enable_ac = GENERATE(false, true);
-  auto enable_vs = GENERATE(false, true);
-  auto enable_ss = GENERATE(false, true);
-
   tiledb::Context ctx;
   tiledb::VFS vfs(ctx);
 
@@ -192,15 +188,12 @@ TEST_CASE("TileDB-VCF: Test multi sample delete", "[tiledbvcf][delete]") {
     vfs.remove_dir(dataset_uri);
   }
 
-  // Create and enable stats arrays
+  // Create dataset
   {
     CreationParams create_args;
     create_args.uri = dataset_uri;
     create_args.tile_capacity = 10000;
     create_args.allow_duplicates = false;
-    create_args.enable_allele_count = enable_ac;
-    create_args.enable_variant_stats = enable_vs;
-    create_args.enable_sample_stats = enable_ss;
     TileDBVCFDataset::create(create_args);
   }
 


### PR DESCRIPTION
This PR makes changes to ensure that the deletion operation stays within its memory budget, especially when deleting multiple samples. Specifically:
* Samples are deleted one at a time but there was a bug that updated the stats for all samples simultaneously, which used a lot of memory. This has been fixed.
* The deletion memory budget was previously hard-coded. This can now be controlled via CLI flags.
* The memory budget of the dataset object performing the deletion was previously unbounded. Now this is also controlled by the previously mentioned CLI flags.
* Previously there were no unit or CLI tests for deletions! These have been added.