### PR TITLE
Migrate to macos-15

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,7 +18,7 @@ env:
   MACOSX_DEPLOYMENT_TARGET: "11"
 jobs:
   libtiledbvcf:
-    runs-on: macos-13
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - name: Setup to build htslib from source
@@ -64,7 +64,7 @@ jobs:
           # USAGE: run-cli-tests.sh <build-dir> <inputs-dir>
           libtiledbvcf/test/run-cli-tests.sh libtiledbvcf/build libtiledbvcf/test/inputs
   python:
-    runs-on: macos-13
+    runs-on: macos-15
     needs: libtiledbvcf
     env:
       DYLD_LIBRARY_PATH: "${{ github.workspace }}/dist/lib"
@@ -98,7 +98,7 @@ jobs:
       - name: Confirm linking
         run: otool -L /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/tiledbvcf/libtiledbvcf.cpython-*-darwin.so
   java:
-    runs-on: macos-13
+    runs-on: macos-15
     needs: libtiledbvcf
     steps:
       - uses: actions/checkout@v4
@@ -114,7 +114,7 @@ jobs:
       - name: Test
         run: cd apis/java && ./gradlew test
   python-standalone:
-    runs-on: macos-13
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, ubuntu-24.04]
+        os: [macos-15, ubuntu-24.04]
         branches:
           - {libtiledb: release-2.29, tiledb-py: 0.35.0}
           - {libtiledb: main, tiledb-py: main}


### PR DESCRIPTION
The CI worked with both macos-14 and macos-15 (#840). My understanding is that they are both arm64, so we may as well jump to the later one.