### PR TITLE
Support pybind11 3.0

### DIFF
--- a/apis/python/src/tiledbvcf/binding/pyarrow_helpers.h
+++ b/apis/python/src/tiledbvcf/binding/pyarrow_helpers.h
@@ -44,7 +44,7 @@ using namespace tiledb::vcf;
  * @return py::object Arrow table
  */
 py::object _buffer_to_table(std::shared_ptr<ArrayBuffers> buffers) {
-  auto pa = py::module::import("pyarrow");
+  auto pa = py::module_::import("pyarrow");
   auto pa_table_from_arrays = pa.attr("Table").attr("from_arrays");
   auto pa_array_import = pa.attr("Array").attr("_import_from_c");
   auto pa_schema_import = pa.attr("Schema").attr("_import_from_c");

--- a/apis/python/src/tiledbvcf/binding/sample_stats.h
+++ b/apis/python/src/tiledbvcf/binding/sample_stats.h
@@ -35,7 +35,7 @@ namespace py = pybind11;
 using namespace py::literals;
 using namespace tiledb::vcf;
 
-void load_sample_stats(py::module& m) {
+void load_sample_stats(py::module_& m) {
   m.def(
       "sample_qc",
       [](const std::string& dataset_uri,

--- a/apis/python/src/tiledbvcf/binding/vcf_arrow.cc
+++ b/apis/python/src/tiledbvcf/binding/vcf_arrow.cc
@@ -316,7 +316,7 @@ void build_arrow_array_from_buffer(
 }
 
 py::object buffers_to_table(std::vector<std::shared_ptr<BufferInfo>>& buffers) {
-  auto pa = py::module::import("pyarrow");
+  auto pa = py::module_::import("pyarrow");
   auto pa_table_from_arrays = pa.attr("Table").attr("from_arrays");
   auto pa_array_import = pa.attr("Array").attr("_import_from_c");
   auto pa_schema_import = pa.attr("Schema").attr("_import_from_c");


### PR DESCRIPTION
Replace deprecated `py::module` with `py::module_` in Python bindings to support pybind11 3.0 while maintaining backward compatibility with 2.x.