### PR TITLE
Allow users to skip updating aggregate stats when deleting samples

### DIFF
--- a/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
+++ b/apis/python/src/tiledbvcf/binding/libtiledbvcf.cc
@@ -131,6 +131,7 @@ PYBIND11_MODULE(libtiledbvcf, m) {
           "ingest_samples",
           &Writer::ingest_samples,
           py::call_guard<py::gil_scoped_release>())
+      .def("set_skip_aggregate_stats", &Writer::set_skip_aggregate_stats)
       .def(
           "delete_samples",
           &Writer::delete_samples,

--- a/apis/python/src/tiledbvcf/binding/writer.cc
+++ b/apis/python/src/tiledbvcf/binding/writer.cc
@@ -232,6 +232,11 @@ void Writer::ingest_samples() {
   check_error(writer, tiledb_vcf_writer_store(writer));
 }
 
+void Writer::set_skip_aggregate_stats(bool skip) {
+  auto writer = ptr.get();
+  check_error(writer, tiledb_vcf_writer_set_skip_aggregate_stats(writer, skip));
+}
+
 void Writer::delete_samples(std::vector<std::string> samples_to_delete) {
   std::vector<const char*> samples;
   for (std::string& sample : samples_to_delete) {

--- a/apis/python/src/tiledbvcf/binding/writer.h
+++ b/apis/python/src/tiledbvcf/binding/writer.h
@@ -162,6 +162,8 @@ class Writer {
 
   void ingest_samples();
 
+  void set_skip_aggregate_stats(bool skip);
+
   void delete_samples(std::vector<std::string> samples);
 
   /** Returns schema version number of the TileDB VCF dataset */

--- a/apis/python/src/tiledbvcf/dataset.py
+++ b/apis/python/src/tiledbvcf/dataset.py
@@ -1111,9 +1111,23 @@ class Dataset(object):
     def delete_samples(
         self,
         sample_uris: List[str] = None,
+        skip_aggregate_stats: bool = False,
     ):
+        """
+        Delete samples from the dataset.
+
+        Parameters
+        ----------
+        sample_uris
+            List of sample names to delete.
+        skip_aggregate_stats
+            If True, skip updating allele_count and variant_stats arrays
+            during deletion.
+        """
         if self.mode != "w":
             raise Exception("Dataset not open in write mode")
+        if skip_aggregate_stats:
+            self.writer.set_skip_aggregate_stats(True)
         self.writer.delete_samples(sample_uris)
 
     def tiledb_stats(self) -> str:

--- a/apis/python/tests/test_delete.py
+++ b/apis/python/tests/test_delete.py
@@ -102,18 +102,17 @@ def test_delete_samples_skip_aggregate_stats(tmp_path, stats_v3_dataset):
     assert "second" not in sample_names
     assert "third" in sample_names
 
-    # Verify skipped_delete_samples metadata on allele_count and variant_stats
+    # Verify per-sample skipped deletion key is recorded on allele_count and variant_stats
     for array_name in ["allele_count", "variant_stats"]:
         with tiledb.open(os.path.join(uri, array_name), "r") as arr:
-            meta = arr.meta["skipped_delete_samples"]
-            assert b"second" in meta
+            assert "skipped_delete_sample:second" in arr.meta
 
 
 @skip_if_no_bcftools
 def test_delete_samples_skip_aggregate_stats_accumulates(
     tmp_path, stats_v3_dataset
 ):
-    """Verify skipped_delete_samples metadata accumulates across deletions."""
+    """Verify per-sample skipped deletion keys are recorded across multiple deletions."""
     uri = os.path.join(tmp_path, "stats_test")
 
     ds = tiledbvcf.Dataset(uri=uri, mode="w")
@@ -124,8 +123,8 @@ def test_delete_samples_skip_aggregate_stats_accumulates(
 
     for array_name in ["allele_count", "variant_stats"]:
         with tiledb.open(os.path.join(uri, array_name), "r") as arr:
-            meta = arr.meta["skipped_delete_samples"]
-            assert meta == b"second,fifth"
+            assert "skipped_delete_sample:second" in arr.meta
+            assert "skipped_delete_sample:fifth" in arr.meta
 
 
 def test_delete_samples_read_mode_raises(tmp_path):

--- a/apis/python/tests/test_delete.py
+++ b/apis/python/tests/test_delete.py
@@ -89,6 +89,45 @@ def test_delete_samples_nonexistent_raises(tmp_path):
         ds.delete_samples(["NONEXISTENT"])
 
 
+@skip_if_no_bcftools
+def test_delete_samples_skip_aggregate_stats(tmp_path, stats_v3_dataset):
+    """Verify skip_aggregate_stats skips stats update and records metadata."""
+    uri = os.path.join(tmp_path, "stats_test")
+    ds = tiledbvcf.Dataset(uri=uri, mode="w")
+    ds.delete_samples(["second"], skip_aggregate_stats=True)
+
+    # Verify sample is deleted
+    ds = tiledbvcf.Dataset(uri=uri, mode="r")
+    sample_names = ds.samples()
+    assert "second" not in sample_names
+    assert "third" in sample_names
+
+    # Verify skipped_delete_samples metadata on allele_count and variant_stats
+    for array_name in ["allele_count", "variant_stats"]:
+        with tiledb.open(os.path.join(uri, array_name), "r") as arr:
+            meta = arr.meta["skipped_delete_samples"]
+            assert b"second" in meta
+
+
+@skip_if_no_bcftools
+def test_delete_samples_skip_aggregate_stats_accumulates(
+    tmp_path, stats_v3_dataset
+):
+    """Verify skipped_delete_samples metadata accumulates across deletions."""
+    uri = os.path.join(tmp_path, "stats_test")
+
+    ds = tiledbvcf.Dataset(uri=uri, mode="w")
+    ds.delete_samples(["second"], skip_aggregate_stats=True)
+
+    ds = tiledbvcf.Dataset(uri=uri, mode="w")
+    ds.delete_samples(["fifth"], skip_aggregate_stats=True)
+
+    for array_name in ["allele_count", "variant_stats"]:
+        with tiledb.open(os.path.join(uri, array_name), "r") as arr:
+            meta = arr.meta["skipped_delete_samples"]
+            assert meta == b"second,fifth"
+
+
 def test_delete_samples_read_mode_raises(tmp_path):
     """Verify delete_samples() raises in read mode."""
     uri = os.path.join(tmp_path, "dataset")

--- a/libtiledbvcf/src/c_api/tiledbvcf.cc
+++ b/libtiledbvcf/src/c_api/tiledbvcf.cc
@@ -1573,6 +1573,19 @@ int32_t tiledb_vcf_writer_set_verbose(
   return TILEDB_VCF_OK;
 }
 
+int32_t tiledb_vcf_writer_set_skip_aggregate_stats(
+    tiledb_vcf_writer_t* writer, const bool skip_aggregate_stats) {
+  if (sanity_check(writer) == TILEDB_VCF_ERR)
+    return TILEDB_VCF_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          writer,
+          writer->writer_->set_skip_aggregate_stats(skip_aggregate_stats)))
+    return TILEDB_VCF_ERR;
+
+  return TILEDB_VCF_OK;
+}
+
 int32_t tiledb_vcf_writer_set_tiledb_stats_enabled(
     tiledb_vcf_writer_t* writer, const bool stats_enabled) {
   if (sanity_check(writer) == TILEDB_VCF_ERR)

--- a/libtiledbvcf/src/c_api/tiledbvcf.h
+++ b/libtiledbvcf/src/c_api/tiledbvcf.h
@@ -1501,6 +1501,16 @@ TILEDBVCF_EXPORT int32_t
 tiledb_vcf_writer_set_verbose(tiledb_vcf_writer_t* writer, bool verbose);
 
 /**
+ * Set whether to skip aggregate stats updates during deletion.
+ *
+ * @param writer VCF writer object
+ * @param skip_aggregate_stats whether to skip aggregate stats
+ * @return `TILEDB_VCF_OK` for success or `TILEDB_VCF_ERR` for error.
+ */
+TILEDBVCF_EXPORT int32_t tiledb_vcf_writer_set_skip_aggregate_stats(
+    tiledb_vcf_writer_t* writer, bool skip_aggregate_stats);
+
+/**
  * Sets whether TileDB internal statistics should be enabled or not.
  *
  * @param writer VCF writer object

--- a/libtiledbvcf/src/cli/tiledbvcf.cc
+++ b/libtiledbvcf/src/cli/tiledbvcf.cc
@@ -131,7 +131,7 @@ void do_delete(const DeleteParams& args, const CLI::App& cmd) {
   params.memory_budget_breakdown.buffers_percentage = args.buffers_percentage;
   params.memory_budget_breakdown.tile_cache_percentage =
       args.tile_cache_percentage;
-  dataset.delete_samples(args.sample_names, params);
+  dataset.delete_samples(args.sample_names, params, args.skip_aggregate_stats);
   LOG_TRACE("Finished delete command.");
 }
 
@@ -722,6 +722,10 @@ void add_delete(CLI::App& app) {
       args->tile_cache_percentage,
       "The percentage of the memory budget to use for TileDB tile "
       "cache.");
+  cmd->add_flag(
+      "--skip-aggregate-stats",
+      args->skip_aggregate_stats,
+      "Skip updating allele_count and variant_stats arrays during deletion.");
   add_logging_options(cmd, args->log_level, args->log_file);
 
   // register function to implement this command

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.cc
@@ -954,17 +954,20 @@ bool TileDBVCFDataset::sample_exists(const std::string& sample) {
 void TileDBVCFDataset::delete_samples(
     const std::string& uri,
     const std::vector<std::string>& sample_names,
-    const std::vector<std::string>& tiledb_config) {
+    const std::vector<std::string>& tiledb_config,
+    bool skip_aggregate_stats) {
   ExportParams params;
   params.format = ExportFormat::Delete;
   params.export_to_disk = true;
   params.uri = uri;
   params.tiledb_config = tiledb_config;
-  delete_samples(sample_names, params);
+  delete_samples(sample_names, params, skip_aggregate_stats);
 }
 
 void TileDBVCFDataset::delete_samples(
-    const std::vector<std::string>& sample_names, const ExportParams& params) {
+    const std::vector<std::string>& sample_names,
+    const ExportParams& params,
+    bool skip_aggregate_stats) {
   assert(params.format == ExportFormat::Delete);
   assert(params.export_to_disk);
 
@@ -1003,14 +1006,19 @@ void TileDBVCFDataset::delete_samples(
       throw std::runtime_error("Sample not found in dataset: " + sample);
     }
 
-    // If a stats array exists, read the data with the delete exporter,
-    // which adds negative counts to the stats arrays
+    // If a stats array exists, update or skip the allele_count and
+    // variant_stats arrays
     if (stats_array_exists) {
-      Reader reader;
-      reader.set_all_params(params);
-      reader.set_samples(sample);
-      reader.open_dataset(params.uri);
-      reader.read();
+      if (skip_aggregate_stats) {
+        AlleleCount::skip_delete_sample(ctx_, group, sample);
+        VariantStats::skip_delete_sample(ctx_, group, sample);
+      } else {
+        Reader reader;
+        reader.set_all_params(params);
+        reader.set_samples(sample);
+        reader.open_dataset(params.uri);
+        reader.read();
+      }
     }
 
     // Delete samples from the vcf_header, data, and sample_stats arrays

--- a/libtiledbvcf/src/dataset/tiledbvcfdataset.h
+++ b/libtiledbvcf/src/dataset/tiledbvcfdataset.h
@@ -114,6 +114,9 @@ struct DeleteParams {
   uint64_t memory_budget_mb = 2 * 1024;
   float buffers_percentage = 25;
   float tile_cache_percentage = 10;
+
+  // Skip updating allele_count and variant_stats arrays during deletion
+  bool skip_aggregate_stats = false;
 };
 
 struct UtilsParams {
@@ -436,9 +439,13 @@ class TileDBVCFDataset {
    *
    * @param sample_names Sample names to delete
    * @param params The read parameters to use, including TileDB config values
+   * @param skip_aggregate_stats If true, skip updating allele_count and
+   *   variant_stats arrays and record skipped samples as metadata instead
    */
   void delete_samples(
-      const std::vector<std::string>& sample_names, const ExportParams& params);
+      const std::vector<std::string>& sample_names,
+      const ExportParams& params,
+      bool skip_aggregate_stats = false);
 
   /**
    * @brief Delete samples from the dataset. This removes samples from the
@@ -447,11 +454,14 @@ class TileDBVCFDataset {
    * @param uri TileDB-VCF dataset URI
    * @param sample_names Sample names to delete
    * @param tiledb_config TileDB config values
+   * @param skip_aggregate_stats If true, skip updating allele_count and
+   *   variant_stats arrays and record skipped samples as metadata instead
    */
   void delete_samples(
       const std::string& uri,
       const std::vector<std::string>& sample_names,
-      const std::vector<std::string>& tiledb_config = {});
+      const std::vector<std::string>& tiledb_config = {},
+      bool skip_aggregate_stats = false);
 
   const Metadata& metadata() const;
 

--- a/libtiledbvcf/src/stats/allele_count.cc
+++ b/libtiledbvcf/src/stats/allele_count.cc
@@ -211,6 +211,41 @@ void AlleleCount::close() {
   enabled_ = false;
 }
 
+void AlleleCount::skip_delete_sample(
+    std::shared_ptr<Context> ctx,
+    const Group& group,
+    const std::string& sample) {
+  auto uri = AlleleCount::group_uri(group);
+  if (uri.empty()) {
+    return;
+  }
+
+  // Read existing skipped_delete_samples metadata
+  std::string existing;
+  {
+    Array read_array(*ctx, uri, TILEDB_READ);
+    const void* value = nullptr;
+    tiledb_datatype_t type = TILEDB_ANY;
+    uint32_t num = 0;
+    read_array.get_metadata("skipped_delete_samples", &type, &num, &value);
+    if (value != nullptr && num > 0) {
+      existing = std::string(static_cast<const char*>(value), num);
+    }
+  }
+
+  // Build updated CSV
+  std::string csv = existing.empty() ? sample : existing + "," + sample;
+
+  // Write updated metadata
+  {
+    Array write_array(*ctx, uri, TILEDB_WRITE);
+    write_array.put_metadata(
+        "skipped_delete_samples", TILEDB_STRING_ASCII, csv.size(), csv.c_str());
+  }
+
+  LOG_INFO("[AlleleCount] Recorded skipped deletion for sample {}", sample);
+}
+
 void AlleleCount::consolidate_commits(
     std::shared_ptr<Context> ctx, const Group& group) {
   auto uri = AlleleCount::group_uri(group);

--- a/libtiledbvcf/src/stats/allele_count.cc
+++ b/libtiledbvcf/src/stats/allele_count.cc
@@ -220,30 +220,37 @@ void AlleleCount::skip_delete_sample(
     return;
   }
 
-  // Read existing skipped_delete_samples metadata
-  std::string existing;
-  {
-    Array read_array(*ctx, uri, TILEDB_READ);
-    const void* value = nullptr;
-    tiledb_datatype_t type = TILEDB_ANY;
-    uint32_t num = 0;
-    read_array.get_metadata("skipped_delete_samples", &type, &num, &value);
-    if (value != nullptr && num > 0) {
-      existing = std::string(static_cast<const char*>(value), num);
-    }
-  }
-
-  // Build updated CSV
-  std::string csv = existing.empty() ? sample : existing + "," + sample;
-
-  // Write updated metadata
-  {
-    Array write_array(*ctx, uri, TILEDB_WRITE);
-    write_array.put_metadata(
-        "skipped_delete_samples", TILEDB_STRING_ASCII, csv.size(), csv.c_str());
-  }
+  // Write one key per sample to avoid a read-modify-write race condition.
+  // Concurrent callers write to different keys so no coordination is needed.
+  std::string key = "skipped_delete_sample:" + sample;
+  Array write_array(*ctx, uri, TILEDB_WRITE);
+  write_array.put_metadata(key, TILEDB_STRING_ASCII, 0, nullptr);
 
   LOG_INFO("[AlleleCount] Recorded skipped deletion for sample {}", sample);
+}
+
+std::vector<std::string> AlleleCount::get_skipped_delete_samples(
+    std::shared_ptr<Context> ctx, const Group& group) {
+  auto uri = AlleleCount::group_uri(group);
+  if (uri.empty()) {
+    return {};
+  }
+
+  const std::string prefix = "skipped_delete_sample:";
+  std::vector<std::string> samples;
+  Array array(*ctx, uri, TILEDB_READ);
+  uint64_t n = array.metadata_num();
+  for (uint64_t i = 0; i < n; i++) {
+    std::string key;
+    tiledb_datatype_t type;
+    uint32_t num;
+    const void* value;
+    array.get_metadata_from_index(i, &key, &type, &num, &value);
+    if (key.rfind(prefix, 0) == 0) {
+      samples.push_back(key.substr(prefix.size()));
+    }
+  }
+  return samples;
 }
 
 void AlleleCount::consolidate_commits(

--- a/libtiledbvcf/src/stats/allele_count.h
+++ b/libtiledbvcf/src/stats/allele_count.h
@@ -120,8 +120,9 @@ class AlleleCount {
   /**
    * @brief Record a skipped sample deletion in array metadata.
    *
-   * Reads existing "skipped_deletions" metadata (if any), appends the sample
-   * name, and writes back the updated CSV.
+   * Writes a per-sample metadata key "skipped_delete_sample:<sample>" to the
+   * array. Using one key per sample avoids the read-modify-write race condition
+   * that would arise from accumulating a single CSV value.
    *
    * @param ctx TileDB context
    * @param group TileDB-VCF dataset group
@@ -131,6 +132,19 @@ class AlleleCount {
       std::shared_ptr<Context> ctx,
       const Group& group,
       const std::string& sample);
+
+  /**
+   * @brief Return the list of samples whose deletion was skipped.
+   *
+   * Enumerates all array metadata keys with the prefix
+   * "skipped_delete_sample:" and returns the sample name suffixes.
+   *
+   * @param ctx TileDB context
+   * @param group TileDB-VCF dataset group
+   * @return Vector of sample names recorded as skipped
+   */
+  static std::vector<std::string> get_skipped_delete_samples(
+      std::shared_ptr<Context> ctx, const Group& group);
 
   /**
    * @brief Consolidate commits

--- a/libtiledbvcf/src/stats/allele_count.h
+++ b/libtiledbvcf/src/stats/allele_count.h
@@ -118,6 +118,21 @@ class AlleleCount {
   static void close();
 
   /**
+   * @brief Record a skipped sample deletion in array metadata.
+   *
+   * Reads existing "skipped_deletions" metadata (if any), appends the sample
+   * name, and writes back the updated CSV.
+   *
+   * @param ctx TileDB context
+   * @param group TileDB-VCF dataset group
+   * @param sample Sample name whose stats update was skipped
+   */
+  static void skip_delete_sample(
+      std::shared_ptr<Context> ctx,
+      const Group& group,
+      const std::string& sample);
+
+  /**
    * @brief Consolidate commits
    *
    * @param ctx TileDB context

--- a/libtiledbvcf/src/stats/variant_stats.cc
+++ b/libtiledbvcf/src/stats/variant_stats.cc
@@ -309,6 +309,41 @@ void VariantStats::close() {
   enabled_ = false;
 }
 
+void VariantStats::skip_delete_sample(
+    std::shared_ptr<Context> ctx,
+    const Group& group,
+    const std::string& sample) {
+  auto uri = VariantStats::group_uri(group);
+  if (uri.empty()) {
+    return;
+  }
+
+  // Read existing skipped_delete_samples metadata
+  std::string existing;
+  {
+    Array read_array(*ctx, uri, TILEDB_READ);
+    const void* value = nullptr;
+    tiledb_datatype_t type = TILEDB_ANY;
+    uint32_t num = 0;
+    read_array.get_metadata("skipped_delete_samples", &type, &num, &value);
+    if (value != nullptr && num > 0) {
+      existing = std::string(static_cast<const char*>(value), num);
+    }
+  }
+
+  // Build updated CSV
+  std::string csv = existing.empty() ? sample : existing + "," + sample;
+
+  // Write updated metadata
+  {
+    Array write_array(*ctx, uri, TILEDB_WRITE);
+    write_array.put_metadata(
+        "skipped_delete_samples", TILEDB_STRING_ASCII, csv.size(), csv.c_str());
+  }
+
+  LOG_INFO("[VariantStats] Recorded skipped deletion for sample {}", sample);
+}
+
 void VariantStats::consolidate_commits(
     std::shared_ptr<Context> ctx, const Group& group) {
   auto uri = VariantStats::group_uri(group);

--- a/libtiledbvcf/src/stats/variant_stats.cc
+++ b/libtiledbvcf/src/stats/variant_stats.cc
@@ -318,30 +318,37 @@ void VariantStats::skip_delete_sample(
     return;
   }
 
-  // Read existing skipped_delete_samples metadata
-  std::string existing;
-  {
-    Array read_array(*ctx, uri, TILEDB_READ);
-    const void* value = nullptr;
-    tiledb_datatype_t type = TILEDB_ANY;
-    uint32_t num = 0;
-    read_array.get_metadata("skipped_delete_samples", &type, &num, &value);
-    if (value != nullptr && num > 0) {
-      existing = std::string(static_cast<const char*>(value), num);
-    }
-  }
-
-  // Build updated CSV
-  std::string csv = existing.empty() ? sample : existing + "," + sample;
-
-  // Write updated metadata
-  {
-    Array write_array(*ctx, uri, TILEDB_WRITE);
-    write_array.put_metadata(
-        "skipped_delete_samples", TILEDB_STRING_ASCII, csv.size(), csv.c_str());
-  }
+  // Write one key per sample to avoid a read-modify-write race condition.
+  // Concurrent callers write to different keys so no coordination is needed.
+  std::string key = "skipped_delete_sample:" + sample;
+  Array write_array(*ctx, uri, TILEDB_WRITE);
+  write_array.put_metadata(key, TILEDB_STRING_ASCII, 0, nullptr);
 
   LOG_INFO("[VariantStats] Recorded skipped deletion for sample {}", sample);
+}
+
+std::vector<std::string> VariantStats::get_skipped_delete_samples(
+    std::shared_ptr<Context> ctx, const Group& group) {
+  auto uri = VariantStats::group_uri(group);
+  if (uri.empty()) {
+    return {};
+  }
+
+  const std::string prefix = "skipped_delete_sample:";
+  std::vector<std::string> samples;
+  Array array(*ctx, uri, TILEDB_READ);
+  uint64_t n = array.metadata_num();
+  for (uint64_t i = 0; i < n; i++) {
+    std::string key;
+    tiledb_datatype_t type;
+    uint32_t num;
+    const void* value;
+    array.get_metadata_from_index(i, &key, &type, &num, &value);
+    if (key.rfind(prefix, 0) == 0) {
+      samples.push_back(key.substr(prefix.size()));
+    }
+  }
+  return samples;
 }
 
 void VariantStats::consolidate_commits(

--- a/libtiledbvcf/src/stats/variant_stats.h
+++ b/libtiledbvcf/src/stats/variant_stats.h
@@ -123,6 +123,21 @@ class VariantStats {
   static void close();
 
   /**
+   * @brief Record a skipped sample deletion in array metadata.
+   *
+   * Reads existing "skipped_deletions" metadata (if any), appends the sample
+   * name, and writes back the updated CSV.
+   *
+   * @param ctx TileDB context
+   * @param group TileDB-VCF dataset group
+   * @param sample Sample name whose stats update was skipped
+   */
+  static void skip_delete_sample(
+      std::shared_ptr<Context> ctx,
+      const Group& group,
+      const std::string& sample);
+
+  /**
    * @brief Consolidate commits
    *
    * @param ctx TileDB context

--- a/libtiledbvcf/src/stats/variant_stats.h
+++ b/libtiledbvcf/src/stats/variant_stats.h
@@ -125,8 +125,9 @@ class VariantStats {
   /**
    * @brief Record a skipped sample deletion in array metadata.
    *
-   * Reads existing "skipped_deletions" metadata (if any), appends the sample
-   * name, and writes back the updated CSV.
+   * Writes a per-sample metadata key "skipped_delete_sample:<sample>" to the
+   * array. Using one key per sample avoids the read-modify-write race condition
+   * that would arise from accumulating a single CSV value.
    *
    * @param ctx TileDB context
    * @param group TileDB-VCF dataset group
@@ -136,6 +137,19 @@ class VariantStats {
       std::shared_ptr<Context> ctx,
       const Group& group,
       const std::string& sample);
+
+  /**
+   * @brief Return the list of samples whose deletion was skipped.
+   *
+   * Enumerates all array metadata keys with the prefix
+   * "skipped_delete_sample:" and returns the sample name suffixes.
+   *
+   * @param ctx TileDB context
+   * @param group TileDB-VCF dataset group
+   * @return Vector of sample names recorded as skipped
+   */
+  static std::vector<std::string> get_skipped_delete_samples(
+      std::shared_ptr<Context> ctx, const Group& group);
 
   /**
    * @brief Consolidate commits

--- a/libtiledbvcf/src/write/writer.cc
+++ b/libtiledbvcf/src/write/writer.cc
@@ -1484,9 +1484,16 @@ void Writer::set_variant_stats_array_version(uint8_t version) {
   creation_params_.variant_stats_array_version = version;
 }
 
+void Writer::set_skip_aggregate_stats(bool skip) {
+  ingestion_params_.skip_aggregate_stats = skip;
+}
+
 void Writer::delete_samples(std::vector<std::string> samples) {
   dataset_->delete_samples(
-      ingestion_params_.uri, samples, ingestion_params_.tiledb_config);
+      ingestion_params_.uri,
+      samples,
+      ingestion_params_.tiledb_config,
+      ingestion_params_.skip_aggregate_stats);
 }
 
 }  // namespace vcf

--- a/libtiledbvcf/src/write/writer.h
+++ b/libtiledbvcf/src/write/writer.h
@@ -150,6 +150,9 @@ struct IngestionParams {
   //  SEPARATE = contigs in the contigs_to_keep_separate
   //  MERGED = contigs not in the contigs_to_keep_separate
   ContigMode contig_mode = ContigMode::ALL;
+
+  // Skip updating allele_count and variant_stats arrays during deletion
+  bool skip_aggregate_stats = false;
 };
 
 /* ********************************* */
@@ -381,6 +384,9 @@ class Writer {
 
   /** Set variant stats array version */
   void set_variant_stats_array_version(uint8_t version);
+
+  /** Set whether to skip aggregate stats updates during deletion. */
+  void set_skip_aggregate_stats(bool skip);
 
   /**
    * @brief Delete samples from the writer's dataset.

--- a/libtiledbvcf/test/run-cli-tests.sh
+++ b/libtiledbvcf/test/run-cli-tests.sh
@@ -438,6 +438,27 @@ cat <<EOF
 EOF
 ) || exit 1
 
+# check deletion with --skip-aggregate-stats
+$tilevcf create -u skip_stats_test || exit 1
+for i in {1..5}; do
+  $tilevcf store -u skip_stats_test ${input_dir}/random_synthetic/G$i.bcf || exit 1
+done
+$tilevcf delete -u skip_stats_test -s G1,G2 --skip-aggregate-stats
+diff -u <($tilevcf list -u skip_stats_test) <(
+cat <<EOF
+G3
+G4
+G5
+EOF
+) || exit 1
+# delete more samples to verify accumulation
+$tilevcf delete -u skip_stats_test -s G3,G4 --skip-aggregate-stats
+diff -u <($tilevcf list -u skip_stats_test) <(
+cat <<EOF
+G5
+EOF
+) || exit 1
+
 # check create from vcf
 $tilevcf create -u create_test -v ${input_dir}/small3.bcf || exit 1
 diff <($tilevcf stat -u create_test | grep Extracted) <(echo "- Extracted attributes: fmt_AD, fmt_DP, fmt_GQ, fmt_GT, fmt_MIN_DP, fmt_PL, fmt_SB, info_BaseQRankSum, info_ClippingRankSum, info_DP, info_DS, info_END, info_HaplotypeScore, info_InbreedingCoeff, info_MLEAC, info_MLEAF, info_MQ, info_MQ0, info_MQRankSum, info_ReadPosRankSum") || exit 1

--- a/libtiledbvcf/test/src/unit-vcf-delete.cc
+++ b/libtiledbvcf/test/src/unit-vcf-delete.cc
@@ -244,3 +244,208 @@ TEST_CASE("TileDB-VCF: Test multi sample delete", "[tiledbvcf][delete]") {
     vfs.remove_dir(dataset_uri);
   }
 }
+
+TEST_CASE(
+    "TileDB-VCF: Test delete with skip_aggregate_stats",
+    "[tiledbvcf][delete]") {
+  tiledb::Context ctx;
+  tiledb::VFS vfs(ctx);
+
+  std::string dataset_uri = "test_dataset";
+  std::string sample_name = "stats-test";
+
+  if (vfs.is_dir(dataset_uri)) {
+    vfs.remove_dir(dataset_uri);
+  }
+
+  // Create dataset with all stats arrays enabled
+  {
+    CreationParams create_args;
+    create_args.uri = dataset_uri;
+    create_args.tile_capacity = 10000;
+    create_args.allow_duplicates = false;
+    create_args.enable_allele_count = true;
+    create_args.enable_variant_stats = true;
+    create_args.enable_sample_stats = true;
+    TileDBVCFDataset::create(create_args);
+  }
+
+  // Ingest
+  {
+    Writer writer;
+    IngestionParams params;
+    params.uri = dataset_uri;
+    params.sample_uris = {input_dir + "/stats-test.vcf.gz"};
+    writer.set_all_params(params);
+    writer.ingest_samples();
+  }
+
+  // Verify pre-delete stat values
+  REQUIRE(sum<int64_t>(ctx, dataset_uri + "/allele_count", "count") == 246);
+  REQUIRE(sum<int64_t>(ctx, dataset_uri + "/variant_stats", "ac") == 492);
+  REQUIRE(sum<int64_t>(ctx, dataset_uri + "/variant_stats", "n_hom") == 163);
+  REQUIRE(
+      sum<uint64_t>(ctx, dataset_uri + "/sample_stats", "n_records") == 246);
+
+  // Delete with skip_aggregate_stats=true
+  {
+    Config cfg;
+    TileDBVCFDataset dataset(cfg);
+    dataset.delete_samples(dataset_uri, {sample_name}, {}, true);
+  }
+
+  // Verify sample is deleted
+  {
+    auto ctx2 = std::make_shared<Context>();
+    TileDBVCFDataset dataset(ctx2);
+    dataset.open(dataset_uri);
+    REQUIRE(dataset.sample_names().empty());
+  }
+
+  // allele_count and variant_stats should be unchanged (stats were skipped)
+  REQUIRE(sum<int64_t>(ctx, dataset_uri + "/allele_count", "count") == 246);
+  REQUIRE(sum<int64_t>(ctx, dataset_uri + "/variant_stats", "ac") == 492);
+  REQUIRE(sum<int64_t>(ctx, dataset_uri + "/variant_stats", "n_hom") == 163);
+
+  // sample_stats should be zeroed (always runs regardless of flag)
+  REQUIRE(sum<uint64_t>(ctx, dataset_uri + "/sample_stats", "n_records") == 0);
+
+  // Verify skipped_delete_samples metadata on allele_count
+  {
+    Array array(ctx, dataset_uri + "/allele_count", TILEDB_READ);
+    const void* value = nullptr;
+    tiledb_datatype_t type = TILEDB_ANY;
+    uint32_t num = 0;
+    array.get_metadata("skipped_delete_samples", &type, &num, &value);
+    REQUIRE(value != nullptr);
+    REQUIRE(type == TILEDB_STRING_ASCII);
+    std::string meta(static_cast<const char*>(value), num);
+    REQUIRE(meta == sample_name);
+  }
+
+  // Verify skipped_delete_samples metadata on variant_stats
+  {
+    Array array(ctx, dataset_uri + "/variant_stats", TILEDB_READ);
+    const void* value = nullptr;
+    tiledb_datatype_t type = TILEDB_ANY;
+    uint32_t num = 0;
+    array.get_metadata("skipped_delete_samples", &type, &num, &value);
+    REQUIRE(value != nullptr);
+    REQUIRE(type == TILEDB_STRING_ASCII);
+    std::string meta(static_cast<const char*>(value), num);
+    REQUIRE(meta == sample_name);
+  }
+
+  if (vfs.is_dir(dataset_uri)) {
+    vfs.remove_dir(dataset_uri);
+  }
+}
+
+TEST_CASE(
+    "TileDB-VCF: Test skip_aggregate_stats metadata accumulates",
+    "[tiledbvcf][delete]") {
+  tiledb::Context ctx;
+  tiledb::VFS vfs(ctx);
+
+  std::string dataset_uri = "test_dataset";
+
+  if (vfs.is_dir(dataset_uri)) {
+    vfs.remove_dir(dataset_uri);
+  }
+
+  // Create dataset with allele_count and variant_stats enabled
+  {
+    CreationParams create_args;
+    create_args.uri = dataset_uri;
+    create_args.tile_capacity = 10000;
+    create_args.allow_duplicates = false;
+    create_args.enable_allele_count = true;
+    create_args.enable_variant_stats = true;
+    TileDBVCFDataset::create(create_args);
+  }
+
+  // Ingest G1, G2, G3
+  {
+    Writer writer;
+    IngestionParams params;
+    params.uri = dataset_uri;
+    for (int i = 1; i <= 3; i++) {
+      params.sample_uris.push_back(
+          input_dir + "/random_synthetic/G" + std::to_string(i) + ".bcf");
+    }
+    writer.set_all_params(params);
+    writer.ingest_samples();
+  }
+
+  // Delete G1 with skip_aggregate_stats=true
+  {
+    Config cfg;
+    TileDBVCFDataset dataset(cfg);
+    dataset.delete_samples(dataset_uri, {"G1"}, {}, true);
+  }
+
+  // Verify metadata is "G1" on both arrays
+  {
+    Array ac_array(ctx, dataset_uri + "/allele_count", TILEDB_READ);
+    const void* value = nullptr;
+    tiledb_datatype_t type = TILEDB_ANY;
+    uint32_t num = 0;
+    ac_array.get_metadata("skipped_delete_samples", &type, &num, &value);
+    REQUIRE(value != nullptr);
+    std::string meta(static_cast<const char*>(value), num);
+    REQUIRE(meta == "G1");
+  }
+  {
+    Array vs_array(ctx, dataset_uri + "/variant_stats", TILEDB_READ);
+    const void* value = nullptr;
+    tiledb_datatype_t type = TILEDB_ANY;
+    uint32_t num = 0;
+    vs_array.get_metadata("skipped_delete_samples", &type, &num, &value);
+    REQUIRE(value != nullptr);
+    std::string meta(static_cast<const char*>(value), num);
+    REQUIRE(meta == "G1");
+  }
+
+  // Delete G2 with skip_aggregate_stats=true
+  {
+    Config cfg;
+    TileDBVCFDataset dataset(cfg);
+    dataset.delete_samples(dataset_uri, {"G2"}, {}, true);
+  }
+
+  // Verify metadata accumulated to "G1,G2" on both arrays
+  {
+    Array ac_array(ctx, dataset_uri + "/allele_count", TILEDB_READ);
+    const void* value = nullptr;
+    tiledb_datatype_t type = TILEDB_ANY;
+    uint32_t num = 0;
+    ac_array.get_metadata("skipped_delete_samples", &type, &num, &value);
+    REQUIRE(value != nullptr);
+    std::string meta(static_cast<const char*>(value), num);
+    REQUIRE(meta == "G1,G2");
+  }
+  {
+    Array vs_array(ctx, dataset_uri + "/variant_stats", TILEDB_READ);
+    const void* value = nullptr;
+    tiledb_datatype_t type = TILEDB_ANY;
+    uint32_t num = 0;
+    vs_array.get_metadata("skipped_delete_samples", &type, &num, &value);
+    REQUIRE(value != nullptr);
+    std::string meta(static_cast<const char*>(value), num);
+    REQUIRE(meta == "G1,G2");
+  }
+
+  // Verify G3 still present, G1 and G2 are gone
+  {
+    auto ctx2 = std::make_shared<Context>();
+    TileDBVCFDataset dataset(ctx2);
+    dataset.open(dataset_uri);
+    REQUIRE(dataset.sample_names().size() == 1);
+    std::string remaining(dataset.sample_names().at(0).data());
+    REQUIRE(remaining == "G3");
+  }
+
+  if (vfs.is_dir(dataset_uri)) {
+    vfs.remove_dir(dataset_uri);
+  }
+}

--- a/libtiledbvcf/test/src/unit-vcf-delete.cc
+++ b/libtiledbvcf/test/src/unit-vcf-delete.cc
@@ -34,9 +34,12 @@
 
 #include "dataset/tiledbvcfdataset.h"
 #include "read/reader.h"
+#include "stats/allele_count.h"
+#include "stats/variant_stats.h"
 #include "utils/logger_public.h"
 #include "write/writer.h"
 
+#include <algorithm>
 #include <cstring>
 #include <fstream>
 #include <iostream>
@@ -312,28 +315,20 @@ TEST_CASE(
 
   // Verify skipped_delete_samples metadata on allele_count
   {
-    Array array(ctx, dataset_uri + "/allele_count", TILEDB_READ);
-    const void* value = nullptr;
-    tiledb_datatype_t type = TILEDB_ANY;
-    uint32_t num = 0;
-    array.get_metadata("skipped_delete_samples", &type, &num, &value);
-    REQUIRE(value != nullptr);
-    REQUIRE(type == TILEDB_STRING_ASCII);
-    std::string meta(static_cast<const char*>(value), num);
-    REQUIRE(meta == sample_name);
+    auto ctx_ptr = std::make_shared<tiledb::Context>();
+    tiledb::Group group(*ctx_ptr, dataset_uri, TILEDB_READ);
+    auto skipped = AlleleCount::get_skipped_delete_samples(ctx_ptr, group);
+    REQUIRE(skipped.size() == 1);
+    REQUIRE(skipped[0] == sample_name);
   }
 
   // Verify skipped_delete_samples metadata on variant_stats
   {
-    Array array(ctx, dataset_uri + "/variant_stats", TILEDB_READ);
-    const void* value = nullptr;
-    tiledb_datatype_t type = TILEDB_ANY;
-    uint32_t num = 0;
-    array.get_metadata("skipped_delete_samples", &type, &num, &value);
-    REQUIRE(value != nullptr);
-    REQUIRE(type == TILEDB_STRING_ASCII);
-    std::string meta(static_cast<const char*>(value), num);
-    REQUIRE(meta == sample_name);
+    auto ctx_ptr = std::make_shared<tiledb::Context>();
+    tiledb::Group group(*ctx_ptr, dataset_uri, TILEDB_READ);
+    auto skipped = VariantStats::get_skipped_delete_samples(ctx_ptr, group);
+    REQUIRE(skipped.size() == 1);
+    REQUIRE(skipped[0] == sample_name);
   }
 
   if (vfs.is_dir(dataset_uri)) {
@@ -384,26 +379,20 @@ TEST_CASE(
     dataset.delete_samples(dataset_uri, {"G1"}, {}, true);
   }
 
-  // Verify metadata is "G1" on both arrays
+  // Verify metadata records G1 on both arrays
   {
-    Array ac_array(ctx, dataset_uri + "/allele_count", TILEDB_READ);
-    const void* value = nullptr;
-    tiledb_datatype_t type = TILEDB_ANY;
-    uint32_t num = 0;
-    ac_array.get_metadata("skipped_delete_samples", &type, &num, &value);
-    REQUIRE(value != nullptr);
-    std::string meta(static_cast<const char*>(value), num);
-    REQUIRE(meta == "G1");
+    auto ctx_ptr = std::make_shared<tiledb::Context>();
+    tiledb::Group group(*ctx_ptr, dataset_uri, TILEDB_READ);
+    auto skipped = AlleleCount::get_skipped_delete_samples(ctx_ptr, group);
+    REQUIRE(skipped.size() == 1);
+    REQUIRE(skipped[0] == "G1");
   }
   {
-    Array vs_array(ctx, dataset_uri + "/variant_stats", TILEDB_READ);
-    const void* value = nullptr;
-    tiledb_datatype_t type = TILEDB_ANY;
-    uint32_t num = 0;
-    vs_array.get_metadata("skipped_delete_samples", &type, &num, &value);
-    REQUIRE(value != nullptr);
-    std::string meta(static_cast<const char*>(value), num);
-    REQUIRE(meta == "G1");
+    auto ctx_ptr = std::make_shared<tiledb::Context>();
+    tiledb::Group group(*ctx_ptr, dataset_uri, TILEDB_READ);
+    auto skipped = VariantStats::get_skipped_delete_samples(ctx_ptr, group);
+    REQUIRE(skipped.size() == 1);
+    REQUIRE(skipped[0] == "G1");
   }
 
   // Delete G2 with skip_aggregate_stats=true
@@ -413,26 +402,22 @@ TEST_CASE(
     dataset.delete_samples(dataset_uri, {"G2"}, {}, true);
   }
 
-  // Verify metadata accumulated to "G1,G2" on both arrays
+  // Verify metadata records both G1 and G2 on both arrays
   {
-    Array ac_array(ctx, dataset_uri + "/allele_count", TILEDB_READ);
-    const void* value = nullptr;
-    tiledb_datatype_t type = TILEDB_ANY;
-    uint32_t num = 0;
-    ac_array.get_metadata("skipped_delete_samples", &type, &num, &value);
-    REQUIRE(value != nullptr);
-    std::string meta(static_cast<const char*>(value), num);
-    REQUIRE(meta == "G1,G2");
+    auto ctx_ptr = std::make_shared<tiledb::Context>();
+    tiledb::Group group(*ctx_ptr, dataset_uri, TILEDB_READ);
+    auto skipped = AlleleCount::get_skipped_delete_samples(ctx_ptr, group);
+    REQUIRE(skipped.size() == 2);
+    REQUIRE(std::find(skipped.begin(), skipped.end(), "G1") != skipped.end());
+    REQUIRE(std::find(skipped.begin(), skipped.end(), "G2") != skipped.end());
   }
   {
-    Array vs_array(ctx, dataset_uri + "/variant_stats", TILEDB_READ);
-    const void* value = nullptr;
-    tiledb_datatype_t type = TILEDB_ANY;
-    uint32_t num = 0;
-    vs_array.get_metadata("skipped_delete_samples", &type, &num, &value);
-    REQUIRE(value != nullptr);
-    std::string meta(static_cast<const char*>(value), num);
-    REQUIRE(meta == "G1,G2");
+    auto ctx_ptr = std::make_shared<tiledb::Context>();
+    tiledb::Group group(*ctx_ptr, dataset_uri, TILEDB_READ);
+    auto skipped = VariantStats::get_skipped_delete_samples(ctx_ptr, group);
+    REQUIRE(skipped.size() == 2);
+    REQUIRE(std::find(skipped.begin(), skipped.end(), "G1") != skipped.end());
+    REQUIRE(std::find(skipped.begin(), skipped.end(), "G2") != skipped.end());
   }
 
   // Verify G3 still present, G1 and G2 are gone


### PR DESCRIPTION
Currently the delete samples code path is quite slow because all of the records for the samples being deleted need to be scanned so that the allele count and variant stats arrays can be updated. This PR adds a `--skip-aggregate-stats` flag to the `delete` CLI command and a `skip_aggregate_stats` parameter to `Dataset.delete_samples()` in the Python API to allow users to skip updating the allele count and variant stats arrays when deleting samples.

On a test dataset containing records from 50 VCFs, using this feature when deleting 2 samples changed the run-time from 22 minutes to less then 1 second.