### PR TITLE
Pin pybind11 < 3.0 when building TileDB-Py 0.36.0 in nightly CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -85,6 +85,8 @@ jobs:
           python-version: "3.10"
       - name: Build tiledb-py from source
         run: bash TileDB-VCF/ci/nightly/build-tiledb-py.sh
+        env:
+          PYBIND11_MAX_VERSION: ${{ matrix.branches.tiledb-py != 'main' && '<3' || '' }}
       - name: Build (and test) tiledbvcf-py
         run: bash TileDB-VCF/ci/nightly/build-tiledbvcf-py.sh
   issue:

--- a/ci/nightly/build-tiledb-py.sh
+++ b/ci/nightly/build-tiledb-py.sh
@@ -18,6 +18,12 @@ fi
 
 export TILEDB_PATH=$GITHUB_WORKSPACE/install/
 
+# Pin pybind11 version if PYBIND11_MAX_VERSION is set (e.g. "<3")
+if [ -n "${PYBIND11_MAX_VERSION:-}" ]; then
+  echo "pybind11${PYBIND11_MAX_VERSION}" > /tmp/pybind11-constraint.txt
+  export PIP_CONSTRAINT=/tmp/pybind11-constraint.txt
+fi
+
 cd TileDB-Py/
 python -m pip install -Cskbuild.cmake.define.TILEDB_REMOVE_DEPRECATIONS=OFF -v .
 


### PR DESCRIPTION
TileDB-Py 0.36.0 (used with the release-2.30 configuration) is incompatible with pybind11 3.0+, which introduced stricter lambda return type deduction that breaks domain.cc. The main configuration is unaffected since TileDB-Py main already has pybind11 3.0 support.

This can be undone when a TileDB-Py tags a release against `main`.