### PR TITLE
 Define SDKROOT to fix failing macOS nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -100,6 +100,6 @@ jobs:
         with:
           name: nightly build
           label: nightly-failure
-          assignee: awenocur,gspowley,ihnorton,Shelnutt2,jdblischak
+          assignee: alancleary,ihnorton,Shelnutt2,jdblischak
         env:
           TZ: "America/New_York"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,6 +46,9 @@ jobs:
         with:
           path: TileDB-VCF
           fetch-depth: 0 # fetch everything for python setuptools_scm
+      - name: Define SDKROOT (macOS)
+        if: runner.os == 'macOS'
+        run: echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> $GITHUB_ENV
       - name: Build libtiledb
         run: bash TileDB-VCF/ci/nightly/build-libtiledb.sh
       - name: Setup to build htslib from source (Linux)


### PR DESCRIPTION
Closes #841 

I split these commits off of #840. The goal of this PR is limited to fixing the currently failing nightly builds. It defines `SDKROOT` to address the recent changes in CMake 4.0 (https://github.com/TileDB-Inc/TileDB/pull/5633) and also updates the maintainers assigned to nightly-failure Issues.